### PR TITLE
reduced x-labels to 30min

### DIFF
--- a/src/devtools/playground_testbench.ipynb
+++ b/src/devtools/playground_testbench.ipynb
@@ -2,9 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-03-13 14:26:20 - INFO:root:62:Logging initialized - writing to ../logs/dev_tastytrade_20250313.log\n"
+     ]
+    }
+   ],
    "source": [
     "import logging\n",
     "import asyncio\n",
@@ -64,9 +72,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-03-13 14:26:22 - INFO:tastytrade.config.manager:170:Initialized 16 variables from .env file in Redis\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:848:Get address info api.tastyworks.com:443, type=<SocketKind.SOCK_STREAM: 1>, flags=<AddressInfo.AI_ADDRCONFIG: 32>\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:858:Getting address info api.tastyworks.com:443, type=<SocketKind.SOCK_STREAM: 1>, flags=<AddressInfo.AI_ADDRCONFIG: 32> took 17.325ms: [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('170.76.244.144', 443))]\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:535:<asyncio.sslproto.SSLProtocol object at 0x7bcace62d410> starts SSL handshake\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:594:<asyncio.sslproto.SSLProtocol object at 0x7bcace62d410>: SSL handshake took 41.9 ms\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:1121:<asyncio.TransportSocket fd=85, family=2, type=1, proto=6, laddr=('172.18.0.7', 42526), raddr=('170.76.244.144', 443)> connected to None:None: (<asyncio.sslproto._SSLProtocolTransport object at 0x7bcace3fc2f0>, <aiohttp.client_proto.ResponseHandler object at 0x7bcace3f32a0>)\n",
+      "2025-03-13 14:26:22 - INFO:tastytrade.connections.requests:144:Session created successfully\n",
+      "2025-03-13 14:26:22 - DEBUG:asyncio:848:Get address info tasty-openapi-ws.dxfeed.com:443, type=<SocketKind.SOCK_STREAM: 1>\n",
+      "2025-03-13 14:26:22 - INFO:asyncio:856:Getting address info tasty-openapi-ws.dxfeed.com:443, type=<SocketKind.SOCK_STREAM: 1> took 287.598ms: [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('13.226.94.84', 443)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('13.226.94.119', 443)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('13.226.94.47', 443)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('13.226.94.104', 443))]\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:535:<asyncio.sslproto.SSLProtocol object at 0x7bcace403050> starts SSL handshake\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:594:<asyncio.sslproto.SSLProtocol object at 0x7bcace403050>: SSL handshake took 15.5 ms\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:1121:<asyncio.TransportSocket fd=87, family=2, type=1, proto=6, laddr=('172.18.0.7', 50632), raddr=('13.226.94.84', 443)> connected to tasty-openapi-ws.dxfeed.com:443: (<asyncio.sslproto._SSLProtocolTransport object at 0x7bcacd9726f0>, <websockets.asyncio.client.ClientConnection object at 0x7bcacd9007d0>)\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:848:Get address info redis:6379, type=<SocketKind.SOCK_STREAM: 1>\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:858:Getting address info redis:6379, type=<SocketKind.SOCK_STREAM: 1> took 0.402ms: [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('172.18.0.2', 6379))]\n",
+      "2025-03-13 14:26:23 - DEBUG:asyncio:1121:<asyncio.TransportSocket fd=88, family=2, type=1, proto=6, laddr=('172.18.0.7', 59518), raddr=('172.18.0.2', 6379)> connected to redis:6379: (<_SelectorSocketTransport fd=88 read=polling write=<idle, bufsize=0>>, <asyncio.streams.StreamReaderProtocol object at 0x7bcb13e19490>)\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.connections.subscription:116:Redis ping response: True\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.connections.subscription:120:Redis version: 7.4.2\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.connections.subscription:121:Connected clients: 3\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Control listener on channel 0\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Quote listener on channel 7\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Trade listener on channel 5\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Greeks listener on channel 11\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Profile listener on channel 1\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Summary listener on channel 3\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:78:Started Channels.Candle listener on channel 9\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:212:SETUP\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:215:AUTH_STATE:UNAUTHORIZED\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:215:AUTH_STATE:AUTHORIZED\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:1\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:3\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:5\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:7\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:9\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:11\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:218:CHANNEL_OPENED:99\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:5:COMPACT\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:7:COMPACT\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:11:COMPACT\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:1:COMPACT\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:3:COMPACT\n",
+      "2025-03-13 14:26:23 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:9:COMPACT\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:5:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:7:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:11:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:1:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:3:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.messaging.handlers:223:FEED_CONFIG:9:COMPACT:SUBSCRIBED\n",
+      "2025-03-13 14:26:37 - DEBUG:asyncio:1022:<_SelectorSocketTransport fd=85 read=polling write=<idle, bufsize=0>> received EOF\n",
+      "2025-03-13 14:26:37 - DEBUG:asyncio:461:<asyncio.sslproto.SSLProtocol object at 0x7bcace62d410> received EOF\n"
+     ]
+    }
+   ],
    "source": [
     "config = RedisConfigManager(env_file=\"/workspace/.env\")\n",
     "config.initialize(force=True)\n",
@@ -95,21 +165,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=d}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=h}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=30m}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=15m}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=5m}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: BTC/USD:CXTALP{=m}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=d}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=h}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=30m}\n",
+      "2025-03-13 14:26:24 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=15m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=5m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: NVDA{=m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=d}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=h}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=30m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=15m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=5m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: AAPL{=m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=d}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=h}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=30m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=15m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=5m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: QQQ{=m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=d}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=h}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=30m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=15m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=5m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPY{=m}\n",
+      "2025-03-13 14:26:25 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=d}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=h}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=30m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=15m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=5m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: SPX{=m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=d}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=h}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=30m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=15m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=5m}\n",
+      "2025-03-13 14:26:26 - INFO:tastytrade.connections.sockets:231:Added subscription: /ESH25:XCME{=m}\n"
+     ]
+    }
+   ],
    "source": [
-    "start_time = datetime(2025, 3, 5)\n",
+    "start_time = datetime(2025, 3, 13)\n",
+    "\n",
+    "symbols = [\"BTC/USD:CXTALP\", \"NVDA\", \"AAPL\", \"QQQ\", \"SPY\", \"SPX\", \"/ESH25:XCME\"]\n",
+    "intervals = [\"1d\", \"1h\", \"30m\", \"15m\", \"5m\", \"m\"]\n",
     "\n",
     "# ticker subscriptions\n",
-    "symbols = [\"BTC/USD:CXTALP\", \"SPX\", \"NVDA\", \"SPY\", \"QQQ\", \"/ESH25:XCME\"]\n",
-    "# symbols = [\"/ESH25:XCME\"]\n",
     "await dxlink.subscribe(symbols)\n",
     "\n",
     "# candle subscriptions\n",
-    "for symbol in [\"BTC/USD:CXTALP\", \"NVDA\", \"QQQ\", \"SPY\", \"SPX\", \"/ESH25:XCME\"]:\n",
-    "# for symbol in [\"/ESH25:XCME\"]:\n",
-    "    for interval in [\"1d\", \"1h\", \"30m\", \"15m\", \"5m\", \"m\"]:\n",
+    "for symbol in symbols:\n",
+    "    for interval in intervals:\n",
     "        coroutine = dxlink.subscribe_to_candles(\n",
     "            symbol=symbol,\n",
     "            interval=interval,\n",
@@ -125,9 +251,8 @@
    "outputs": [],
    "source": [
     "# forward fill\n",
-    "for symbol in [\"BTC/USD:CXTALP\", \"NVDA\", \"QQQ\", \"SPY\", \"SPX\"]:\n",
-    "# for symbol in [\"/ESH25:XCME\"]:\n",
-    "    for interval in [\"1d\", \"1h\", \"30m\", \"15m\", \"5m\", \"1m\"]:\n",
+    "for symbol in symbols:\n",
+    "    for interval in intervals:\n",
     "        event_symbol = f\"{symbol}{{={interval}}}\"\n",
     "        logging.debug(\"Forward-filling %s\", event_symbol)\n",
     "        forward_fill(symbol=event_symbol, lookback_days=5)"
@@ -142,9 +267,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Candle Feed:** /ESH25:XCME{=m}"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 16)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>eventSymbol</th><th>time</th><th>eventFlags</th><th>index</th><th>sequence</th><th>count</th><th>open</th><th>high</th><th>low</th><th>close</th><th>volume</th><th>bidVolume</th><th>askVolume</th><th>openInterest</th><th>vwap</th><th>impVolatility</th></tr><tr><td>str</td><td>datetime[μs]</td><td>i64</td><td>i64</td><td>i64</td><td>i64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;/ESH25:XCME{=m}&quot;</td><td>2025-03-13 14:26:00</td><td>0</td><td>7481300281888604160</td><td>0</td><td>1650</td><td>5598.75</td><td>5600.75</td><td>5597.25</td><td>5598.25</td><td>2093.0</td><td>1095.0</td><td>998.0</td><td>2.091047e6</td><td>5599.07</td><td>0.26</td></tr><tr><td>&quot;/ESH25:XCME{=m}&quot;</td><td>2025-03-13 14:25:00</td><td>0</td><td>7481300024190566400</td><td>0</td><td>6041</td><td>5596.75</td><td>5603.75</td><td>5595.0</td><td>5598.5</td><td>8133.0</td><td>3837.0</td><td>4296.0</td><td>2.091047e6</td><td>5600.28</td><td>0.26</td></tr><tr><td>&quot;/ESH25:XCME{=m}&quot;</td><td>2025-03-13 14:24:00</td><td>0</td><td>7481299766492528640</td><td>0</td><td>3969</td><td>5590.25</td><td>5597.5</td><td>5588.0</td><td>5596.75</td><td>4878.0</td><td>2022.0</td><td>2856.0</td><td>2.091047e6</td><td>5591.91</td><td>0.26</td></tr><tr><td>&quot;/ESH25:XCME{=m}&quot;</td><td>2025-03-13 14:23:00</td><td>0</td><td>7481299508794490880</td><td>0</td><td>4162</td><td>5591.0</td><td>5591.5</td><td>5587.5</td><td>5590.0</td><td>5128.0</td><td>2720.0</td><td>2408.0</td><td>2.091047e6</td><td>5589.4</td><td>0.26</td></tr><tr><td>&quot;/ESH25:XCME{=m}&quot;</td><td>2025-03-13 14:22:00</td><td>0</td><td>7481299251096453120</td><td>0</td><td>2732</td><td>5593.25</td><td>5593.5</td><td>5589.5</td><td>5590.75</td><td>3361.0</td><td>1666.0</td><td>1695.0</td><td>2.091047e6</td><td>5591.22</td><td>0.26</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (5, 16)\n",
+       "┌────────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬─────────┬───────────┐\n",
+       "│ eventSymbo ┆ time      ┆ eventFlag ┆ index     ┆ … ┆ askVolume ┆ openInter ┆ vwap    ┆ impVolati │\n",
+       "│ l          ┆ ---       ┆ s         ┆ ---       ┆   ┆ ---       ┆ est       ┆ ---     ┆ lity      │\n",
+       "│ ---        ┆ datetime[ ┆ ---       ┆ i64       ┆   ┆ f64       ┆ ---       ┆ f64     ┆ ---       │\n",
+       "│ str        ┆ μs]       ┆ i64       ┆           ┆   ┆           ┆ f64       ┆         ┆ f64       │\n",
+       "╞════════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═════════╪═══════════╡\n",
+       "│ /ESH25:XCM ┆ 2025-03-1 ┆ 0         ┆ 748130028 ┆ … ┆ 998.0     ┆ 2.091047e ┆ 5599.07 ┆ 0.26      │\n",
+       "│ E{=m}      ┆ 3         ┆           ┆ 188860416 ┆   ┆           ┆ 6         ┆         ┆           │\n",
+       "│            ┆ 14:26:00  ┆           ┆ 0         ┆   ┆           ┆           ┆         ┆           │\n",
+       "│ /ESH25:XCM ┆ 2025-03-1 ┆ 0         ┆ 748130002 ┆ … ┆ 4296.0    ┆ 2.091047e ┆ 5600.28 ┆ 0.26      │\n",
+       "│ E{=m}      ┆ 3         ┆           ┆ 419056640 ┆   ┆           ┆ 6         ┆         ┆           │\n",
+       "│            ┆ 14:25:00  ┆           ┆ 0         ┆   ┆           ┆           ┆         ┆           │\n",
+       "│ /ESH25:XCM ┆ 2025-03-1 ┆ 0         ┆ 748129976 ┆ … ┆ 2856.0    ┆ 2.091047e ┆ 5591.91 ┆ 0.26      │\n",
+       "│ E{=m}      ┆ 3         ┆           ┆ 649252864 ┆   ┆           ┆ 6         ┆         ┆           │\n",
+       "│            ┆ 14:24:00  ┆           ┆ 0         ┆   ┆           ┆           ┆         ┆           │\n",
+       "│ /ESH25:XCM ┆ 2025-03-1 ┆ 0         ┆ 748129950 ┆ … ┆ 2408.0    ┆ 2.091047e ┆ 5589.4  ┆ 0.26      │\n",
+       "│ E{=m}      ┆ 3         ┆           ┆ 879449088 ┆   ┆           ┆ 6         ┆         ┆           │\n",
+       "│            ┆ 14:23:00  ┆           ┆ 0         ┆   ┆           ┆           ┆         ┆           │\n",
+       "│ /ESH25:XCM ┆ 2025-03-1 ┆ 0         ┆ 748129925 ┆ … ┆ 1695.0    ┆ 2.091047e ┆ 5591.22 ┆ 0.26      │\n",
+       "│ E{=m}      ┆ 3         ┆           ┆ 109645312 ┆   ┆           ┆ 6         ┆         ┆           │\n",
+       "│            ┆ 14:22:00  ┆           ┆ 0         ┆   ┆           ┆           ┆         ┆           │\n",
+       "└────────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴─────────┴───────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "symbol = \"SPX{=m}\"\n",
     "symbol = \"BTC/USD:CXTALP{=5m}\"\n",
@@ -162,9 +341,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Quote Feed:** /ESH25:XCME{=m}"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (7, 5)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>eventSymbol</th><th>bidPrice</th><th>askPrice</th><th>bidSize</th><th>askSize</th></tr><tr><td>str</td><td>f64</td><td>f64</td><td>f64</td><td>f64</td></tr></thead><tbody><tr><td>&quot;BTC/USD:CXTALP&quot;</td><td>81944.53</td><td>82520.18</td><td>1.5</td><td>1.5</td></tr><tr><td>&quot;SPX&quot;</td><td>5590.98</td><td>5596.66</td><td>null</td><td>null</td></tr><tr><td>&quot;SPY&quot;</td><td>558.54</td><td>558.56</td><td>201.0</td><td>300.0</td></tr><tr><td>&quot;QQQ&quot;</td><td>475.56</td><td>475.57</td><td>120.0</td><td>18.0</td></tr><tr><td>&quot;NVDA&quot;</td><td>117.47</td><td>117.49</td><td>420.0</td><td>350.0</td></tr><tr><td>&quot;/ESH25:XCME&quot;</td><td>5598.75</td><td>5599.0</td><td>6.0</td><td>31.0</td></tr><tr><td>&quot;AAPL&quot;</td><td>215.2</td><td>215.23</td><td>143.0</td><td>339.0</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (7, 5)\n",
+       "┌────────────────┬──────────┬──────────┬─────────┬─────────┐\n",
+       "│ eventSymbol    ┆ bidPrice ┆ askPrice ┆ bidSize ┆ askSize │\n",
+       "│ ---            ┆ ---      ┆ ---      ┆ ---     ┆ ---     │\n",
+       "│ str            ┆ f64      ┆ f64      ┆ f64     ┆ f64     │\n",
+       "╞════════════════╪══════════╪══════════╪═════════╪═════════╡\n",
+       "│ BTC/USD:CXTALP ┆ 81944.53 ┆ 82520.18 ┆ 1.5     ┆ 1.5     │\n",
+       "│ SPX            ┆ 5590.98  ┆ 5596.66  ┆ null    ┆ null    │\n",
+       "│ SPY            ┆ 558.54   ┆ 558.56   ┆ 201.0   ┆ 300.0   │\n",
+       "│ QQQ            ┆ 475.56   ┆ 475.57   ┆ 120.0   ┆ 18.0    │\n",
+       "│ NVDA           ┆ 117.47   ┆ 117.49   ┆ 420.0   ┆ 350.0   │\n",
+       "│ /ESH25:XCME    ┆ 5598.75  ┆ 5599.0   ┆ 6.0     ┆ 31.0    │\n",
+       "│ AAPL           ┆ 215.2    ┆ 215.23   ┆ 143.0   ┆ 339.0   │\n",
+       "└────────────────┴──────────┴──────────┴─────────┴─────────┘"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(Markdown(f\"**Quote Feed:** {symbol}\"))\n",
     "\n",
@@ -214,7 +438,7 @@
     "import pytz\n",
     "\n",
     "month = 3\n",
-    "day = 6\n",
+    "day = 13\n",
     "\n",
     "subscription = RedisSubscription(config=RedisConfigManager())\n",
     "await subscription.connect()\n",
@@ -227,18 +451,18 @@
     "\n",
     "streamer = MarketDataProvider(subscription, influxdb)\n",
     "\n",
-    "start = datetime(2025, month, day, 9) + timedelta(hours=5)\n",
-    "stop = datetime(2025, month, day, 17) + timedelta(hours=5)"
+    "start = market_open + timedelta(minutes=-(padding := 5))\n",
+    "stop = market_close + timedelta(minutes=padding)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
     "candle_symbol = \"SPX{=m}\"\n",
-    "candle_symbol = \"/ESH25:XCME{=m}\"\n",
+    "# candle_symbol = \"/ESH25:XCME{=m}\"\n",
     "\n",
     "prior_day: CandleEvent = CandleEvent(\n",
     "    **(\n",
@@ -284,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,6 +642,24 @@
     "    ),\n",
     "    VerticalLine(\n",
     "        time=datetime(2025, 3, 6, 14, 30) + timedelta(hours=2, minutes=10),\n",
+    "        color=\"#555555\",\n",
+    "        line_dash=\"dot\",\n",
+    "        label=\"Open\",\n",
+    "    ),\n",
+    "    VerticalLine(\n",
+    "        time=datetime(2025, 3, 7, 14, 30) + timedelta(hours=0, minutes=45),\n",
+    "        color=\"#555555\",\n",
+    "        line_dash=\"dot\",\n",
+    "        label=\"Open\",\n",
+    "    ),\n",
+    "    VerticalLine(\n",
+    "        time=datetime(2025, 3, 7, 14, 30) + timedelta(hours=2, minutes=55),\n",
+    "        color=\"#555555\",\n",
+    "        line_dash=\"dot\",\n",
+    "        label=\"Open\",\n",
+    "    ),\n",
+    "    VerticalLine(\n",
+    "        time=datetime(2025, 3, 13, 10, 20, tzinfo=et_tz),\n",
     "        color=\"#555555\",\n",
     "        line_dash=\"dot\",\n",
     "        label=\"Open\",\n",
@@ -484,27 +726,7 @@
    "outputs": [],
    "source": [
     "# debug\n",
-    "df_macd_5m.to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "await streamer.subscribe(\"CandleEvent\", \"SPX{=*}\")\n",
-    "await asyncio.sleep(2)\n",
-    "streamer.frames.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "streamer[\"CandleEvent:SPX{=m}\"].sort(\"time\", descending=True)"
+    "df_macd_5m.to_pandas().head()"
    ]
   },
   {
@@ -515,6 +737,13 @@
    "source": [
     "await dxlink.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/tastytrade/analytics/visualizations/plots.py
+++ b/src/tastytrade/analytics/visualizations/plots.py
@@ -492,6 +492,8 @@ def plot_macd_with_hull(
         zerolinecolor="rgba(128,128,128,0.1)",
         range=[x_min, x_max],
         automargin=True,
+        # Set 30-minute interval for x-axis ticks
+        dtick=30 * 60 * 1000,  # 30 minutes in milliseconds
     )
 
     fig.show()


### PR DESCRIPTION
This pull request includes several updates to the `src/devtools/playground_testbench.ipynb` file to enhance logging, update execution counts, and streamline the code for subscriptions and data handling.

### Logging and Execution Counts:
* Updated the `execution_count` for multiple cells to reflect their new order of execution. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL5-R15) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL67-R139) [[3]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL98-R238) [[4]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL145-R326) [[5]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL165-R391) [[6]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL217-R441) [[7]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL230-R465) [[8]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL287-R511) [[9]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL360-R584)
* Added detailed logging outputs to capture various stages of the test bench execution, including initialization, connection, and subscription events. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL5-R15) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL67-R139) [[3]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL98-R238)

### Code Simplification:
* Simplified the subscription and forward-fill loops by defining `symbols` and `intervals` lists and iterating over them. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL98-R238) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL128-R255)
* Updated date and time variables to use more dynamic and descriptive names, such as `start_time`, `market_open`, and `market_close`. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL217-R441) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL230-R465)

### Data Display:
* Enhanced the display of candle and quote feed data by formatting the output in markdown and HTML tables for better readability. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL145-R326) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL165-R391)

### Date Updates:
* Changed hardcoded dates to reflect the new testing date of March 13, 2025. [[1]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL98-R238) [[2]](diffhunk://#diff-418f34992afe8e7b1088a42f844719622c7fb8e4d64f79c7900d43e3798faa5bL217-R441)