### PR TITLE
TT-19: Add justfile recipes for tasty-subscription CLI

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+# TastyTrade SDK - Common development recipes
+# Run `just --list` to see all available recipes
+
+# Default symbols and intervals for subscription
+default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX"
+default_intervals := "1d,1h,30m,15m,5m,m"
+
+# Check status of active subscriptions
+status:
+    uv run tasty-subscription status
+
+# Check status in JSON format
+status-json:
+    uv run tasty-subscription status --json
+
+# Run subscription with defaults (start date = today)
+subscribe start_date=`date +%Y-%m-%d` log_level="INFO":
+    uv run tasty-subscription run \
+        --symbols "{{default_symbols}}" \
+        --intervals {{default_intervals}} \
+        --start-date {{start_date}} \
+        --log-level {{log_level}}
+
+# Run subscription with custom symbols and intervals
+subscribe-custom symbols intervals start_date=`date +%Y-%m-%d` log_level="INFO":
+    uv run tasty-subscription run \
+        --symbols "{{symbols}}" \
+        --intervals {{intervals}} \
+        --start-date {{start_date}} \
+        --log-level {{log_level}}


### PR DESCRIPTION
## Summary

Adds a justfile with convenience recipes for common tasty-subscription CLI operations, eliminating verbose command-line invocations for routine tasks like checking subscription status and launching market data feeds.

## Related Jira Issue

**Jira**: [TT-19](https://mandeng.atlassian.net/browse/TT-19)

## Acceptance Criteria - Functional Evidence

### AC1: `just status` runs subscription status check

**Real Example: Live subscription status against running infrastructure**

```
$ just status
uv run tasty-subscription status
Connection Health
----------------------------------------
  Redis:    Connected (v7.4.5)

Active Subscriptions: 42
----------------------------------------
  Ticker feeds: 6
    AAPL                 9m ago
    BTC/USD:CXTALP       9m ago
    ...
  Candle feeds: 36
    AAPL{=15m}           9m ago
    ...
```

**Results:**
- Real Redis connection confirmed (v7.4.5)
- 42 active subscriptions detected (6 ticker + 36 candle feeds)
- Timestamps confirm live data freshness (9m ago)

---

### AC2: `just status-json` outputs JSON format

**Real Example: Dry-run confirms correct command expansion**

```
$ just --dry-run status-json
uv run tasty-subscription status --json
```

**Results:**
- Correctly passes `--json` flag to CLI
- Output suitable for programmatic consumption / piping

---

### AC3: `just subscribe` uses defaults with today's date

**Real Example: Dry-run showing default parameter expansion**

```
$ just --dry-run subscribe
uv run tasty-subscription run \
    --symbols "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX" \
    --intervals 1d,1h,30m,15m,5m,m \
    --start-date `date +%Y-%m-%d` \
    --log-level INFO
```

**Results:**
- Default symbols: BTC/USD:CXTALP, NVDA, AAPL, QQQ, SPY, SPX (6 tickers)
- Default intervals: 1d, 1h, 30m, 15m, 5m, m (6 intervals = 36 candle feeds)
- Dynamic start date via `date +%Y-%m-%d`
- Default log level: INFO

---

### AC4: Start date override works

**Real Example: Custom start date parameter**

```
$ just --dry-run subscribe 2026-01-24
uv run tasty-subscription run \
    --symbols "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX" \
    --intervals 1d,1h,30m,15m,5m,m \
    --start-date 2026-01-24 \
    --log-level INFO
```

**Results:**
- Start date correctly overridden to 2026-01-24
- Other defaults preserved (symbols, intervals, log level)

---

### AC5: Log level override works

**Real Example: Custom start date and log level**

```
$ just --dry-run subscribe 2026-01-24 DEBUG
uv run tasty-subscription run \
    --symbols "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX" \
    --intervals 1d,1h,30m,15m,5m,m \
    --start-date 2026-01-24 \
    --log-level DEBUG
```

**Results:**
- Log level correctly overridden to DEBUG
- Start date override also applied (2026-01-24)
- Symbols and intervals remain at defaults

---

### AC6: `just subscribe-custom` with custom symbols/intervals

**Real Example: Fully customized subscription command**

```
$ just --dry-run subscribe-custom "AAPL,NVDA" "1d,1h"
uv run tasty-subscription run \
    --symbols "AAPL,NVDA" \
    --intervals 1d,1h \
    --start-date `date +%Y-%m-%d` \
    --log-level INFO

$ just --dry-run subscribe-custom "AAPL,NVDA" "1d,1h" 2026-01-24 DEBUG
uv run tasty-subscription run \
    --symbols "AAPL,NVDA" \
    --intervals 1d,1h \
    --start-date 2026-01-24 \
    --log-level DEBUG
```

**Results:**
- Custom symbols accepted (AAPL, NVDA only)
- Custom intervals accepted (1d, 1h only)
- Optional start date and log level overrides work
- All 4 parameters independently configurable

---

## Test Evidence

- Pre-commit hooks passed (linting, formatting enforced at commit level)
- Live `just status` confirmed working against active infrastructure (42 feeds, Redis v7.4.5)
- All 4 recipes verified via dry-run showing correct command expansion
- Parameter overrides confirmed for start date, log level, symbols, and intervals

## Changes Made

- `justfile` (new): 4 recipes -- status, status-json, subscribe, subscribe-custom -- with default symbols, intervals, log level (INFO), and dynamic start date