### PR TITLE
TT-8: Add CandleSnapshotTracker to synchronize gap-fill with snapshot delivery

### DIFF
--- a/src/tastytrade/messaging/processors/__init__.py
+++ b/src/tastytrade/messaging/processors/__init__.py
@@ -1,4 +1,5 @@
 from .influxdb import TelegrafHTTPEventProcessor
 from .redis import RedisEventProcessor
+from .snapshot import CandleSnapshotTracker
 
-__all__ = ["RedisEventProcessor", "TelegrafHTTPEventProcessor"]
+__all__ = ["CandleSnapshotTracker", "RedisEventProcessor", "TelegrafHTTPEventProcessor"]

--- a/src/tastytrade/messaging/processors/snapshot.py
+++ b/src/tastytrade/messaging/processors/snapshot.py
@@ -1,0 +1,126 @@
+"""Candle snapshot completion tracker.
+
+Monitors DXLink eventFlags bitmask on CandleEvent to detect when historical
+snapshot delivery is complete for each subscribed symbol. Used to synchronize
+gap-fill operations that depend on data being in InfluxDB.
+
+DXLink eventFlags protocol:
+    Bit 0 (0x01) = TX_PENDING    — more events coming in this transaction
+    Bit 1 (0x02) = REMOVE_EVENT  — event removal (used in empty snapshots)
+    Bit 2 (0x04) = SNAPSHOT_BEGIN — first event in a snapshot
+    Bit 3 (0x08) = SNAPSHOT_END  — last event in a snapshot
+    Bit 4 (0x10) = SNAPSHOT_SNIP — snapshot truncated (also signals end)
+"""
+
+import asyncio
+import logging
+
+from tastytrade.messaging.models.events import BaseEvent, CandleEvent
+
+logger = logging.getLogger(__name__)
+
+TX_PENDING = 0x01
+REMOVE_EVENT = 0x02
+SNAPSHOT_BEGIN = 0x04
+SNAPSHOT_END = 0x08
+SNAPSHOT_SNIP = 0x10
+
+
+class CandleSnapshotTracker:
+    """Tracks candle snapshot completion across multiple symbols.
+
+    Attach to the Candle EventHandler via add_processor(). Register expected
+    symbols before subscriptions are sent, then consume ``completions`` queue
+    to react as each symbol finishes, or await ``wait_for_completion()`` to
+    block until all snapshots have landed.
+
+    Attributes:
+        completions: asyncio.Queue that receives each event symbol string
+            as its snapshot completes. Drain this to trigger per-symbol work
+            (e.g. gap-fill) without waiting for all symbols.
+    """
+
+    name: str = "candle_snapshot_tracker"
+
+    def __init__(self) -> None:
+        self.pending_symbols: set[str] = set()
+        self.completed_symbols: set[str] = set()
+        self.completions: asyncio.Queue[str] = asyncio.Queue()
+        self._all_complete = asyncio.Event()
+
+    def register_symbol(self, event_symbol: str) -> None:
+        """Register a symbol to track for snapshot completion.
+
+        Args:
+            event_symbol: The candle event symbol (e.g., "AAPL{=d}").
+        """
+        self.pending_symbols.add(event_symbol)
+        self._all_complete.clear()
+
+    def process_event(self, event: BaseEvent) -> None:
+        """Check each CandleEvent for snapshot-end flags.
+
+        Non-candle events and events for unregistered symbols are ignored.
+        """
+        if not isinstance(event, CandleEvent):
+            return
+
+        flags = event.eventFlags
+        if flags is None:
+            return
+
+        symbol = event.eventSymbol
+        if symbol not in self.pending_symbols:
+            return
+
+        if flags & (SNAPSHOT_END | SNAPSHOT_SNIP):
+            self.pending_symbols.discard(symbol)
+            self.completed_symbols.add(symbol)
+            self.completions.put_nowait(symbol)
+            logger.debug(
+                "Snapshot complete for %s (flags=0x%02x) — %d remaining",
+                symbol,
+                flags,
+                len(self.pending_symbols),
+            )
+
+            if not self.pending_symbols:
+                logger.info(
+                    "All %d candle snapshots received", len(self.completed_symbols)
+                )
+                self._all_complete.set()
+
+    async def wait_for_completion(self, timeout: float) -> set[str]:
+        """Block until all registered symbols have completed their snapshots.
+
+        Args:
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            Set of symbols that did NOT complete within the timeout.
+            Empty set means all snapshots arrived successfully.
+        """
+        if not self.pending_symbols:
+            return set()
+
+        try:
+            await asyncio.wait_for(self._all_complete.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Snapshot timeout after %.1fs — %d/%d symbols incomplete: %s",
+                timeout,
+                len(self.pending_symbols),
+                len(self.pending_symbols) + len(self.completed_symbols),
+                sorted(self.pending_symbols),
+            )
+
+        return set(self.pending_symbols)
+
+    def reset(self) -> None:
+        """Clear all tracking state."""
+        self.pending_symbols.clear()
+        self.completed_symbols.clear()
+        self._all_complete.clear()
+        # Drain the queue
+        while not self.completions.empty():
+            self.completions.get_nowait()

