### PR TITLE
TT-47: Migrate TastyTrade auth from session-token to OAuth2

### DIFF
--- a/.claude/skills/github-operations/scripts/create-branch.sh
+++ b/.claude/skills/github-operations/scripts/create-branch.sh
@@ -83,5 +83,12 @@ fi
 # Create worktree
 git worktree add "$WORKTREE_PATH" "origin/$BRANCH_NAME" >&2
 
+# Symlink .env so worktree has access to the same configuration
+MAIN_WORKSPACE=$(git rev-parse --show-toplevel)
+if [ -f "$MAIN_WORKSPACE/.env" ]; then
+    ln -sf "$MAIN_WORKSPACE/.env" "$WORKTREE_PATH/.env"
+    echo "Symlinked .env into worktree" >&2
+fi
+
 # Output result as JSON for easy parsing
 echo "{\"branch\": \"$BRANCH_NAME\", \"worktree\": \"$WORKTREE_PATH\", \"ticket\": \"$TICKET_ID\"}"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# TastyTrade SDK - Environment Variables
+# Copy this file to .env and fill in your values
+
+# Environment: "Test" or "Live"
+ENVIRONMENT=LIVE
+
+# TastyTrade API URLs
+TT_API_URL=https://api.tastyworks.com
+TT_SANDBOX_URL=https://api.cert.tastyworks.com
+
+# Account numbers
+TT_ACCOUNT=your_live_account_number
+TT_SANDBOX_ACCOUNT=your_sandbox_account_number
+
+# OAuth2 Credentials (required)
+# Obtain from TastyTrade developer portal
+TT_OAUTH_CLIENT_ID=your_oauth_client_id
+TT_OAUTH_CLIENT_SECRET=your_oauth_client_secret
+TT_OAUTH_REFRESH_TOKEN=your_oauth_refresh_token
+
+# InfluxDB
+INFLUX_DB_URL=http://influxdb:8086
+INFLUX_DB_ORG=TastyGroup
+INFLUX_DB_BUCKET=tastytrade
+INFLUX_DB_TOKEN=your_influxdb_token
+
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+
+# Grafana Cloud OTLP (optional)
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-2.grafana.net/otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+GRAFANA_CLOUD_INSTANCE_ID=your_instance_id
+GRAFANA_CLOUD_TOKEN=your_grafana_token
+
+# Service identification
+OTEL_SERVICE_NAME=tastytrade-subscription
+APP_ENV=dev
+APP_VERSION=1.0.0
+LOG_LEVEL=INFO

--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,15 @@ TT_SANDBOX_URL=https://api.cert.tastyworks.com
 TT_ACCOUNT=your_live_account_number
 TT_SANDBOX_ACCOUNT=your_sandbox_account_number
 
-# OAuth2 Credentials (required)
+# OAuth2 Credentials (Live environment)
 # Obtain from TastyTrade developer portal
 TT_OAUTH_CLIENT_ID=your_oauth_client_id
 TT_OAUTH_CLIENT_SECRET=your_oauth_client_secret
 TT_OAUTH_REFRESH_TOKEN=your_oauth_refresh_token
+
+# Legacy Credentials (Sandbox environment)
+TT_SANDBOX_USER=your_sandbox_username
+TT_SANDBOX_PASS=your_sandbox_password
 
 # InfluxDB
 INFLUX_DB_URL=http://influxdb:8086

--- a/src/tastytrade/connections/__init__.py
+++ b/src/tastytrade/connections/__init__.py
@@ -2,36 +2,27 @@ from tastytrade.config import ConfigurationManager
 
 
 class Credentials:
-    login: str
-    password: str
     base_url: str
     is_sandbox: bool
+    oauth_client_id: str
+    oauth_client_secret: str
+    oauth_refresh_token: str
 
     @property
     def as_dict(self) -> dict:
         return vars(self)
 
     def __init__(self, config: ConfigurationManager, env: str = "Test"):
-        """Tastytrade credentials are read from OS environment variables which can be loaded from a `.env` file, exported in the shell, or directly set in the environment.
+        """Tastytrade OAuth2 credentials read from environment variables.
 
         Args:
