### PR TITLE
TT-47: Migrate TastyTrade auth from session-token to OAuth2

### DIFF
--- a/.claude/skills/github-operations/scripts/create-branch.sh
+++ b/.claude/skills/github-operations/scripts/create-branch.sh
@@ -83,5 +83,12 @@ fi
 # Create worktree
 git worktree add "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
 
+# Symlink .env so worktree has access to the same configuration
+MAIN_WORKSPACE=$(git rev-parse --show-toplevel)
+if [ -f "$MAIN_WORKSPACE/.env" ]; then
+    ln -sf "$MAIN_WORKSPACE/.env" "$WORKTREE_PATH/.env"
+    echo "Symlinked .env into worktree" >&2
+fi
+
 # Output result as JSON for easy parsing
 echo "{\"branch\": \"$BRANCH_NAME\", \"worktree\": \"$WORKTREE_PATH\", \"ticket\": \"$TICKET_ID\"}"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# TastyTrade SDK - Environment Variables
+# Copy this file to .env and fill in your values
+
+# Environment: "Test" or "Live"
+ENVIRONMENT=LIVE
+
+# TastyTrade API URLs
+TT_API_URL=https://api.tastyworks.com
+TT_SANDBOX_URL=https://api.cert.tastyworks.com
+
+# Account numbers
+TT_ACCOUNT=your_live_account_number
+TT_SANDBOX_ACCOUNT=your_sandbox_account_number
+
+# OAuth2 Credentials (required)
+# Obtain from TastyTrade developer portal
+TT_OAUTH_CLIENT_ID=your_oauth_client_id
+TT_OAUTH_CLIENT_SECRET=your_oauth_client_secret
+TT_OAUTH_REFRESH_TOKEN=your_oauth_refresh_token
+
+# InfluxDB
+INFLUX_DB_URL=http://influxdb:8086
+INFLUX_DB_ORG=TastyGroup
+INFLUX_DB_BUCKET=tastytrade
+INFLUX_DB_TOKEN=your_influxdb_token
+
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+
+# Grafana Cloud OTLP (optional)
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-2.grafana.net/otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+GRAFANA_CLOUD_INSTANCE_ID=your_instance_id
+GRAFANA_CLOUD_TOKEN=your_grafana_token
+
+# Service identification
+OTEL_SERVICE_NAME=tastytrade-subscription
+APP_ENV=dev
+APP_VERSION=1.0.0
+LOG_LEVEL=INFO

--- a/src/tastytrade/connections/__init__.py
+++ b/src/tastytrade/connections/__init__.py
@@ -2,36 +2,27 @@ from tastytrade.config import ConfigurationManager
 
 
 class Credentials:
-    login: str
-    password: str
     base_url: str
     is_sandbox: bool
+    oauth_client_id: str
+    oauth_client_secret: str
+    oauth_refresh_token: str
 
     @property
     def as_dict(self) -> dict:
         return vars(self)
 
     def __init__(self, config: ConfigurationManager, env: str = "Test"):
-        """Tastytrade credentials are read from OS environment variables which can be loaded from a `.env` file, exported in the shell, or directly set in the environment.
+        """Tastytrade OAuth2 credentials read from environment variables.
 
         Args:
-            env (str, optional): Environment is either "Test" or "Live". Defaults to "Test".
+            env: Environment is either "Test" or "Live". Defaults to "Test".
 
