### PR TITLE
TT-21: Add WebSocket connection recovery and error-based health status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,25 @@ After creating or updating any Jira ticket, the jira-workflow agent MUST:
 
 This ensures tickets are properly documented and nothing is missed.
 
+### Plan-Ticket Alignment (MANDATORY)
+
+When planning work for a Jira ticket, you MUST ensure the ticket description includes the full implementation plan:
+
+1. **Before implementation begins**, update the Jira ticket with:
+   - Detailed implementation steps with file paths and line numbers
+   - Code snippets showing current vs proposed changes
+   - Design rationale (why this approach)
+   - Updated acceptance criteria matching the plan
+
+2. **Why this matters:**
+   - Other agents may pick up the work without context from the planning session
+   - The Jira ticket is the source of truth for what should be implemented
+   - Plans discussed in conversation are lost if not persisted to Jira
+
+3. **Verification:**
+   - After updating, re-read the ticket to confirm all plan details are present
+   - Ensure acceptance criteria match implementation plan exactly
+
 ---
 
 ## GitHub Operations Protocol - MANDATORY DELEGATION


### PR DESCRIPTION
## Summary

Fixes the zombie state issue where WebSocket keepalive timeout caused the system to continue running without recovery, while health status falsely reported "6 channels active" for hours.

**Root Causes Fixed:**
1. `send_keepalives()` now triggers reconnection on errors (was only logging)
2. Main loop monitors reconnection signals via `wait_for_reconnect_signal()`
3. Health status now reports connection state (CONNECTED/ERROR) instead of cumulative message counts
4. Redis status updated on error for external monitoring

## Related Jira Issue

[TT-21: WebSocket connection dies without recovery - subscriptions enter zombie state](https://mandeng.atlassian.net/browse/TT-21)

## Acceptance Criteria Evidence

### AC1: Keepalive failure triggers reconnection
```python
# In send_keepalives():
except Exception as e:
    logger.error("Error sending keepalive: %s", e)
    self.trigger_reconnect(f"Keepalive error: {e}")
    # Exit loop so reconnection can occur
```
- Before: Error logged but ignored, system continued in zombie state
- After: Error triggers reconnection signal, exits loop

### AC2: Main loop monitors reconnection signals
```python
monitor_task = asyncio.create_task(reconnection_monitor())
done, pending = await asyncio.wait(
    [monitor_task, sleep_task],
    return_when=asyncio.FIRST_COMPLETED,
)
if monitor_task in done:
    reason = monitor_task.result()
    raise ConnectionError(f"Reconnection triggered: {reason}")
```
- Before: Main loop only slept, never checked for reconnection signals
- After: Uses asyncio.wait to respond to reconnection signals immediately

### AC3: Health status reports connection state
```python
if dxlink.connection_state == ConnectionState.ERROR:
    logger.error("Health — Uptime: %s | STATE: ERROR | Reason: %s", ...)
elif dxlink.connection_state == ConnectionState.CONNECTED:
    logger.info("Health — Uptime: %s | STATE: CONNECTED | %d channels", ...)
```
- Before: Reported "6 channels active" based on cumulative message count
- After: Reports actual connection state (ERROR with reason, or CONNECTED)

### AC4: Redis status updated on error
```python
await update_redis_connection_status(
    subscription_store,
    state="error",
    reason=reason,
)
# Redis key: tastytrade:connection
# Fields: state, timestamp, error
```

### AC5: State resets on reconnection
- CONNECTED state set after successful authorization in open()
- DISCONNECTED state set in close()
- Outer retry loop will reinitialize connection on next attempt

## Test Evidence

- All 52 unit tests pass
- Ruff linting passes
- Pre-commit hooks pass

## Changes Made

| File | Changes |
|------|---------|
| `src/tastytrade/connections/sockets.py` | Added `ConnectionState` enum, state tracking, keepalive fix |
| `src/tastytrade/subscription/orchestrator.py` | Added reconnection monitor, error-based health status, Redis updates |
| `CLAUDE.md` | Added plan-ticket alignment requirement |