-            env (str, optional): Environment is either "Test" or "Live". Defaults to "Test".
+            env: Environment is either "Test" or "Live". Defaults to "Test".
 
-        Raises
+        Raises:
             ValueError: If environment is not "Test" or "Live"
         """
         if env not in ["Test", "Live"]:
             raise ValueError("Environment must be either 'Test' or 'Live'")
-
-        self.login: str = (
-            config.get("TT_SANDBOX_USER") if env == "Test" else config.get("TT_USER")
-        )
-        # self.login: str = os.environ["TT_SANDBOX_USER"] if env == "Test" else os.environ["TT_USER"]
-
-        self.password: str = (
-            config.get("TT_SANDBOX_PASS") if env == "Test" else config.get("TT_PASS")
-            # os.environ["TT_SANDBOX_PASS"] if env == "Test" else os.environ["TT_PASS"]
-        )
 
         self.base_url: str = (
             config.get("TT_SANDBOX_URL") if env == "Test" else config.get("TT_API_URL")
@@ -43,9 +34,11 @@ class Credentials:
             else config.get("TT_ACCOUNT")
         )
 
-        self.remember_me: bool = True
+        self.oauth_client_id: str = config.get("TT_OAUTH_CLIENT_ID")
+        self.oauth_client_secret: str = config.get("TT_OAUTH_CLIENT_SECRET")
+        self.oauth_refresh_token: str = config.get("TT_OAUTH_REFRESH_TOKEN")
 
-        self.is_sandbox: bool = True if env == "Test" else False
+        self.is_sandbox: bool = env == "Test"
 
 
 class InfluxCredentials:

--- a/src/tastytrade/connections/auth.py
+++ b/src/tastytrade/connections/auth.py
@@ -1,0 +1,285 @@
+"""Authentication strategies for TastyTrade API.
+
+Provides a strategy pattern for environment-aware authentication:
+- OAuth2AuthStrategy: For Live environment (POST /oauth/token with refresh_token grant)
+- LegacyAuthStrategy: For Sandbox environment (POST /sessions with login/password)
+
+Usage:
+    strategy = create_auth_strategy(credentials)
+    await strategy.authenticate(session, base_url)
+    await strategy.refresh_if_needed(session, base_url)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from tastytrade.connections import Credentials
+
+import aiohttp
+import requests as req
+
+from tastytrade.utils.validators import validate_async_response, validate_response
+
+logger = logging.getLogger(__name__)
+
+# Refresh the token 60 seconds before it expires
+TOKEN_REFRESH_BUFFER_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# Async Protocols and Strategies
+# ---------------------------------------------------------------------------
+
+
+class AuthStrategy(Protocol):
+    """Protocol for async authentication strategies."""
+
+    async def authenticate(
+        self, session: aiohttp.ClientSession, base_url: str
+    ) -> None: ...
+
+    async def refresh_if_needed(
+        self, session: aiohttp.ClientSession, base_url: str
+    ) -> None: ...
+
+
+class OAuth2AuthStrategy:
+    """OAuth2 refresh_token grant authentication for Live environment.
+
+    Exchanges a long-lived refresh token for short-lived access tokens (900s).
+    Automatically refreshes when the token is near expiry.
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+    ) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.token_expires_at: float = 0.0
+
+    async def authenticate(self, session: aiohttp.ClientSession, base_url: str) -> None:
+        async with session.post(
+            url=f"{base_url}/oauth/token",
+            json={
+                "grant_type": "refresh_token",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "refresh_token": self.refresh_token,
+            },
+        ) as response:
+            validate_async_response(response)
+            data = await response.json()
+
+        access_token = data["access_token"]
+        expires_in = data.get("expires_in", 900)
+
+        session.headers.update({"Authorization": f"Bearer {access_token}"})
+        self.token_expires_at = (
+            time.monotonic() + expires_in - TOKEN_REFRESH_BUFFER_SECONDS
+        )
+        logger.info("Session created via OAuth2")
+
+    async def refresh_if_needed(
+        self, session: aiohttp.ClientSession, base_url: str
+    ) -> None:
+        if time.monotonic() >= self.token_expires_at:
+            logger.info("Access token near expiry, refreshing")
+            await self.authenticate(session, base_url)
+
+
+class LegacyAuthStrategy:
+    """Legacy session-token authentication for Sandbox environment.
+
+    Uses POST /sessions with login/password to obtain a session token.
+    Session tokens are long-lived and do not require refresh.
+    """
+
+    def __init__(self, login: str, password: str) -> None:
+        self.login = login
+        self.password = password
+
+    async def authenticate(self, session: aiohttp.ClientSession, base_url: str) -> None:
+        async with session.post(
+            url=f"{base_url}/sessions",
+            json={
+                "login": self.login,
+                "password": self.password,
+                "remember-me": True,
+            },
+        ) as response:
+            validate_async_response(response)
+            data = await response.json()
+
+        session_token = data["data"]["session-token"]
+        session.headers.update({"Authorization": session_token})
+        logger.info("Session created via legacy login")
+
+    async def refresh_if_needed(
+        self, session: aiohttp.ClientSession, base_url: str
+    ) -> None:
+        pass  # Legacy sessions are long-lived
+
+
+# ---------------------------------------------------------------------------
+# Sync Protocols and Strategies
+# ---------------------------------------------------------------------------
+
+
+class SyncAuthStrategy(Protocol):
+    """Protocol for sync authentication strategies."""
+
+    def authenticate(self, session: req.Session, base_url: str) -> None: ...
+
+    def refresh_if_needed(self, session: req.Session, base_url: str) -> None: ...
+
+
+class SyncOAuth2AuthStrategy:
+    """Sync OAuth2 refresh_token grant authentication for Live environment."""
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        refresh_token: str,
+    ) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.token_expires_at: float = 0.0
+
+    def authenticate(self, session: req.Session, base_url: str) -> None:
+        response = session.post(
+            url=f"{base_url}/oauth/token",
+            json={
+                "grant_type": "refresh_token",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "refresh_token": self.refresh_token,
+            },
+        )
+        validate_response(response)
+
+        data = response.json()
+        access_token = data["access_token"]
+        expires_in = data.get("expires_in", 900)
+
+        session.headers.update({"Authorization": f"Bearer {access_token}"})
+        self.token_expires_at = (
+            time.monotonic() + expires_in - TOKEN_REFRESH_BUFFER_SECONDS
+        )
+        logger.info("Session created via OAuth2")
+
+    def refresh_if_needed(self, session: req.Session, base_url: str) -> None:
+        if time.monotonic() >= self.token_expires_at:
+            logger.info("Access token near expiry, refreshing")
+            self.authenticate(session, base_url)
+
+
+class SyncLegacyAuthStrategy:
+    """Sync legacy session-token authentication for Sandbox environment."""
+
+    def __init__(self, login: str, password: str) -> None:
+        self.login = login
+        self.password = password
+
+    def authenticate(self, session: req.Session, base_url: str) -> None:
+        response = session.post(
+            url=f"{base_url}/sessions",
+            json={
+                "login": self.login,
+                "password": self.password,
+                "remember-me": True,
+            },
+        )
+        validate_response(response)
+
+        data = response.json()
+        session_token = data["data"]["session-token"]
+        session.headers.update({"Authorization": session_token})
+        logger.info("Session created via legacy login")
+
+    def refresh_if_needed(self, session: req.Session, base_url: str) -> None:
+        pass  # Legacy sessions are long-lived
+
+
+# ---------------------------------------------------------------------------
+# Factory Functions
+# ---------------------------------------------------------------------------
+
+
+def create_auth_strategy(credentials: Credentials) -> AuthStrategy:
+    """Select the appropriate async auth strategy based on environment.
+
+    Args:
+        credentials: Credentials instance with environment and auth fields.
+
+    Returns:
+        OAuth2AuthStrategy for Live, LegacyAuthStrategy for Sandbox.
+    """
+    if credentials.is_sandbox:
+        if not credentials.login or not credentials.password:
+            raise ValueError(
+                "Sandbox environment requires TT_SANDBOX_USER and TT_SANDBOX_PASS"
+            )
+        return LegacyAuthStrategy(
+            login=credentials.login,
+            password=credentials.password,
+        )
+
+    if (
+        not credentials.oauth_client_id
+        or not credentials.oauth_client_secret
+        or not credentials.oauth_refresh_token
+    ):
+        raise ValueError(
+            "Live environment requires TT_OAUTH_CLIENT_ID, "
+            "TT_OAUTH_CLIENT_SECRET, and TT_OAUTH_REFRESH_TOKEN"
+        )
+    return OAuth2AuthStrategy(
+        client_id=credentials.oauth_client_id,
+        client_secret=credentials.oauth_client_secret,
+        refresh_token=credentials.oauth_refresh_token,
+    )
+
+
+def create_sync_auth_strategy(credentials: Credentials) -> SyncAuthStrategy:
+    """Select the appropriate sync auth strategy based on environment.
+
+    Args:
+        credentials: Credentials instance with environment and auth fields.
+
+    Returns:
+        SyncOAuth2AuthStrategy for Live, SyncLegacyAuthStrategy for Sandbox.
+    """
+    if credentials.is_sandbox:
+        if not credentials.login or not credentials.password:
+            raise ValueError(
+                "Sandbox environment requires TT_SANDBOX_USER and TT_SANDBOX_PASS"
+            )
+        return SyncLegacyAuthStrategy(
+            login=credentials.login,
+            password=credentials.password,
+        )
+
+    if (
+        not credentials.oauth_client_id
+        or not credentials.oauth_client_secret
+        or not credentials.oauth_refresh_token
+    ):
+        raise ValueError(
+            "Live environment requires TT_OAUTH_CLIENT_ID, "
+            "TT_OAUTH_CLIENT_SECRET, and TT_OAUTH_REFRESH_TOKEN"
+        )
+    return SyncOAuth2AuthStrategy(
+        client_id=credentials.oauth_client_id,
+        client_secret=credentials.oauth_client_secret,
+        refresh_token=credentials.oauth_refresh_token,
+    )

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -240,7 +240,10 @@ async def _run_subscription_once(
         config = RedisConfigManager(env_file=env_file)
         config.initialize(force=True)
 
-        credentials = Credentials(config=config, env="Live")
+        env_setting = config.get("ENVIRONMENT", "LIVE").upper()
+        env = "Live" if env_setting == "LIVE" else "Test"
+        credentials = Credentials(config=config, env=env)
+        logger.info("Using %s environment (%s)", env, credentials.base_url)
 
         logger.info("Opening DXLink connection")
         dxlink = DXLinkManager(subscription_store=RedisSubscriptionStore())

--- a/unit_tests/accounts/test_account_models.py
+++ b/unit_tests/accounts/test_account_models.py
@@ -380,15 +380,17 @@ def test_credentials_loads_sandbox_account() -> None:
         side_effect=lambda key: {
             "TT_SANDBOX_URL": "https://sandbox.tastyworks.com",
             "TT_SANDBOX_ACCOUNT": "5WT00001",
-            "TT_OAUTH_CLIENT_ID": "test-client-id",
-            "TT_OAUTH_CLIENT_SECRET": "test-client-secret",
-            "TT_OAUTH_REFRESH_TOKEN": "test-refresh-token",
+            "TT_SANDBOX_USER": "sandbox_user",
+            "TT_SANDBOX_PASS": "sandbox_pass",
         }[key]
     )
     from tastytrade.connections import Credentials
 
     creds = Credentials(config=config, env="Test")
     assert creds.account_number == "5WT00001"
+    assert creds.login == "sandbox_user"
+    assert creds.password == "sandbox_pass"
+    assert creds.oauth_client_id is None
 
 
 def test_credentials_loads_live_account() -> None:

--- a/unit_tests/accounts/test_account_models.py
+++ b/unit_tests/accounts/test_account_models.py
@@ -378,10 +378,11 @@ def test_credentials_loads_sandbox_account() -> None:
     config = MagicMock()
     config.get = MagicMock(
         side_effect=lambda key: {
-            "TT_SANDBOX_USER": "user",
-            "TT_SANDBOX_PASS": "pass",
             "TT_SANDBOX_URL": "https://sandbox.tastyworks.com",
             "TT_SANDBOX_ACCOUNT": "5WT00001",
+            "TT_OAUTH_CLIENT_ID": "test-client-id",
+            "TT_OAUTH_CLIENT_SECRET": "test-client-secret",
+            "TT_OAUTH_REFRESH_TOKEN": "test-refresh-token",
         }[key]
     )
     from tastytrade.connections import Credentials
@@ -394,10 +395,11 @@ def test_credentials_loads_live_account() -> None:
     config = MagicMock()
     config.get = MagicMock(
         side_effect=lambda key: {
-            "TT_USER": "user",
-            "TT_PASS": "pass",
             "TT_API_URL": "https://api.tastyworks.com",
             "TT_ACCOUNT": "ABC12345",
+            "TT_OAUTH_CLIENT_ID": "test-client-id",
+            "TT_OAUTH_CLIENT_SECRET": "test-client-secret",
+            "TT_OAUTH_REFRESH_TOKEN": "test-refresh-token",
         }[key]
     )
     from tastytrade.connections import Credentials

--- a/unit_tests/connections/test_auth_strategies.py
+++ b/unit_tests/connections/test_auth_strategies.py
@@ -1,0 +1,262 @@
+"""Tests for authentication strategies (TT-47)."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tastytrade.connections.auth import (
+    LegacyAuthStrategy,
+    OAuth2AuthStrategy,
+    SyncLegacyAuthStrategy,
+    SyncOAuth2AuthStrategy,
+    create_auth_strategy,
+    create_sync_auth_strategy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Factory function tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_auth_strategy_returns_oauth2_for_live() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = False
+    creds.oauth_client_id = "client-id"
+    creds.oauth_client_secret = "client-secret"
+    creds.oauth_refresh_token = "refresh-token"
+
+    strategy = create_auth_strategy(creds)
+    assert isinstance(strategy, OAuth2AuthStrategy)
+
+
+def test_create_auth_strategy_returns_legacy_for_sandbox() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = True
+    creds.login = "user"
+    creds.password = "pass"
+
+    strategy = create_auth_strategy(creds)
+    assert isinstance(strategy, LegacyAuthStrategy)
+
+
+def test_create_auth_strategy_raises_when_live_missing_oauth() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = False
+    creds.oauth_client_id = None
+    creds.oauth_client_secret = "secret"
+    creds.oauth_refresh_token = "token"
+
+    with pytest.raises(ValueError, match="TT_OAUTH_CLIENT_ID"):
+        create_auth_strategy(creds)
+
+
+def test_create_auth_strategy_raises_when_sandbox_missing_login() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = True
+    creds.login = None
+    creds.password = "pass"
+
+    with pytest.raises(ValueError, match="TT_SANDBOX_USER"):
+        create_auth_strategy(creds)
+
+
+def test_create_sync_auth_strategy_returns_oauth2_for_live() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = False
+    creds.oauth_client_id = "client-id"
+    creds.oauth_client_secret = "client-secret"
+    creds.oauth_refresh_token = "refresh-token"
+
+    strategy = create_sync_auth_strategy(creds)
+    assert isinstance(strategy, SyncOAuth2AuthStrategy)
+
+
+def test_create_sync_auth_strategy_returns_legacy_for_sandbox() -> None:
+    creds = MagicMock()
+    creds.is_sandbox = True
+    creds.login = "user"
+    creds.password = "pass"
+
+    strategy = create_sync_auth_strategy(creds)
+    assert isinstance(strategy, SyncLegacyAuthStrategy)
+
+
+# ---------------------------------------------------------------------------
+# OAuth2AuthStrategy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oauth2_authenticate_sets_bearer_token() -> None:
+    strategy = OAuth2AuthStrategy(
+        client_id="cid",
+        client_secret="csecret",
+        refresh_token="rtoken",
+    )
+
+    response_mock = AsyncMock()
+    response_mock.status = 200
+    response_mock.json = AsyncMock(
+        return_value={"access_token": "test-access-token", "expires_in": 900}
+    )
+    response_mock.headers = {"content-type": "application/json"}
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__ = AsyncMock(return_value=response_mock)
+    context_manager.__aexit__ = AsyncMock(return_value=False)
+
+    headers: dict[str, str] = {}
+    session = MagicMock()
+    session.post = MagicMock(return_value=context_manager)
+    session.headers = MagicMock()
+    session.headers.update = lambda d: headers.update(d)
+
+    await strategy.authenticate(session, "https://api.tastyworks.com")
+
+    assert headers["Authorization"] == "Bearer test-access-token"
+    assert strategy.token_expires_at > 0
+
+
+@pytest.mark.asyncio
+async def test_oauth2_refresh_if_needed_refreshes_when_expired() -> None:
+    strategy = OAuth2AuthStrategy(
+        client_id="cid",
+        client_secret="csecret",
+        refresh_token="rtoken",
+    )
+    # Set token as expired
+    strategy.token_expires_at = time.monotonic() - 10
+
+    response_mock = AsyncMock()
+    response_mock.status = 200
+    response_mock.json = AsyncMock(
+        return_value={"access_token": "refreshed-token", "expires_in": 900}
+    )
+    response_mock.headers = {"content-type": "application/json"}
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__ = AsyncMock(return_value=response_mock)
+    context_manager.__aexit__ = AsyncMock(return_value=False)
+
+    headers: dict[str, str] = {}
+    session = MagicMock()
+    session.post = MagicMock(return_value=context_manager)
+    session.headers = MagicMock()
+    session.headers.update = lambda d: headers.update(d)
+
+    await strategy.refresh_if_needed(session, "https://api.tastyworks.com")
+
+    assert headers["Authorization"] == "Bearer refreshed-token"
+
+
+@pytest.mark.asyncio
+async def test_oauth2_refresh_if_needed_skips_when_valid() -> None:
+    strategy = OAuth2AuthStrategy(
+        client_id="cid",
+        client_secret="csecret",
+        refresh_token="rtoken",
+    )
+    # Set token as valid (expires far in the future)
+    strategy.token_expires_at = time.monotonic() + 600
+
+    session = MagicMock()
+    session.post = MagicMock()
+
+    await strategy.refresh_if_needed(session, "https://api.tastyworks.com")
+
+    # post should NOT have been called
+    session.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# LegacyAuthStrategy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_authenticate_sets_raw_session_token() -> None:
+    strategy = LegacyAuthStrategy(login="user", password="pass")
+
+    response_mock = AsyncMock()
+    response_mock.status = 201
+    response_mock.json = AsyncMock(
+        return_value={"data": {"session-token": "raw-session-token-123"}}
+    )
+    response_mock.headers = {"content-type": "application/json"}
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__ = AsyncMock(return_value=response_mock)
+    context_manager.__aexit__ = AsyncMock(return_value=False)
+
+    headers: dict[str, str] = {}
+    session = MagicMock()
+    session.post = MagicMock(return_value=context_manager)
+    session.headers = MagicMock()
+    session.headers.update = lambda d: headers.update(d)
+
+    await strategy.authenticate(session, "https://api.cert.tastyworks.com")
+
+    # Legacy sets raw token WITHOUT "Bearer " prefix
+    assert headers["Authorization"] == "raw-session-token-123"
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_if_needed_is_noop() -> None:
+    strategy = LegacyAuthStrategy(login="user", password="pass")
+    session = MagicMock()
+
+    # Should not raise, should not call anything
+    await strategy.refresh_if_needed(session, "https://api.cert.tastyworks.com")
+    session.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sync strategy tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_oauth2_authenticate_sets_bearer_token() -> None:
+    strategy = SyncOAuth2AuthStrategy(
+        client_id="cid",
+        client_secret="csecret",
+        refresh_token="rtoken",
+    )
+
+    response_mock = MagicMock()
+    response_mock.status_code = 200
+    response_mock.json.return_value = {
+        "access_token": "sync-access-token",
+        "expires_in": 900,
+    }
+
+    headers: dict[str, str] = {}
+    session = MagicMock()
+    session.post.return_value = response_mock
+    session.headers = MagicMock()
+    session.headers.update = lambda d: headers.update(d)
+
+    with patch("tastytrade.connections.auth.validate_response"):
+        strategy.authenticate(session, "https://api.tastyworks.com")
+
+    assert headers["Authorization"] == "Bearer sync-access-token"
+
+
+def test_sync_legacy_authenticate_sets_raw_token() -> None:
+    strategy = SyncLegacyAuthStrategy(login="user", password="pass")
+
+    response_mock = MagicMock()
+    response_mock.status_code = 201
+    response_mock.json.return_value = {"data": {"session-token": "sync-raw-token"}}
+
+    headers: dict[str, str] = {}
+    session = MagicMock()
+    session.post.return_value = response_mock
+    session.headers = MagicMock()
+    session.headers.update = lambda d: headers.update(d)
+
+    with patch("tastytrade.connections.auth.validate_response"):
+        strategy.authenticate(session, "https://api.cert.tastyworks.com")
+
+    assert headers["Authorization"] == "sync-raw-token"