-        Raises
+        Raises:
             ValueError: If environment is not "Test" or "Live"
         """
         if env not in ["Test", "Live"]:
             raise ValueError("Environment must be either 'Test' or 'Live'")
-
-        self.login: str = (
-            config.get("TT_SANDBOX_USER") if env == "Test" else config.get("TT_USER")
-        )
-        # self.login: str = os.environ["TT_SANDBOX_USER"] if env == "Test" else os.environ["TT_USER"]
-
-        self.password: str = (
-            config.get("TT_SANDBOX_PASS") if env == "Test" else config.get("TT_PASS")
-            # os.environ["TT_SANDBOX_PASS"] if env == "Test" else os.environ["TT_PASS"]
-        )
 
         self.base_url: str = (
             config.get("TT_SANDBOX_URL") if env == "Test" else config.get("TT_API_URL")
@@ -43,9 +34,11 @@ class Credentials:
             else config.get("TT_ACCOUNT")
         )
 
-        self.remember_me: bool = True
+        self.oauth_client_id: str = config.get("TT_OAUTH_CLIENT_ID")
+        self.oauth_client_secret: str = config.get("TT_OAUTH_CLIENT_SECRET")
+        self.oauth_refresh_token: str = config.get("TT_OAUTH_REFRESH_TOKEN")
 
-        self.is_sandbox: bool = True if env == "Test" else False
+        self.is_sandbox: bool = env == "Test"
 
 
 class InfluxCredentials:

--- a/unit_tests/accounts/test_account_models.py
+++ b/unit_tests/accounts/test_account_models.py
@@ -378,10 +378,11 @@ def test_credentials_loads_sandbox_account() -> None:
     config = MagicMock()
     config.get = MagicMock(
         side_effect=lambda key: {
-            "TT_SANDBOX_USER": "user",
-            "TT_SANDBOX_PASS": "pass",
             "TT_SANDBOX_URL": "https://sandbox.tastyworks.com",
             "TT_SANDBOX_ACCOUNT": "5WT00001",
+            "TT_OAUTH_CLIENT_ID": "test-client-id",
+            "TT_OAUTH_CLIENT_SECRET": "test-client-secret",
+            "TT_OAUTH_REFRESH_TOKEN": "test-refresh-token",
         }[key]
     )
     from tastytrade.connections import Credentials
@@ -394,10 +395,11 @@ def test_credentials_loads_live_account() -> None:
     config = MagicMock()
     config.get = MagicMock(
         side_effect=lambda key: {
-            "TT_USER": "user",
-            "TT_PASS": "pass",
             "TT_API_URL": "https://api.tastyworks.com",
             "TT_ACCOUNT": "ABC12345",
+            "TT_OAUTH_CLIENT_ID": "test-client-id",
+            "TT_OAUTH_CLIENT_SECRET": "test-client-secret",
+            "TT_OAUTH_REFRESH_TOKEN": "test-refresh-token",
         }[key]
     )
     from tastytrade.connections import Credentials


### PR DESCRIPTION
## Summary

TastyTrade deprecated session-token auth (`POST /sessions` with login/password) on Dec 1, 2025. This PR migrates both `SessionHandler` and `AsyncSessionHandler` to OAuth2 (`POST /oauth/token` with `refresh_token` grant), adds Bearer auth headers, and implements automatic token refresh before expiry.

## Related Jira Issue

**Jira**: [TT-47](https://mandeng.atlassian.net/browse/TT-47)

## Acceptance Criteria - Functional Evidence

### ✅ AC1: OAuth2 token exchange replaces session-token auth

**Before:** `POST /sessions` with login/password → HTTP 400 `missing_request_token`
**After:** `POST /oauth/token` with refresh_token grant → HTTP 200, access_token received

**Real Example: OAuth2 token exchange against production API**

```
POST https://api.tastyworks.com/oauth/token → 200
access_token: eyJhbGciOiJFZERTQSIs... (900s expiry)
```

**Results:**
- ✓ OAuth2 endpoint returns valid access_token
- ✓ Token expiry tracked (900 seconds)
- ✓ Session-token auth code fully removed

---

### ✅ AC2: Bearer auth header set correctly

**Before:** `Authorization: {raw-session-token}` (no prefix)
**After:** `Authorization: Bearer {access_token}`

**Real Example: Authenticated API call with Bearer token**

```
GET /api-quote-tokens with Bearer token → 200
dxlink-url: wss://tasty-openapi-ws.dxfeed.com/realtime
token: dGFzdHksYXBpLCwxNzcwOTU2NTYzLD...
```

**Results:**
- ✓ Bearer prefix correctly prepended to access_token
- ✓ Authenticated API calls succeed (HTTP 200)
- ✓ DXLink quote token retrieved successfully

---

### ✅ AC3: Full subscription pipeline works end-to-end

**Real Example: Production subscription pipeline (SPY 1d candles from 2026-02-10)**

```
Session created via OAuth2
Initialized 55 variables from .env file in Redis
Opening DXLink connection
WebSocket: 101 Switching Protocols
AUTH_STATE: AUTHORIZED (userId: d2089ece-4c6d-4224-8cb4-9c569e5a428b)
7 channels opened: Control, Quote, Trade, Greeks, Profile, Summary, Candle
Added subscription: SPY
Added subscription: SPY{=d}
FEED_DATA channel 9: Candle data received (2 daily candles)
Snapshot complete for SPY{=d}
Subscription and back-fill complete for 1/1 subscriptions
Subscription active - press Ctrl+C to stop
```

**Results:**
- ✓ OAuth2 session created successfully
- ✓ WebSocket authorized (AUTH_STATE: AUTHORIZED)
- ✓ 7 data channels opened
- ✓ Live candle data received and backfill completed
- ✓ Full end-to-end pipeline operational with production data

---

### ✅ AC4: Token auto-refresh mechanism in place

Both `SessionHandler` and `AsyncSessionHandler` track `token_expires_at` (monotonic clock) and call `refresh_token_if_needed()` before API calls. Refresh fires 60 seconds before the 900s expiry window.

**Results:**
- ✓ `token_expires_at` set on initial auth (monotonic clock + 900s)
- ✓ `refresh_token_if_needed()` called before each API request
- ✓ Refresh triggers 60 seconds before expiry
- ✓ Both sync and async handlers implement refresh logic

---

### ✅ AC5: Worktree .env symlink ensures config availability

**Before:** Running from worktree → `No variables found in .env file: .env` → stale Redis → 400 auth failure
**After:** `create-branch.sh` symlinks `.env` into worktree → `Initialized 55 variables from .env file in Redis` → OAuth2 succeeds

**Results:**
- ✓ `create-branch.sh` detects and symlinks `.env` from main workspace
- ✓ Worktree environments receive full configuration (55 variables)
- ✓ OAuth2 credentials available in worktree context

---

## Test Evidence

- ✅ All 195 unit tests passing (`uv run pytest`)
- ✅ ruff check: clean on all modified files
- ✅ mypy: clean on all modified files
- ✅ Pre-commit hooks passed (ruff, ruff-format, mypy, trailing whitespace, end of files)

## Changes Made

| File | Change |
|------|--------|
| `src/tastytrade/connections/__init__.py` | Replace `login`, `password`, `remember_me` with `oauth_client_id`, `oauth_client_secret`, `oauth_refresh_token` |
| `src/tastytrade/connections/requests.py` | Rewrite `SessionHandler` and `AsyncSessionHandler`: `POST /oauth/token`, Bearer auth, auto-refresh |
| `.env.example` | New file with OAuth2 env var placeholders |
| `unit_tests/accounts/test_account_models.py` | Update mock config fixtures for OAuth2 fields |
| `.claude/skills/github-operations/scripts/create-branch.sh` | Symlink `.env` into worktrees on creation |

[TT-47]: https://mandeng.atlassian.net/browse/TT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