--- a/unit_tests/test_snapshot_tracker.py
+++ b/unit_tests/test_snapshot_tracker.py
@@ -1,0 +1,162 @@
+"""Tests for CandleSnapshotTracker processor."""
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from tastytrade.messaging.models.events import CandleEvent, TradeEvent
+from tastytrade.messaging.processors.snapshot import (
+    SNAPSHOT_BEGIN,
+    SNAPSHOT_END,
+    SNAPSHOT_SNIP,
+    CandleSnapshotTracker,
+)
+
+
+def make_candle(symbol: str, flags: int | None = None) -> CandleEvent:
+    """Create a CandleEvent with the given symbol and eventFlags."""
+    return CandleEvent(
+        eventSymbol=symbol,
+        time=datetime(2026, 1, 28, 10, 0, 0),
+        eventFlags=flags,
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.5,
+        volume=1000.0,
+    )
+
+
+class TestCandleSnapshotTracker:
+    def test_single_symbol_completion(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_BEGIN))
+        assert "AAPL{=d}" in tracker.pending_symbols
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+        assert "AAPL{=d}" not in tracker.pending_symbols
+        assert "AAPL{=d}" in tracker.completed_symbols
+
+    def test_multiple_symbols_all_must_complete(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+        tracker.register_symbol("SPY{=5m}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+        assert len(tracker.pending_symbols) == 1
+        assert "SPY{=5m}" in tracker.pending_symbols
+
+        tracker.process_event(make_candle("SPY{=5m}", SNAPSHOT_END))
+        assert len(tracker.pending_symbols) == 0
+        assert tracker.completed_symbols == {"AAPL{=d}", "SPY{=5m}"}
+
+    def test_snapshot_snip_also_completes(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("QQQ{=m}")
+
+        tracker.process_event(make_candle("QQQ{=m}", SNAPSHOT_SNIP))
+        assert "QQQ{=m}" in tracker.completed_symbols
+        assert len(tracker.pending_symbols) == 0
+
+    def test_non_snapshot_flags_do_not_complete(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_BEGIN))
+        assert "AAPL{=d}" in tracker.pending_symbols
+        assert "AAPL{=d}" not in tracker.completed_symbols
+
+        tracker.process_event(make_candle("AAPL{=d}", 0x00))
+        assert "AAPL{=d}" in tracker.pending_symbols
+
+    def test_none_flags_ignored(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        tracker.process_event(make_candle("AAPL{=d}", flags=None))
+        assert "AAPL{=d}" in tracker.pending_symbols
+
+    def test_unregistered_symbol_ignored(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        tracker.process_event(make_candle("MSFT{=d}", SNAPSHOT_END))
+        assert "MSFT{=d}" not in tracker.completed_symbols
+        assert "AAPL{=d}" in tracker.pending_symbols
+
+    def test_non_candle_event_ignored(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        trade = TradeEvent(eventSymbol="AAPL", price=150.0)
+        tracker.process_event(trade)
+        assert "AAPL{=d}" in tracker.pending_symbols
+
+    @pytest.mark.asyncio
+    async def test_wait_completes_immediately_when_empty(self) -> None:
+        tracker = CandleSnapshotTracker()
+        incomplete = await tracker.wait_for_completion(timeout=1.0)
+        assert incomplete == set()
+
+    @pytest.mark.asyncio
+    async def test_wait_completes_when_all_snapshots_arrive(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+        tracker.register_symbol("SPY{=5m}")
+
+        async def deliver_snapshots() -> None:
+            await asyncio.sleep(0.05)
+            tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+            tracker.process_event(make_candle("SPY{=5m}", SNAPSHOT_END))
+
+        asyncio.get_event_loop().create_task(deliver_snapshots())
+        incomplete = await tracker.wait_for_completion(timeout=5.0)
+        assert incomplete == set()
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_incomplete_symbols(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+        tracker.register_symbol("SPY{=5m}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+
+        incomplete = await tracker.wait_for_completion(timeout=0.1)
+        assert incomplete == {"SPY{=5m}"}
+
+    def test_completions_queue_receives_symbols(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+        tracker.register_symbol("SPY{=5m}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+        tracker.process_event(make_candle("SPY{=5m}", SNAPSHOT_END))
+
+        assert tracker.completions.qsize() == 2
+        assert tracker.completions.get_nowait() == "AAPL{=d}"
+        assert tracker.completions.get_nowait() == "SPY{=5m}"
+
+    def test_completions_queue_ignores_non_completing_events(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_BEGIN))
+        tracker.process_event(make_candle("AAPL{=d}", 0x00))
+
+        assert tracker.completions.empty()
+
+    def test_reset_clears_all_state(self) -> None:
+        tracker = CandleSnapshotTracker()
+        tracker.register_symbol("AAPL{=d}")
+        tracker.process_event(make_candle("AAPL{=d}", SNAPSHOT_END))
+
+        assert len(tracker.completed_symbols) == 1
+        assert tracker.completions.qsize() == 1
+        tracker.reset()
+
+        assert tracker.pending_symbols == set()
+        assert tracker.completed_symbols == set()
+        assert tracker.completions.empty()


### PR DESCRIPTION
## Summary
- Added `CandleSnapshotTracker` processor that monitors DXLink `eventFlags` bitmask (`SNAPSHOT_END`/`SNAPSHOT_SNIP`) to detect when each symbol's historical candle snapshot delivery is complete
- Gap-fill now runs per-symbol as each snapshot completes via an asyncio queue, instead of running after all subscriptions are sent (which caused a race condition where gap-fill queried InfluxDB before data had landed)
- Fixed event symbol format mismatch (`1d`→`d`, `1h`→`h`) using `format_candle_symbol`

## Related Jira Issue
[TT-8](https://mandeng.atlassian.net/browse/TT-8)

## Acceptance Criteria
- [x] Gap-fill only runs after snapshot data has landed in InfluxDB
- [x] Per-symbol gap-fill fires as each snapshot completes (no waiting for all 36)
- [x] Timeout handling for incomplete snapshots with clear logging
- [x] Event symbol format matches DXLink protocol (1d→d, 1h→h)

## Functional Evidence

### AC1: Snapshot completion detection
Real production run with 6 symbols x 6 intervals = 36 candle feeds from 2026-01-24:
```
Subscribing to 36 candle feeds from 2026-01-24
Waiting for snapshots and loading data...
Loaded BTC/USD:CXTALP{=d} (1/36)
Loaded BTC/USD:CXTALP{=h} (2/36)
...
Loaded SPY{=5m} (36/36)
All 36 candle snapshots received
Gap-fill complete for 36/36 feeds
Subscription active - press Ctrl+C to stop
```
All 36/36 feeds completed successfully. Gap-fill ran only after data landed.

### AC2: Per-symbol gap-fill (no waiting for all)
Interleaved snapshot completion and gap-fill in production logs shows gap-fill starts as soon as each symbol completes:
```
Snapshot complete for BTC/USD:CXTALP{=d} (flags=0x08) — 35 remaining
Gap-filling BTC/USD:CXTALP{=d}
Gap-fill done for BTC/USD:CXTALP{=d}
```

### AC3: Format mismatch fix
Before fix: tracker registered `AAPL{=1d}` but events arrived as `AAPL{=d}` — 12/36 symbols timed out (all `{=1d}` and `{=1h}`).
After fix: using `format_candle_symbol()` to normalize, all 36/36 complete.

## Test Evidence
- 13 unit tests pass covering: single/multi symbol completion, SNIP flag, non-snapshot flags, None flags, unregistered symbols, non-candle events, async completion, timeout, completions queue, and reset
- All pre-commit hooks pass (ruff, ruff-format, mypy)

## Changes Made
- **NEW** `src/tastytrade/messaging/processors/snapshot.py` — `CandleSnapshotTracker` with completions queue
- **MOD** `src/tastytrade/messaging/processors/__init__.py` — export `CandleSnapshotTracker`
- **MOD** `src/tastytrade/subscription/orchestrator.py` — integrate tracker, per-symbol gap-fill, clean logging
- **NEW** `unit_tests/test_snapshot_tracker.py` — 13 tests