### PR TITLE
TT-24: Fix reconnection logic and add failure simulation

### DIFF
--- a/src/tastytrade/config/enumerations.py
+++ b/src/tastytrade/config/enumerations.py
@@ -59,3 +59,17 @@ class DXLinkErrorType(Enum):
 
 # Errors that should trigger reconnection
 RECONNECTABLE_ERRORS = {DXLinkErrorType.TIMEOUT, DXLinkErrorType.UNAUTHORIZED}
+
+
+class ReconnectReason(Enum):
+    """Reasons for triggering connection reconnection.
+
+    Used for typed signaling in the reconnection flow, enabling
+    both production error handling and test injection.
+    """
+
+    AUTH_EXPIRED = "auth_expired"  # Token expired mid-session
+    CONNECTION_DROPPED = "connection_dropped"  # WebSocket closed unexpectedly
+    TIMEOUT = "timeout"  # No response within threshold
+    PROTOCOL_ERROR = "protocol_error"  # Invalid message from server
+    MANUAL_TRIGGER = "manual_trigger"  # Test injection / manual trigger

--- a/src/tastytrade/connections/routing.py
+++ b/src/tastytrade/connections/routing.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Callable, List, Optional, Protocol
 
-from tastytrade.config.enumerations import Channels
+from tastytrade.config.enumerations import Channels, ReconnectReason
 from tastytrade.connections.subscription import SubscriptionStore
 from tastytrade.messaging.handlers import ControlHandler, EventHandler
 from tastytrade.messaging.processors.default import (
@@ -13,7 +13,7 @@ from tastytrade.messaging.processors.default import (
 logger = logging.getLogger(__name__)
 
 
-ReconnectCallback = Callable[[str], None]
+ReconnectCallback = Callable[[ReconnectReason], None]
 
 
 class Websocket(Protocol):


### PR DESCRIPTION
## Summary

This PR fixes a production incident where the session terminated instead of reconnecting after 20 hours of uptime. Root cause: CLI was calling `run_subscription()` directly instead of `run_subscription_with_reconnect()`. The solution merges both functions into one with an `auto_reconnect` parameter (default: `True`) and adds typed `ReconnectReason` enum for type-safe reconnection signaling.

## Related Jira Issue

**Jira**: [TT-24](https://mandeng.atlassian.net/browse/TT-24)

## Acceptance Criteria - Functional Evidence

### AC1: CLI uses merged function by default

**Real Example: CLI invocation now has reconnection enabled by default**

```python
# cli.py:176-183 calls run_subscription() which now defaults to auto_reconnect=True
asyncio.run(
    run_subscription(
        symbols=symbols,
        intervals=intervals,
        start_date=start_date,
        health_interval=health_interval,
        # auto_reconnect=True by default - reconnection enabled
    )
)
```

**Results:**
- CLI no longer bypasses reconnection logic
- Default behavior matches production requirements (20+ hour sessions)
- No code change required in CLI - function signature handles it

---

### AC2: Tests can disable auto-reconnect

**Real Example: Single-shot mode for testing**

```python
# New signature allows single-shot mode for testing
await run_subscription(
    symbols=["SPY"],
    intervals=["1d"],
    start_date=start_date,
    auto_reconnect=False,  # No retry on failure - exits immediately
)
```

**Results:**
- Tests can run without infinite retry loops
- Integration tests can verify single connection behavior
- Parameter is optional - existing test code unchanged

---

### AC3: All reconnect triggers use ReconnectReason enum

**Real Example: Type-safe reconnection signaling**

```python
# handlers.py now uses typed enum
self.reconnect_callback(ReconnectReason.AUTH_EXPIRED)  # Not string
self.reconnect_callback(ReconnectReason.TIMEOUT)
self.reconnect_callback(ReconnectReason.PROTOCOL_ERROR)

# sockets.py uses typed enum
self.trigger_reconnect(ReconnectReason.CONNECTION_DROPPED)
```

**Results:**
- All reconnection triggers use typed enum (not raw strings)
- Type checker catches invalid reconnect reasons at compile time
- Consistent logging with enum values

---

### AC4: simulate_failure() method exists for test injection

**Real Example: Failure simulation for testing**

```python
# sockets.py:299-312
def simulate_failure(self, reason: ReconnectReason) -> None:
    """Simulate a connection failure for testing purposes."""
    logger.warning("Simulating failure: %s", reason.value)
    self.trigger_reconnect(reason)

# Usage in tests:
dxlink.simulate_failure(ReconnectReason.AUTH_EXPIRED)
```

**Results:**
- Tests can inject specific failure scenarios
- Reconnection logic can be verified without actual network failures
- All ReconnectReason types can be simulated

---

### AC5: ReconnectReason enum covers all failure types

**Real Example: Enum definition**

```python
class ReconnectReason(Enum):
    AUTH_EXPIRED = "auth_expired"           # Token expired mid-session
    CONNECTION_DROPPED = "connection_dropped"  # WebSocket closed unexpectedly
    TIMEOUT = "timeout"                     # No response within threshold
    PROTOCOL_ERROR = "protocol_error"       # Invalid message from server
    MANUAL_TRIGGER = "manual_trigger"       # Test injection via simulate_failure()
```

**Results:**
- All production failure scenarios covered
- Each reason has descriptive value for logging
- MANUAL_TRIGGER enables test injection

---

### AC6: Existing reconnection behavior preserved

**Real Example: Exponential backoff preserved in merged function**

```python
# Retry with backoff: 2s, 4s, 8s, ... up to 300s max, 10 attempts
delay = min(base_delay * (2**attempt), max_delay)
logger.warning(
    "Connection failed (attempt %d/%d): %s. Reconnecting in %.1fs",
    attempt, max_reconnect_attempts, e, delay,
)
```

**Results:**
- Exponential backoff: 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 300s (capped)
- Maximum 10 reconnection attempts before giving up
- Logging provides visibility into reconnection progress

---

## Test Evidence

- All 52 unit tests pass: `uv run pytest unit_tests/ -v`
- Ruff linting passes: `uv run ruff check .`
- MyPy type checking passes (except 2 pre-existing unrelated errors)

## Changes Made

- `src/tastytrade/config/enumerations.py`: Added `ReconnectReason` enum with 5 failure types
- `src/tastytrade/connections/sockets.py`: Updated `trigger_reconnect()` to use enum, added `simulate_failure()` method
- `src/tastytrade/connections/routing.py`: Updated callback type signature to use `ReconnectReason`
- `src/tastytrade/messaging/handlers.py`: Updated `handle_auth_state()` and `handle_error()` to use typed enum
- `src/tastytrade/subscription/orchestrator.py`: Merged `run_subscription()` and `run_subscription_with_reconnect()` with `auto_reconnect` parameter (default: `True`)

[TT-24]: https://mandeng.atlassian.net/browse/TT-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