### PR TITLE
TT-16: Downgrade misleading "Fatal error" log to WARNING

### DIFF
--- a/unit_tests/test_event_handler.py
+++ b/unit_tests/test_event_handler.py
@@ -1,0 +1,134 @@
+"""Tests for EventHandler log severity on validation errors (TT-16)."""
+
+import asyncio
+import logging
+
+import pytest
+
+from tastytrade.common.exceptions import MessageProcessingError
+from tastytrade.config.enumerations import Channels
+from tastytrade.messaging.handlers import EventHandler
+from tastytrade.messaging.models.messages import Message
+
+
+def make_quote_message(
+    bid_price: object,
+    ask_price: object,
+    bid_size: float = 100.0,
+    ask_size: float = 200.0,
+) -> Message:
+    """Build a Message that the Quote EventHandler can process."""
+    return Message(
+        type="FEED_DATA",
+        channel=Channels.Quote.value,
+        headers={},
+        data=[["AAPL", bid_price, ask_price, bid_size, ask_size]],
+    )
+
+
+@pytest.fixture
+def quote_handler() -> EventHandler:
+    return EventHandler(channel=Channels.Quote)
+
+
+@pytest.mark.asyncio
+async def test_valid_quote_processes_without_error(
+    quote_handler: EventHandler,
+) -> None:
+    """Sanity check: a valid quote message should process cleanly."""
+    msg = make_quote_message(bid_price=185.0, ask_price=185.5)
+    result = await quote_handler.handle_message(msg)
+    assert result is not None
+    assert isinstance(result, list)
+    assert len(result) == 1
+    event = result[0]
+    assert hasattr(event, "askPrice")
+    assert event.askPrice == 185.5  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_none_ask_price_raises_message_processing_error(
+    quote_handler: EventHandler,
+) -> None:
+    """A None askPrice should raise MessageProcessingError, not crash the handler."""
+    msg = make_quote_message(bid_price=185.0, ask_price=None)
+    with pytest.raises(MessageProcessingError, match="Skipped invalid event"):
+        await quote_handler.handle_message(msg)
+
+
+@pytest.mark.asyncio
+async def test_validation_error_logs_warning_not_error(
+    quote_handler: EventHandler, caplog: pytest.LogCaptureFixture
+) -> None:
+    """TT-16: Validation errors must log at WARNING, not ERROR."""
+    msg = make_quote_message(bid_price=185.0, ask_price=None)
+
+    with caplog.at_level(logging.DEBUG, logger="tastytrade.messaging.handlers"):
+        with pytest.raises(MessageProcessingError):
+            await quote_handler.handle_message(msg)
+
+    handler_records = [
+        r for r in caplog.records if r.name == "tastytrade.messaging.handlers"
+    ]
+
+    # No ERROR-level records should exist for a recoverable validation error
+    error_records = [r for r in handler_records if r.levelno >= logging.ERROR]
+    assert error_records == [], (
+        f"Expected no ERROR logs for a recoverable validation error, "
+        f"got: {[r.message for r in error_records]}"
+    )
+
+    # At least one WARNING-level record should exist
+    warning_records = [r for r in handler_records if r.levelno == logging.WARNING]
+    assert (
+        len(warning_records) >= 1
+    ), "Expected at least one WARNING log for skipped event"
+    assert any("Skipped invalid event" in r.message for r in warning_records)
+
+
+@pytest.mark.asyncio
+async def test_queue_listener_continues_after_validation_error(
+    quote_handler: EventHandler, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The queue listener must recover from validation errors and keep processing."""
+    queue: asyncio.Queue[dict] = asyncio.Queue()
+
+    bad_raw = {
+        "type": "FEED_DATA",
+        "channel": Channels.Quote.value,
+        "data": [["AAPL", 185.0, None, 100.0, 200.0]],
+    }
+    good_raw = {
+        "type": "FEED_DATA",
+        "channel": Channels.Quote.value,
+        "data": [["AAPL", 186.0, 186.5, 100.0, 200.0]],
+    }
+    await queue.put(bad_raw)
+    await queue.put(good_raw)
+
+    EventHandler.stop_listener.clear()
+    with caplog.at_level(logging.DEBUG, logger="tastytrade.messaging.handlers"):
+        task = asyncio.create_task(quote_handler.queue_listener(queue))
+        await asyncio.wait_for(queue.join(), timeout=5.0)
+
+        EventHandler.stop_listener.set()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Should have recorded exactly 1 error in metrics
+    assert quote_handler.metrics.error_count == 1
+    # Should have processed both messages (2 total)
+    assert quote_handler.metrics.total_messages == 2
+
+    # The error log should be WARNING, not ERROR
+    handler_records = [
+        r for r in caplog.records if r.name == "tastytrade.messaging.handlers"
+    ]
+    error_records = [r for r in handler_records if r.levelno >= logging.ERROR]
+    assert error_records == [], (
+        f"Expected no ERROR logs from queue_listener recovery, "
+        f"got: {[r.message for r in error_records]}"
+    )


### PR DESCRIPTION
## Summary

Validation errors on individual events (e.g., `askPrice=None` from upstream DXLink feed) are fully recovered from by the queue listener. The previous ERROR level and "Fatal error" message implied the handler died, when in reality only a single event was dropped. Production data confirmed: 1 error out of 20,384 quote messages (0.005%) in a 3-hour session — the stream continued processing without interruption.

## Related Jira Issue

**Jira**: [TT-16](https://mandeng.atlassian.net/browse/TT-16)

## Acceptance Criteria - Functional Evidence

### AC1: Log level downgraded to WARNING

Three log statements in `src/tastytrade/messaging/handlers.py` changed from `logger.error` to `logger.warning`:
- **Line 171**: ValidationError catch → `logger.warning("Skipped invalid event on %s channel: %s", ...)`
- **Line 204**: Outer exception catch → `logger.warning("Skipped invalid event on %s channel", ...)`
- **Line 102**: queue_listener recovery → `logger.warning("Event skipped in %s listener: %s", ...)`

Test `test_validation_error_logs_warning_not_error` verifies no ERROR-level records are emitted for validation errors.

### AC2: Log message accurately describes impact

All three messages now use "Skipped invalid event" / "Event skipped" instead of "Fatal error" / "Message processing error". The test asserts the WARNING records contain "Skipped invalid event".

### AC3: No regressions introduced

All 39 tests pass (4 new + 35 existing):
```
unit_tests/test_event_handler.py ....             [ 10%]
unit_tests/test_snapshot_tracker.py .............  [ 43%]
unit_tests/test_subscription_status.py .......... [100%]
39 passed in 0.79s
```

Additionally, `test_queue_listener_continues_after_validation_error` proves the stream processes subsequent messages after a validation error (bad message followed by good message → metrics show 2 total, 1 error, listener still running).

**Production evidence from original incident:**
- Stream ran 3 hours (22:27 to 01:24) processing 50K+ total messages
- Quote channel: 20,384 messages, 1 error (0.005% rate)
- All other channels: zero errors
- Stream confirmed still alive via Redis pub/sub (24 BTC/USD quotes in 15 seconds post-error)

## Test Evidence

- All 39 tests passing (`uv run pytest`)
- mypy: Success, no issues found in 2 source files
- ruff: All pre-commit hooks passed (ruff check, ruff format, mypy)

## Changes Made

- `src/tastytrade/messaging/handlers.py`: Downgrade 3 log statements from ERROR to WARNING, replace "Fatal error" with "Skipped invalid event", add `raise ... from e` for proper exception chaining (B904)
- `unit_tests/test_event_handler.py`: 4 new tests — valid quote processing, MessageProcessingError on None askPrice, WARNING log level verification, queue listener recovery continuity