### PR DESCRIPTION
## Summary
- Migrate TastyTrade authentication from deprecated session-token to OAuth2
- Add dependency injection via strategy pattern for environment-aware auth: OAuth2 for Live, legacy login/password for Sandbox
- Add token auto-refresh for OAuth2 (900s expiry with 60s buffer)

## Related Jira Issue
[TT-47](https://tastytrade-board.atlassian.net/browse/TT-47)

## Acceptance Criteria

### AC1: OAuth2 authentication works for Live environment
**Evidence:** Full CLI subscription test with `ENVIRONMENT=LIVE`:
```
Session created via OAuth2
Using Live environment (https://api.tastyworks.com)
AUTH_STATE:AUTHORIZED
Subscription and back-fill complete for 1/1 subscriptions
```

### AC2: Legacy login/password works for Sandbox environment
**Evidence:** Direct Python test with `env='Test'`:
```
Testing Sandbox auth (https://api.cert.tastyworks.com)...
  Auth header prefix: Q8xS7Cq_gQGpCmvKHRYjlOnnLhezU_...
  Has Bearer prefix: False
  Has dxlink-url: True
  Has token: True
  Sandbox Legacy: SUCCESS
```

### AC3: Strategy pattern selects correct auth per environment
**Evidence:** Factory function test:
```
Live strategy: OAuth2AuthStrategy
  has oauth: True, has login: False
Sandbox strategy: LegacyAuthStrategy
  has oauth: False, has login: True
```

### AC4: Token auto-refresh for OAuth2
Bearer tokens expire every 900s. `OAuth2AuthStrategy.refresh_if_needed()` checks `time.monotonic()` against expiry minus 60s buffer, and re-authenticates when near expiry.

## Test Evidence
- 220 unit tests pass (including 13 new auth strategy tests)
- ruff check: clean (no new issues)
- mypy: clean (no new issues)
- Pre-commit hooks: all pass

## Changes Made

| File | Change |
|------|--------|
| `src/tastytrade/connections/auth.py` | NEW: AuthStrategy Protocol, OAuth2/Legacy strategies (async+sync), factory functions |
| `src/tastytrade/connections/__init__.py` | Credentials: environment-aware auth field loading (OAuth2 for Live, login/password for Sandbox) |
| `src/tastytrade/connections/requests.py` | SessionHandlers delegate auth to injected strategy |
| `.env.example` | Add legacy credential placeholders alongside OAuth2 |
| `.claude/skills/github-operations/scripts/create-branch.sh` | Symlink .env into worktrees |
| `unit_tests/connections/test_auth_strategies.py` | NEW: 13 strategy tests |
| `unit_tests/accounts/test_account_models.py` | Fix sandbox credential mocks |

[TT-47]: https://mandeng.atlassian.net/browse/TT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