### PR TITLE
TT-7: Extract notebook logic into importable Python modules

### DIFF
--- a/src/tastytrade/subscription/__init__.py
+++ b/src/tastytrade/subscription/__init__.py
@@ -1,10 +1,12 @@
 """
 Subscription management module for TastyTrade market data feeds.
 
-This module provides the CLI tool for managing market data subscriptions,
-including historical backfill, live streaming, and operational monitoring.
+This module provides the CLI tool and orchestration logic for managing
+market data subscriptions, including historical backfill, live streaming,
+and operational monitoring.
 """
 
 from tastytrade.subscription.cli import cli
+from tastytrade.subscription.orchestrator import run_subscription
 
-__all__ = ["cli"]
+__all__ = ["cli", "run_subscription"]

--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -5,6 +5,7 @@ This module implements the `tasty-subscription` CLI tool with `run` and `status`
 subcommands for managing market data feeds.
 """
 
+import asyncio
 import logging
 import sys
 from datetime import datetime
@@ -12,6 +13,7 @@ from datetime import datetime
 import click
 
 from tastytrade.common.logging import setup_logging
+from tastytrade.subscription.orchestrator import run_subscription
 
 # Valid log levels for validation
 VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
@@ -152,10 +154,20 @@ def run(
     logger.info(f"  Feed Count:  {len(symbols) * len(intervals)} candle feeds")
     logger.info("=" * 60)
 
-    # Placeholder for orchestration (implemented in later stories)
-    logger.info("Feed process initialized successfully")
-    logger.info("Orchestration not yet implemented - exiting cleanly")
-    logger.info("See TT-7 through TT-12 for remaining implementation")
+    # Run the orchestration
+    try:
+        asyncio.run(
+            run_subscription(
+                symbols=symbols,
+                intervals=intervals,
+                start_date=start_date,
+            )
+        )
+    except KeyboardInterrupt:
+        logger.info("Received interrupt signal - shutting down")
+    except Exception as e:
+        logger.error("Fatal error: %s", e, exc_info=True)
+        sys.exit(1)
 
     sys.exit(0)
 

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -1,0 +1,121 @@
+"""
+Market data subscription orchestrator.
+
+This module provides the orchestration logic for market data subscriptions,
+extracted from devtools/playground_testbench.ipynb for CLI integration.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+
+from tastytrade.config import RedisConfigManager
+from tastytrade.connections import Credentials
+from tastytrade.connections.sockets import DXLinkManager
+from tastytrade.connections.subscription import RedisSubscriptionStore
+from tastytrade.messaging.processors import (
+    RedisEventProcessor,
+    TelegrafHTTPEventProcessor,
+)
+from tastytrade.utils.time_series import forward_fill
+
+logger = logging.getLogger(__name__)
+
+
+async def run_subscription(
+    symbols: list[str],
+    intervals: list[str],
+    start_date: datetime,
+    env_file: str = ".env",
+    lookback_days: int = 5,
+) -> None:
+    """
+    Orchestrate market data subscriptions.
+
+    This function initializes connections, subscribes to market data feeds,
+    performs gap-fill operations, and runs until interrupted.
+
+    Lifted from devtools/playground_testbench.ipynb cells 2, 4, and 5.
+
+    Args:
+        symbols: List of symbols to subscribe to (e.g., ["AAPL", "SPY", "QQQ"])
+        intervals: List of candle intervals (e.g., ["1d", "1h", "5m", "m"])
+        start_date: Date to begin historical backfill
+        env_file: Path to .env file for configuration
+        lookback_days: Number of days to look back for gap-fill (default: 5)
+    """
+    dxlink: DXLinkManager | None = None
+
+    try:
+        # === Service Connections (notebook cell-2) ===
+        logger.info("Initializing configuration from %s", env_file)
+        config = RedisConfigManager(env_file=env_file)
+        config.initialize(force=True)
+
+        credentials = Credentials(config=config, env="Live")
+
+        logger.info("Opening DXLink connection")
+        dxlink = DXLinkManager(subscription_store=RedisSubscriptionStore())
+        await dxlink.open(credentials=credentials)
+
+        # Attach processors to all handlers
+        router = dxlink.router
+        if router is None:
+            raise RuntimeError("DXLink router not initialized after open()")
+
+        handlers_dict = getattr(router, "handler", None)
+        if handlers_dict is None:
+            raise RuntimeError("DXLink router.handler mapping not initialized")
+
+        for handler in handlers_dict.values():
+            handler.add_processor(TelegrafHTTPEventProcessor())
+            handler.add_processor(RedisEventProcessor())
+
+        logger.info("Processors attached to all handlers")
+
+        # === Market Data Subscriptions (notebook cell-4) ===
+        # Ticker subscriptions (Quote/Trade/Greeks)
+        logger.info("Subscribing to ticker feeds for %d symbols", len(symbols))
+        await dxlink.subscribe(symbols)
+
+        # Candle subscriptions with historical backfill
+        total_candle_feeds = len(symbols) * len(intervals)
+        logger.info(
+            "Subscribing to %d candle feeds (from %s)",
+            total_candle_feeds,
+            start_date.strftime("%Y-%m-%d"),
+        )
+
+        for symbol in symbols:
+            for interval in intervals:
+                await asyncio.wait_for(
+                    dxlink.subscribe_to_candles(
+                        symbol=symbol,
+                        interval=interval,
+                        from_time=start_date,
+                    ),
+                    timeout=60,
+                )
+
+        logger.info("All subscriptions active")
+
+        # === Gap Fill (notebook cell-5) ===
+        logger.info("Running gap-fill with %d day lookback", lookback_days)
+        for symbol in symbols:
+            for interval in intervals:
+                event_symbol = f"{symbol}{{={interval}}}"
+                logger.debug("Forward-filling %s", event_symbol)
+                forward_fill(symbol=event_symbol, lookback_days=lookback_days)
+
+        logger.info("Gap-fill complete")
+
+        # === Run until interrupted ===
+        logger.info("Subscription active - press Ctrl+C to stop")
+        while True:
+            await asyncio.sleep(3600)
+
+    finally:
+        if dxlink is not None:
+            logger.info("Closing DXLink connection")
+            await dxlink.close()
+            logger.info("Cleanup complete")


### PR DESCRIPTION
## Summary

Extract executable logic from `devtools/playground_testbench.ipynb` into importable Python modules so the CLI can orchestrate market data operations without Jupyter dependencies. This implements FR-2 (Notebook Logic Extraction) from Epic TT-1.

## Related Jira Issue

**Jira**: [TT-7](https://mandeng.atlassian.net/browse/TT-7)

## Acceptance Criteria - Functional Evidence

### ✅ AC1: Orchestration module created

```python
>>> from tastytrade.subscription import run_subscription
>>> print(run_subscription)
<function run_subscription at 0x7bd485f6d6c0>
```

**Result:** Module imports without errors, no Jupyter dependencies.

---

### ✅ AC2: Subscription logic extracted

```python
>>> import inspect
>>> from tastytrade.subscription.orchestrator import run_subscription
>>> print(inspect.signature(run_subscription))
(symbols: list[str], intervals: list[str], start_date: datetime.datetime, env_file: str = '.env', lookback_days: int = 5) -> None
```

**Extracted from notebook:**
- Cell 2: Service connections (RedisConfigManager, DXLinkManager, processor attachment)
- Cell 4: Market data subscriptions (ticker feeds + candle backfill)
- Cell 5: Gap-fill using forward_fill utility

---

### ✅ AC3: Gap-fill logic accessible

```python
>>> from tastytrade.utils.time_series import forward_fill
>>> print(forward_fill)
<function forward_fill at 0x7bc4088e0360>
```

**Result:** `forward_fill` is imported and called within `run_subscription()`.

---

### ✅ AC4: Configuration handling

```
CLI args flow directly to orchestrator (no hardcoded values):
  --start-date  → start_date: datetime (REQUIRED)
  --symbols     → symbols: list[str] (REQUIRED)
  --intervals   → intervals: list[str] (REQUIRED)
  --log-level   → configures logging
  
Orchestrator parameters:
  env_file: str = ".env" (configurable)
  lookback_days: int = 5 (configurable)
```

---

### ✅ AC5: No Jupyter dependency

```bash
$ grep -r "ipython\|jupyter\|IPython" src/tastytrade/subscription/
(no output - no matches found)
```

**Result:** Zero Jupyter/IPython imports in the subscription module.

---

## Test Evidence

```bash
# Linting
$ uv run ruff check src/tastytrade/subscription/
All checks passed!

# Type checking  
$ uv run mypy src/tastytrade/subscription/
Success: no issues found in 3 source files
```

## How to Test

```bash
# 1. Verify module imports
cd /tmp/worktrees/TT-7 && unset VIRTUAL_ENV PYTHONPATH && uv run python -c "from tastytrade.subscription import run_subscription; print(run_subscription)"

# 2. Verify no Jupyter deps
cd /tmp/worktrees/TT-7 && unset VIRTUAL_ENV PYTHONPATH && grep -r "ipython\|jupyter\|IPython" src/tastytrade/subscription/

# 3. Run linting/typing
cd /tmp/worktrees/TT-7 && unset VIRTUAL_ENV PYTHONPATH && uv run ruff check src/tastytrade/subscription/
cd /tmp/worktrees/TT-7 && unset VIRTUAL_ENV PYTHONPATH && uv run mypy src/tastytrade/subscription/

# 4. Test CLI wiring
cd /tmp/worktrees/TT-7 && unset VIRTUAL_ENV PYTHONPATH && uv run tasty-subscription run --help
```

## Changes Made

- `src/tastytrade/subscription/orchestrator.py`: New module with `run_subscription()` lifted from notebook cells 2, 4, 5
- `src/tastytrade/subscription/__init__.py`: Export `run_subscription` for public API
- `src/tastytrade/subscription/cli.py`: Wire orchestrator into CLI `run` command, replacing placeholder