### PR TITLE
TT-41: Add InfluxDB signal round-trip (write + read + chart)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,6 @@ venv/
 ENV/
 .python-version
 
-# .claude/*
-# !.claude/hooks/
 .claude/state/
 
 # IDE

--- a/docs/github_workflow.md
+++ b/docs/github_workflow.md
@@ -1,0 +1,138 @@
+# GitHub Workflow — Delegation Guide
+
+This document contains detailed examples and procedures for GitHub operations.
+All GitHub operations MUST be delegated to the `github-workflow` agent via the Task tool.
+
+See [CLAUDE.md](../CLAUDE.md) for the mandatory rules (kept inline there for agent visibility).
+
+---
+
+## Why Delegation Matters
+
+The github-workflow agent is the **mandatory gatekeeper** for all GitHub operations. It enforces:
+
+- **PR title format** (TT-XXX: Description)
+- **PR body structure** (Summary, Related Jira Issue, Acceptance Criteria, Evidence, Test Evidence, Changes Made)
+- **Branch naming conventions** (type/TT-XXX-description)
+- **Commit message format** (TT-XXX: Description)
+- **Functional evidence requirements** (mandatory for each AC)
+- **Quality gates** (tests, type checking, linting)
+- **Immediate branch push** after creation to trigger Jira automation
+
+---
+
+## Operations That Require Delegation
+
+**ALWAYS use github-workflow agent for:**
+- Creating pull requests
+- Getting PR status and details
+- Listing pull requests
+- Viewing PR file changes
+- Creating and pushing branches (CRITICAL: must push immediately after creation)
+- Repository operations (commits, git operations)
+
+**When to use:**
+- Creating, listing, or viewing pull requests
+- Any gh CLI operations
+- Modifying files in `.claude/skills/github-operations/`
+- Repository operations (branches, commits, tags)
+- PR reviews, comments, status checks
+
+---
+
+## Correct Usage Patterns
+
+### Creating a PR
+
+```python
+Task(
+    subagent_type="github-workflow",
+    description="Create PR for feature",
+    prompt="""
+    Create a pull request for the completed work:
+
+    Branch: feature/TT-XXX-description
+    Base: main
+    Title: TT-XXX: Brief description
+
+    Summary: [what was done]
+    Changes: [list of changes]
+    Evidence: [functional evidence for each AC from Jira ticket]
+    """
+)
+```
+
+### Creating and pushing a branch
+
+```python
+# Agent will create branch and IMMEDIATELY push to trigger Jira automation
+Task(
+    subagent_type="github-workflow",
+    description="Create and push feature branch",
+    prompt="Create branch feature/TT-XXX-add-feature and push immediately to remote"
+)
+```
+
+### Getting PR status
+
+```python
+Task(
+    subagent_type="github-workflow",
+    description="Check PR status",
+    prompt="Get status for PR #45 - are checks passing and is it ready to merge?"
+)
+```
+
+---
+
+## Incorrect Usage (DO NOT DO THIS)
+
+```python
+# NEVER DO THIS - These are BLOCKED:
+Skill(command="github-operations")              # Will fail with permission error
+Bash("gh pr create ...")                        # Blocked
+Edit(".claude/skills/github-operations/...")    # Blocked - use agent
+bash .claude/skills/github-operations/scripts/create-pr.sh "..." "..." "main" "..."
+```
+
+```python
+# NEVER DO THIS - Jira automation won't trigger
+git checkout -b feature/TT-XXX-description
+# ... then work on it later without pushing
+```
+
+---
+
+## Autonomous PR Creation Flow
+
+When all ACs pass and code is pushed, create the PR immediately — do NOT ask permission.
+
+```
+Branch created       → Jira: In Progress
+Code pushed + ACs pass → Create PR → Jira: In Review
+PR merged (human)    → Jira: Done
+```
+
+---
+
+## Branch Push Requirement
+
+All new branches MUST be pushed to remote **immediately** after creation.
+
+**Why:** Triggers Jira automation (To Do → In Progress) and signals work has started.
+
+**The github-workflow agent automatically enforces:**
+
+1. Update main branch
+2. Create feature branch
+3. **IMMEDIATELY push to remote** (even if empty)
+4. Then proceed with work
+
+---
+
+## Branch Naming Conventions
+
+- Format: `type/TT-XXX-description`
+- Types: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`
+- MUST include Jira ticket (TT-XXX) in branch name — enforced by agent
+- NEVER work on `main` branch — github-workflow agent will REJECT operations

--- a/docs/jira_workflow.md
+++ b/docs/jira_workflow.md
@@ -1,0 +1,227 @@
+# Jira Workflow — Delegation Guide
+
+This document contains detailed examples, templates, and procedures for Jira operations.
+All Jira operations MUST be delegated to the `jira-workflow` agent via the Task tool.
+
+See [CLAUDE.md](../CLAUDE.md) for the mandatory rules (kept inline there for agent visibility).
+
+---
+
+## Why Delegation Matters
+
+The jira-workflow agent is the **mandatory gatekeeper** for all Jira operations. It enforces:
+
+- **Intelligent type selection** (Story/Task/Bug/Sub-task based on request analysis)
+- **Quality standards** (Test Evidence Requirements embedded in all templates)
+- **Epic governance** (can link to Epics, cannot create Epics)
+- **Validation rules** (ensures tickets meet project standards)
+- **Type-agnostic workflow** (dispatcher processes any ticket type)
+
+---
+
+## Operations That Require Delegation
+
+**ALWAYS use jira-workflow agent for:**
+- Creating tickets (Story, Task, Bug, Sub-task — NOT Epic)
+- Updating tickets (fields, descriptions, priorities)
+- Linking tickets (to Epics, to parent issues)
+- Searching tickets (JQL queries)
+- Adding comments to tickets
+- Getting ticket details
+- Managing sprints (when applicable)
+
+**When to use:**
+- User mentions a Jira ticket (TT-XXX)
+- User asks to "work on TT-XXX" or "start TT-XXX"
+- Need to get issue details, update status, add comments
+- Need to create new issues or search existing ones
+
+---
+
+## Correct Usage Patterns
+
+### Creating a ticket
+
+```python
+Task(
+    subagent_type="jira-workflow",
+    description="Create Jira ticket for feature",
+    prompt="""
+    Create a ticket for the following work:
+
+    Feature: Add WebSocket reconnection logic
+    Context: Users need automatic reconnection when market data streams disconnect
+    Priority: High
+
+    Please create the appropriate ticket type (Story/Task/Bug) based on this request
+    and link it to the relevant Epic if obvious from context.
+    """
+)
+```
+
+### Letting the agent determine type
+
+```python
+# Agent will analyze "fix bug" and create Bug ticket
+Task(
+    subagent_type="jira-workflow",
+    description="Create ticket for bug fix",
+    prompt="Create ticket: Fix message routing failure on malformed events"
+)
+```
+
+### Searching tickets
+
+```python
+Task(
+    subagent_type="jira-workflow",
+    description="Find tickets in epic",
+    prompt="Find all Stories in Market Data epic (TT-1) that are in To Do status"
+)
+```
+
+---
+
+## Incorrect Usage (DO NOT DO THIS)
+
+```python
+# NEVER DO THIS - These are BLOCKED:
+Skill(command="jira-operations")  # Will fail with permission error
+Bash("jira-cli ...")              # Blocked
+bash .claude/skills/jira-operations/scripts/create-issue.sh "..." "..." "Story"
+```
+
+```python
+# NEVER DO THIS - Epics are team-managed strategic tools
+Task(
+    subagent_type="jira-workflow",
+    prompt="Create Epic for Q2 Roadmap"
+)
+# jira-workflow agent will correctly decline this request
+```
+
+---
+
+## Type-Agnostic Approach
+
+The jira-workflow agent uses **intelligent type selection**:
+- Analyzes your request and keywords
+- Automatically selects Story/Task/Bug/Sub-task
+- Asks for clarification if ambiguous
+- Refuses to create Epics (team governance)
+
+**You don't need to specify the type** — just describe what needs to be done:
+
+```python
+"Add real-time quote streaming"       # → Story (user-facing feature)
+"Refactor message router logic"       # → Task (technical work)
+"Fix WebSocket connection drops"      # → Bug (defect)
+"Create API endpoint under TT-50"     # → Sub-task (implementation piece)
+```
+
+---
+
+## Verbatim Content Rule — Full Details
+
+**The jira-workflow agent paraphrases by default. You MUST prevent this.**
+
+When passing plans, code snippets, field lists, or implementation details, explicitly instruct it to use the content **verbatim**.
+
+**Include this instruction in every prompt with detailed content:**
+
+> Use the following content VERBATIM in the description. Do NOT paraphrase, summarize, or rewrite. Copy it exactly as provided.
+
+### What must be passed verbatim (when available):
+
+- Code snippets with file paths and line numbers
+- Field lists, enum values, method signatures
+- Test function names, factory function specs
+- API response shapes
+- Design rationale
+- Acceptance criteria mappings
+
+**Why:** The implementing agent has zero context from your conversation. Paraphrased summaries lose the exact details (field names, line numbers, code patterns) that make a ticket actionable.
+
+---
+
+## Status Transitions
+
+Status transitions are handled by GitHub workflows, NOT manually:
+
+- Branch created → Jira moves to "In Progress" (via `.github/workflows/jira-transition.yml`)
+- PR opened → Jira moves to "In Review" (automated)
+- PR merged → Jira moves to "Done" (automated)
+
+jira-workflow agent has read-only status awareness. Do not manually transition tickets.
+
+---
+
+## Epic Governance
+
+Epics are strategic planning tools managed by the team.
+
+- Agent CAN link tickets to existing Epics
+- Agent CANNOT create new Epics
+
+If you need an Epic created, ask the team to create it manually in Jira, then use jira-workflow agent to link tickets to it.
+
+---
+
+## Implementation Completion Documentation
+
+When you complete work on a Jira ticket, you MUST add a comprehensive implementation comment via the jira-workflow agent.
+
+The comment MUST include:
+
+### 1. Expected Behaviors (MOST IMPORTANT)
+
+Describe changes from user/operational perspective using Before/After format:
+
+```
+Before: Status showed subscription creation time, not actual data flow
+After: Status shows when data was last received (e.g., "8s ago" updating in real-time)
+
+Before: Constant "stale: Profile, Summary" warnings even when feeds were healthy
+After: No false staleness warnings - low-frequency feeds are expected behavior
+```
+
+### 2. Technical Implementation
+
+- New components added (classes, functions, enums)
+- Modified components with explanations
+- Data flow changes if architectural
+
+### 3. Features Added/Removed
+
+- Tables listing all features with file locations
+- Reasons for any removed features
+
+### 4. Verification Evidence
+
+- Test results (unit, integration, live)
+- Specific examples with real data
+
+The jira-workflow agent has detailed templates for this. Always delegate completion comments to it.
+
+---
+
+## Jira Quality Assurance Procedure
+
+After creating or updating any Jira ticket, the jira-workflow agent MUST:
+
+1. **Re-read the ticket** to verify it was created correctly
+2. **Check completeness** against quality standards
+3. **Fix any deficiencies** before reporting back
+4. **Report confidence level** (✅ complete or ⚠️ needs attention)
+
+---
+
+## Plan-Ticket Alignment Procedure
+
+Before implementation begins, persist the **full, exact** implementation plan to the Jira ticket. The ticket is the source of truth — plans discussed in conversation are lost if not persisted.
+
+**How to persist plans:**
+
+1. Pass the complete plan text to the jira-workflow agent with the **Verbatim Content Rule**
+2. After the agent updates the ticket, re-read it to confirm **nothing was paraphrased or omitted**
+3. If content was summarized or truncated, re-send with explicit correction

--- a/docs/pr_standards.md
+++ b/docs/pr_standards.md
@@ -1,0 +1,129 @@
+# Pull Request Standards
+
+This document contains detailed PR evidence templates, quality gates, and checklists.
+See [CLAUDE.md](../CLAUDE.md) for the mandatory rules (kept inline there for agent visibility).
+
+---
+
+## Functional Testing Requirement
+
+**Unit tests are NOT actual tests. You MUST functionally test all code changes before creating a PR.**
+
+Before creating any pull request, you MUST:
+
+1. **Actually run the code** in a realistic environment
+2. **Verify the feature works** by exercising it manually or via integration
+3. **Capture evidence** (logs, output, screenshots) proving it works
+4. **Document blockers** if testing is not possible (missing tools, services, etc.)
+
+**If you cannot test a feature:**
+- STOP and notify the user
+- Explain what is missing (redis-cli, API credentials, external service, etc.)
+- Do NOT create a PR with untested code
+
+---
+
+## What Unit Tests Do NOT Prove
+
+Passing unit tests means:
+
+- **NOT** that the feature works
+- **NOT** that integration points function
+- **NOT** that the code behaves correctly in production
+- **ONLY** that the code compiles and isolated units behave as mocked
+
+---
+
+## Evidence: Insufficient vs Required
+
+### Insufficient: Test-only evidence
+
+```
+## Test Evidence
+- test_load_json PASSED
+- All 50 unit tests pass
+- mypy passes
+- ruff passes
+```
+
+These are quality gates, NOT functional evidence.
+
+### Required: Functional evidence with production data
+
+```
+## Functional Evidence
+
+### AC1: [Specific acceptance criterion from the Jira ticket]
+
+**Real Example: [Demonstrating the feature with realistic data]**
+
+```python
+# Code showing feature working with production/realistic data
+# Include concrete, measurable results
+```
+
+**Results:**
+- Specific outcome 1 with concrete details
+- Specific outcome 2 with measurable results
+```
+
+---
+
+## Evidence Standards
+
+For EVERY acceptance criterion, provide:
+
+### 1. Real Production/Realistic Data
+
+- Use actual production data or realistic files (NOT test fixtures from `unit_tests/fixtures/`)
+- For file-based features: show file names, sizes, and processing results
+- For API/service features: show realistic requests/responses
+- For UI features: show actual user workflows with real data
+
+### 2. Actual Usage Workflows
+
+- Demonstrate the feature working as specified in acceptance criteria
+- Show integration with existing systems works
+- Prove end-to-end workflows function correctly
+
+### 3. Concrete, Measurable Results
+
+- Specific file names, sizes, or identifiers
+- Quantifiable outcomes (counts, durations, sizes)
+- Sample output data relevant to the feature
+
+### 4. End-to-End Verification
+
+- Show feature works in application context
+- Verify dependencies actually work (import and use them)
+- Demonstrate configuration settings function
+
+---
+
+## PR Body Required Sections
+
+Every PR body MUST contain these sections:
+
+| Section | Description |
+|---------|-------------|
+| **Summary** | 1-3 bullet points describing what was done |
+| **Related Jira Issue** | Clickable link to TT-XXX |
+| **Acceptance Criteria** | Each AC with functional evidence |
+| **Test Evidence** | Quality gate results (tests, mypy, ruff) |
+| **Changes Made** | List of files/modules changed |
+
+---
+
+## PR Quality Assurance Checklist
+
+After creating or updating any PR, the github-workflow agent MUST:
+
+1. **Re-read the PR** to verify it was created correctly
+2. **Check completeness** against required sections:
+   - Summary section present and meaningful
+   - Related Jira Issue with clickable link
+   - Acceptance Criteria with evidence for EACH AC
+   - Test Evidence section
+   - Changes Made section
+3. **Fix any deficiencies** before reporting back
+4. **Report confidence level** (✅ Complete or ⚠️ Needs attention)

--- a/docs/signal_architecture.md
+++ b/docs/signal_architecture.md
@@ -1,0 +1,238 @@
+# Signal Detection Architecture
+
+This document describes the real-time signal detection pipeline, its two
+consumption paths, and the design rationale behind each.
+
+---
+
+## Overview
+
+The signal detection system has one engine (`HullMacdEngine`) and **two
+independent consumption paths**. Both receive the same `CandleEvent`
+objects; they differ in where those events come from and how signals are
+collected.
+
+```
+                  ┌─────────────────────────────────────────────────┐
+                  │         DXLink (separate process)               │
+                  │  Streams live market data via WebSocket          │
+                  └───────────┬─────────────────────────────────────┘
+                              │
+                    Redis pub/sub publish
+                    channel: market:CandleEvent:SPX{=5m}
+                              │
+              ┌───────────────┴───────────────┐
+              │                               │
+     PATH A: Production               PATH B: Notebook / Direct
+     (EventHandler pipeline)           (Redis → Engine)
+              │                               │
+     EventHandler.processors           RedisSubscription.queue
+     ├─ TelegrafHTTPProcessor                 │
+     ├─ RedisEventProcessor            await queue.get()
+     └─ SignalEventProcessor                  │
+              │                        engine.on_candle_event(event)
+     engine.on_candle_event()                 │
+              │                        engine.signals  ← read list
+     on_signal callback                       │
+              │                        (no callbacks needed)
+     emit → re-inject into
+     EventHandler chain
+```
+
+---
+
+## Path A: Production EventHandler Pipeline
+
+Used by: `api/main.py`, `subscription/orchestrator.py`, `scripts/dxlink_startup.py`
+
+```python
+candle_handler = dxlink.router.handler[Channels.Candle]
+candle_handler.add_processor(SignalEventProcessor(engine, emit=handler.process_event))
+```
+
+**Data flow:**
+
+1. `DXLink WebSocket` → `asyncio.Queue` → `EventHandler.queue_listener()`
+2. `EventHandler.handle_message()` parses raw data into `CandleEvent`
+3. Loops through `self.processors`, calling `processor.process_event(event)`
+4. `SignalEventProcessor.process_event()` → `engine.on_candle_event()`
+5. Engine detects confluence → calls `on_signal` callback
+6. Callback fires `emit()` → re-injects `TradeSignal` into the handler chain
+7. Other processors (Telegraf, Redis) write the `TradeSignal` to InfluxDB / Redis
+
+**When to use:** Automated production pipelines where signals must be
+persisted and distributed without human interaction.
+
+**Requires:** Direct DXLink WebSocket connection in the same process.
+
+---
+
+## Path B: Notebook / Direct Consumption (Preferred for Development)
+
+Used by: `playground_signals.ipynb`, ad-hoc analysis, backtesting
+
+```python
+engine = HullMacdEngine()
+engine.set_prior_close("SPX{=5m}", prior_close)
+
+await subscription.subscribe("market:CandleEvent:SPX{=5m}")
+queue = subscription.queue["CandleEvent:SPX{=5m}"]
+
+while True:
+    event = await queue.get()        # async, non-blocking to event loop
+    engine.on_candle_event(event)    # state machine processes candle
+
+    if engine.signals:
+        latest = engine.signals[-1]  # read directly from list
+```
+
+**Data flow:**
+
+1. DXLink (separate process) → Redis pub/sub → `RedisSubscription.listener()`
+2. `convert_message_to_event()` deserializes to `CandleEvent`
+3. Event placed in `asyncio.Queue` keyed by `CandleEvent:SPX{=5m}`
+4. Notebook calls `await queue.get()` — blocks until next candle arrives
+5. Feeds `CandleEvent` directly to `engine.on_candle_event()`
+6. Reads `engine.signals` list — no callbacks, no processor chain
+
+**When to use:** Development, testing, real-time monitoring, manual
+exploration during market hours.
+
+**Requires:** DXLink running in a separate process with Redis pub/sub
+active (the standard `tasty-subscription` setup from TT-31).
+
+---
+
+## Why Two Paths Exist
+
+| Concern | Path A (Production) | Path B (Notebook) |
+|---|---|---|
+| DXLink location | Same process | Separate process |
+| Event source | WebSocket → Queue → EventHandler | Redis pub/sub → asyncio.Queue |
+| Signal delivery | Callback → emit into handler chain | Poll `engine.signals` list |
+| Persistence | Automatic (Telegraf processor) | Manual or not needed |
+| Wiring complexity | Processor registration, callbacks | Zero — direct function calls |
+| Latency | Lowest (in-process) | Near-zero (Redis pub/sub hop) |
+
+Path B is simpler because it decouples the engine from the processor
+framework. The engine is a **standalone state machine** — it accepts
+`CandleEvent` in, accumulates internal state, and appends `TradeSignal`
+to a list. No framework required.
+
+---
+
+## Callback Analysis
+
+The engine has an `on_signal` callback mechanism:
+
+```python
+# In HullMacdEngine._emit_signal():
+self._signals.append(signal)     # Always happens — signals accumulate
+if self._on_signal:
+    self._on_signal(signal)      # Only fires if callback is set
+```
+
+**For Path A (Production):** The callback is how `SignalEventProcessor`
+re-injects signals into the EventHandler chain for downstream persistence.
+
+**For Path B (Notebook):** The callback is **unnecessary**. Signals are
+already in `engine.signals`. Setting `on_signal` is optional — skip it.
+
+The `SignalEventProcessor` class itself is a Path A adapter. Path B
+bypasses it entirely.
+
+### Protocol implications
+
+The `SignalEngine` protocol currently requires `on_signal` getter/setter:
+
+```python
+class SignalEngine(Protocol):
+    @property
+    def on_signal(self) -> Callable[[TradeSignal], None] | None: ...
+    @on_signal.setter
+    def on_signal(self, callback: Callable[[TradeSignal], None] | None) -> None: ...
+```
+
+This is a Path A concern. If future engines only need Path B, the
+callback can be removed from the protocol and kept as an optional mixin.
+For now, both paths coexist without conflict — the callback is never
+invoked unless explicitly wired.
+
+---
+
+## Key Components
+
+### HullMacdEngine
+
+Location: `src/tastytrade/analytics/engines/hull_macd.py`
+
+Standalone state machine. No external dependencies at runtime beyond
+the `hull()` and `macd()` indicator functions.
+
+- **Input:** `CandleEvent` via `on_candle_event()`
+- **Output:** `TradeSignal` appended to `self.signals`
+- **State:** Per-symbol `TimeframeState` tracking hull direction, MACD
+  position, armed indicators, and open positions
+- **Time gates:** `earliest_entry` (default 10:00 ET) and `latest_entry`
+  (default 15:00 ET)
+
+### SignalEventProcessor
+
+Location: `src/tastytrade/messaging/processors/signal.py`
+
+Path A adapter. Wraps a `SignalEngine` in the `EventProcessor` interface
+so it can be registered with `EventHandler.add_processor()`.
+
+- Filters non-`CandleEvent` types (prevents re-entrant loops from
+  `TradeSignal` being broadcast back through processors)
+- Sets up `on_signal` callback to emit signals back into the handler chain
+
+**Not needed for Path B.**
+
+### RedisSubscription
+
+Location: `src/tastytrade/providers/subscriptions.py`
+
+Async Redis pub/sub consumer. Deserializes messages back into typed
+`BaseEvent` objects and routes to per-symbol `asyncio.Queue` instances.
+
+- Subscribe: `await subscription.subscribe("market:CandleEvent:SPX{=5m}")`
+- Consume: `event = await subscription.queue["CandleEvent:SPX{=5m}"].get()`
+- Each `.get()` returns a fully typed `CandleEvent` ready for the engine
+
+### TradeSignal
+
+Location: `src/tastytrade/analytics/engines/models.py`
+
+Extends `BaseAnnotation` so it can be persisted to InfluxDB and rendered
+on charts. Key fields:
+
+| Field | Description |
+|---|---|
+| `signal_type` | `OPEN` or `CLOSE` |
+| `direction` | `BULLISH` or `BEARISH` |
+| `trigger` | `hull`, `macd`, or `confluence` |
+| `close_price` | Candle close at trigger time (entry spot price) |
+| `hull_value` | HMA value at signal time |
+| `macd_value` | MACD line value |
+| `macd_signal` | MACD signal line value |
+| `macd_histogram` | MACD histogram value |
+
+---
+
+## Future: Spot Price and Options Chain
+
+When a signal fires, `close_price` captures the triggering candle's close.
+For more precise entry pricing:
+
+1. **Mid price from live Quote feed:** Subscribe to `market:QuoteEvent:SPX`
+   alongside the candle feed. At signal time, read the latest quote from
+   its queue to get bid/ask mid as the spot price.
+
+2. **Options chain at ATM +/-5:** At signal time, query the TastyTrade
+   options chain API for strikes at ATM, ATM+5, ATM-5. This is an API
+   call that adds latency — acceptable for 0DTE decision-making but
+   should not block signal detection.
+
+Both are additive — the engine fires the signal, then enrichment
+happens after.

--- a/docs/subscription_cli.md
+++ b/docs/subscription_cli.md
@@ -1,0 +1,70 @@
+# Market Data Subscription CLI (`tasty-subscription`)
+
+The `tasty-subscription` CLI manages market data subscriptions including historical backfill, live streaming, and operational monitoring.
+
+---
+
+## Commands
+
+### `run` — Start subscription with historical backfill and live streaming
+
+```bash
+uv run tasty-subscription run \
+  --start-date 2026-01-15 \
+  --symbols AAPL,SPY,QQQ \
+  --intervals 1d,1h,5m \
+  --log-level INFO
+```
+
+### `status` — Query active subscriptions
+
+```bash
+uv run tasty-subscription status
+uv run tasty-subscription status --json
+```
+
+---
+
+## Run Command Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--start-date` | Yes | Historical backfill start date (YYYY-MM-DD) |
+| `--symbols` | Yes | Comma-separated symbols (e.g., `AAPL,SPY,QQQ`) |
+| `--intervals` | Yes | Comma-separated intervals: `1d`, `1h`, `30m`, `15m`, `5m`, `m` |
+| `--log-level` | No | `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`) |
+| `--health-interval` | No | Seconds between health logs (default: `300`) |
+
+---
+
+## Full Production Example
+
+```bash
+uv run tasty-subscription run \
+  --start-date 2026-01-20 \
+  --symbols BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX \
+  --intervals 1d,1h,30m,15m,5m,m \
+  --log-level INFO
+```
+
+**Expected Output:**
+
+```
+TastyTrade Market Data Subscription - Starting
+Configuration:
+  Start Date:  2026-01-20
+  Symbols:     BTC/USD:CXTALP, NVDA, AAPL, QQQ, SPY, SPX
+  Intervals:   1d, 1h, 30m, 15m, 5m, m
+  Feed Count:  36 candle feeds
+Subscribing to ticker feeds for 6 symbols
+Subscribing to 36 candle feeds from 2026-01-20
+Subscription and back-fill complete for 36/36 subscriptions
+Subscription active - press Ctrl+C to stop
+Health — Uptime: 5m | 6 channels active
+```
+
+---
+
+## Graceful Shutdown
+
+Press `Ctrl+C` for clean shutdown (flushes data, closes connections).

--- a/src/devtools/playground_signals.ipynb
+++ b/src/devtools/playground_signals.ipynb
@@ -4279,16 +4279,42 @@
   {
    "cell_type": "markdown",
    "id": "476t1sg72p",
-   "source": "## Write Signals to InfluxDB\n\nPersist the engine-computed signals to InfluxDB using the same `Point` format\nas `TelegrafHTTPEventProcessor` (measurement = class name, tag = `eventSymbol`,\nfields = all `__dict__` items). This enables the read-back in the next section.",
-   "metadata": {}
+   "metadata": {},
+   "source": "## Write Signals to InfluxDB\n\nPersist the engine-computed signals to InfluxDB using `TelegrafHTTPEventProcessor` —\nthe same write path as the real-time pipeline.\n\n**InfluxDB Data Explorer query** (paste into `localhost:8086`):\n```flux\nfrom(bucket: \"tastytrade\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"TradeSignal\")\n  |> filter(fn: (r) => r.eventSymbol == \"SPX{=5m}\")\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> group()\n  |> sort(columns: [\"_time\"])\n```"
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "8mrrin4ku",
-   "source": "from tastytrade.messaging.processors.influxdb import TelegrafHTTPEventProcessor\n\nwriter = TelegrafHTTPEventProcessor()\n\nfor s in engine.signals:\n    writer.process_event(s)\n\nwriter.close()\nprint(f\"Wrote {len(engine.signals)} signals to InfluxDB via TelegrafHTTPEventProcessor\")",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-12 02:02:27 - INFO:tastytrade.messaging.processors.influxdb:44:Flushing InfluxDB write API...\n",
+      "2026-02-12 02:02:27 - INFO:tastytrade.messaging.processors.influxdb:47:InfluxDB client closed\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote 14 signals to InfluxDB via TelegrafHTTPEventProcessor\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tastytrade.messaging.processors.influxdb import TelegrafHTTPEventProcessor\n",
+    "\n",
+    "writer = TelegrafHTTPEventProcessor()\n",
+    "\n",
+    "for s in engine.signals:\n",
+    "    writer.process_event(s)\n",
+    "\n",
+    "writer.close()\n",
+    "print(f\"Wrote {len(engine.signals)} signals to InfluxDB via TelegrafHTTPEventProcessor\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -4303,10 +4329,3688 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "1s3xboifnn4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retrieved 14 signals from InfluxDB\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "close": {
+          "bdata": "AAAAAMBGu0AUrkfh+j27QFK4HoXrP7tAUrgehWtBu0DD9Shcjzu7QM3MzMxMMbtAmpmZmRktu0AUrkfhOiS7QGZmZmamGbtAj8L1KBwPu0C4HoXrkQO7QB+F61G4BbtACtejcD0Pu0AAAAAAgBW7QHE9CtcjFbtAzczMzMwNu0CuR+F6lCG7QKRwPQrXH7tAXI/C9agau0AUrkfhuhe7QHsUrkchJbtA9ihcj8Iku0BSuB6F6ym7QDMzMzNzG7tAZmZmZiYgu0BI4XoU7iO7QKRwPQrXJrtACtejcD0ju0AfhetR+CO7QGZmZmYmHbtAw/UoXE8Yu0CF61G4HiC7QM3MzMxMILtA9ihcj0Iiu0AK16NwfSe7QHsUrkfhK7tAKVyPwvUou0AzMzMz8yi7QPYoXI8CLrtAPQrXo3Auu0C4HoXrESy7QDMzMzMzJLtAcT0K1yMju0BxPQrXIx27QLgehesRGbtA9ihcj8Idu0BxPQrXIx+7QHsUrkfhJLtAKVyPwvUfu0C4HoXrUSS7QClcj8J1ILtAUrgehesku0CF61G4niW7QEjhehTuI7tAj8L1KJwku0CkcD0KlyK7QHE9CtdjKbtAH4XrUfgpu0C4HoXrUS27QJqZmZmZLrtAPQrXozAtu0CPwvUonCy7QFK4HoXrLbtA4XoUrocou0AzMzMzMye7QD0K16PwJbtAUrgehSsnu0Bcj8L1qCS7QPYoXI+CJLtArkfhelQku0C4HoXr0SK7QD0K16NwH7tAmpmZmZkcu0BI4XoUbiK7QMP1KFyPIbtAZmZmZiYmu0A9Ctej8CO7QEjhehSuG7tA",
+          "dtype": "f8"
+         },
+         "decreasing": {
+          "fillcolor": "#EF5350",
+          "line": {
+           "color": "#EF5350"
+          }
+         },
+         "high": {
+          "bdata": "FK5H4XpRu0DsUbgexUe7QLgehetRQ7tAZmZmZuZIu0D2KFyPQkO7QI/C9SjcPrtAPQrXo3A3u0AzMzMz8y27QM3MzMzMI7tASOF6FC4bu0DXo3A9ShC7QHsUrkchDLtAmpmZmdkPu0DNzMzMzBW7QK5H4XqUGbtA9ihcjwIZu0AfhetR+CG7QEjhehSuIrtAj8L1KJwiu0C4HoXr0Ru7QJqZmZlZJbtAMzMzM/Mlu0CamZmZWSu7QOxRuB7FKrtAFK5H4foiu0BI4XoU7iO7QD0K16OwKbtA16NwPQopu0B7FK5HYSa7QJqZmZkZJLtAhetRuB4du0BxPQrXIyC7QFyPwvWoIrtAAAAAAMAmu0DhehSuxye7QMP1KFyPLrtAuB6F69Esu0AzMzMzsyq7QI/C9SjcLrtA7FG4HgUvu0DhehSuRzC7QPYoXI8CLLtASOF6FO4lu0DhehSuRyO7QJqZmZkZHbtA16NwPUohu0CkcD0KVyC7QNejcD2KJbtAmpmZmVkmu0BmZmZm5iS7QDMzMzMzJLtArkfhehQlu0Bcj8L1KCa7QHE9CtfjJrtAj8L1KJwku0CuR+F6lCW7QK5H4XqUKrtAuB6F61Eru0CamZmZ2S27QKRwPQoXMLtAmpmZmZkuu0CuR+F6VC+7QFK4HoXrLbtAH4XrUfgtu0AzMzMzcym7QGZmZmZmKLtAZmZmZuYnu0DXo3A9iie7QFK4HoXrJbtAKVyPwjUnu0BmZmZmJiS7QGZmZmbmI7tAmpmZmVkgu0AfhetReCK7QK5H4XrUJbtA16NwPUomu0CF61G4Hia7QOF6FK7HI7tA",
+          "dtype": "f8"
+         },
+         "increasing": {
+          "fillcolor": "rgba(19, 19, 19, 0.1)",
+          "line": {
+           "color": "#4CAF50"
+          }
+         },
+         "line": {
+          "width": 0.75
+         },
+         "low": {
+          "bdata": "FK5H4XpAu0D2KFyPwjy7QKRwPQpXPLtAUrgehes+u0BI4XoUrjm7QI/C9ShcL7tAXI/C9Sgru0DD9ShcTyO7QNejcD3KELtAj8L1KBwPu0AAAAAAQAK7QB+F61H4/7pA4XoUrscEu0CF61G4Hgu7QNejcD3KELtArkfhelQMu0BxPQrXIwu7QIXrUbieHrtAMzMzMzMZu0DD9ShcDxe7QFK4HoVrF7tACtejcH0gu0DsUbgehSS7QDMzMzNzG7tAhetRuJ4Yu0AfhetROBy7QOxRuB4FJLtAmpmZmdkhu0DsUbgeRSG7QBSuR+G6HLtAPQrXo7AWu0CuR+F6lBe7QB+F61H4HLtAFK5H4fodu0C4HoXrER+7QB+F61F4J7tAexSuR+Enu0A9Ctej8Ca7QEjhehTuKLtA9ihcj4Iqu0AzMzMzcyq7QIXrUbieIrtAAAAAAAAgu0BxPQrXIx27QM3MzMwMGLtAH4XrUfgWu0AfhetR+Bu7QD0K16OwHbtAKVyPwvUfu0DXo3A9Sh+7QJqZmZmZHrtAj8L1KFwgu0BSuB6Fqx27QM3MzMxMI7tAcT0K12Mhu0BSuB6F6x67QD0K16PwIbtAj8L1KBwpu0DhehSuxym7QI/C9SjcLLtACtejcP0pu0CPwvUonCy7QI/C9ShcK7tAw/UoXM8gu0AzMzMzsyW7QDMzMzPzJLtAMzMzM3Mku0CPwvUoHCS7QHsUrkfhI7tA4XoUrkcju0DsUbgeRSC7QI/C9ShcH7tA4XoUrscbu0DhehSuRxy7QIXrUbgeIbtAMzMzM3Mhu0Bcj8L16B67QEjhehSuG7tA",
+          "dtype": "f8"
+         },
+         "name": "Price",
+         "open": {
+          "bdata": "FK5H4XpAu0Bcj8L16Ea7QOxRuB4FPrtAexSuR6E/u0ApXI/CtUG7QArXo3D9O7tA9ihcj0Ixu0ApXI/CNS27QDMzMzOzI7tAH4XrUXgZu0BmZmZmZg+7QNejcD3KA7tACtejcH0Fu0Bcj8L1aA+7QEjhehRuFbtAXI/C9agUu0AAAAAAwA27QOF6FK6HIbtAPQrXozAgu0DXo3A9ihq7QB+F61G4F7tA9ihcjwIlu0AfhetRuCS7QB+F61H4KbtAhetRuF4bu0BSuB6FKyC7QOxRuB4FJLtAUrgehasmu0D2KFyPQiO7QDMzMzPzI7tAhetRuB4du0CamZmZGRi7QKRwPQoXILtA4XoUrkcgu0BI4XoUbiK7QB+F61F4J7tAFK5H4Tosu0AAAAAAACm7QEjhehTuKLtAXI/C9egtu0AUrkfh+i27QClcj8L1K7tAPQrXozAku0CamZmZGSO7QJqZmZkZHbtAw/UoXA8Zu0DNzMzMzB27QK5H4XoUH7tAFK5H4boku0AAAAAAwB+7QDMzMzMzJLtA7FG4HoUgu0AUrkfhOiW7QHsUrkehJbtAexSuR+Eju0AzMzMzsyS7QGZmZmamIrtAZmZmZmYpu0B7FK5H4Sm7QFK4HoVrLbtAmpmZmZkuu0BxPQrXIy27QMP1KFyPLLtAhetRuN4tu0ApXI/CdSi7QPYoXI9CJ7tA4XoUrsclu0ApXI/CNSe7QOF6FK6HJLtAmpmZmZkku0B7FK5HISS7QArXo3D9IrtAMzMzM3Mfu0B7FK5HoRy7QMP1KFzPIrtAUrgehashu0CF61G4Hia7QOF6FK7HI7tA",
+          "dtype": "f8"
+         },
+         "showlegend": false,
+         "type": "candlestick",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00-05:00",
+          "2026-02-11T09:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "IGbjjTQiu0BOgYogcCi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:35:00-05:00",
+          "2026-02-11T09:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ToGKIHAou0CjkyNgky+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:40:00-05:00",
+          "2026-02-11T09:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "o5MjYJMvu0B6bu7rqTa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:45:00-05:00",
+          "2026-02-11T09:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "em7u66k2u0AKfzWKATy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:50:00-05:00",
+          "2026-02-11T09:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Cn81igE8u0D6zuJo4D67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:55:00-05:00",
+          "2026-02-11T10:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+s7iaOA+u0ADVmOmVT+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:00:00-05:00",
+          "2026-02-11T10:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A1ZjplU/u0DKY96MHT27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:05:00-05:00",
+          "2026-02-11T10:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ymPejB09u0CdtggiGji7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:10:00-05:00",
+          "2026-02-11T10:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "nbYIIho4u0AQdq2SWTC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:15:00-05:00",
+          "2026-02-11T10:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "EHatklkwu0C4ztIo1yW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:20:00-05:00",
+          "2026-02-11T10:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "uM7SKNclu0BTGfr/2hq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:25:00-05:00",
+          "2026-02-11T10:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Uxn6/9oau0DGcJu3vBG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:30:00-05:00",
+          "2026-02-11T10:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "xnCbt7wRu0DOzzMEogu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:35:00-05:00",
+          "2026-02-11T10:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zs8zBKILu0ArePhgUAi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:40:00-05:00",
+          "2026-02-11T10:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "K3j4YFAIu0Arznf+Twa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:45:00-05:00",
+          "2026-02-11T10:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "K853/k8Gu0DunVPNXQe7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:50:00-05:00",
+          "2026-02-11T10:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "7p1TzV0Hu0D4LvF7Ywq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:55:00-05:00",
+          "2026-02-11T11:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+C7xe2MKu0A14nsaKA67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:00:00-05:00",
+          "2026-02-11T11:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NeJ7GigOu0CzA8uV3hG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:05:00-05:00",
+          "2026-02-11T11:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "swPLld4Ru0CGfUiiYha7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:10:00-05:00",
+          "2026-02-11T11:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "hn1IomIWu0BeBNnm/hq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:15:00-05:00",
+          "2026-02-11T11:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "XgTZ5v4au0AGNd6dyB+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:20:00-05:00",
+          "2026-02-11T11:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "BjXencgfu0AlCyyPqCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:25:00-05:00",
+          "2026-02-11T11:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "JQssj6giu0Dg7XNERSS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:30:00-05:00",
+          "2026-02-11T11:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "4O1zREUku0AdMSJ7WyW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:35:00-05:00",
+          "2026-02-11T11:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "HTEie1slu0Ddm2A0Oya7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:40:00-05:00",
+          "2026-02-11T11:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "3ZtgNDsmu0DWrwuHySa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:45:00-05:00",
+          "2026-02-11T11:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "1q8Lh8kmu0Aer2x+Cye7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:50:00-05:00",
+          "2026-02-11T11:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Hq9sfgsnu0Ba4ECMOia7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:55:00-05:00",
+          "2026-02-11T12:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "WuBAjDomu0A7LWiAGSS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:00:00-05:00",
+          "2026-02-11T12:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Oy1ogBkku0Bzu/9gMCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:05:00-05:00",
+          "2026-02-11T12:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "c7v/YDAiu0ClbvlHtyC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:10:00-05:00",
+          "2026-02-11T12:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "pW75R7cgu0B9yBMtHiC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:15:00-05:00",
+          "2026-02-11T12:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "fcgTLR4gu0ALd1zboCC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:20:00-05:00",
+          "2026-02-11T12:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "C3dc26Agu0CCZaAKISK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:25:00-05:00",
+          "2026-02-11T12:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gmWgCiEiu0Ad+7CL5SO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:30:00-05:00",
+          "2026-02-11T12:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Hfuwi+Uju0DmRPpfsCW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:35:00-05:00",
+          "2026-02-11T12:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "5kT6X7Alu0DWFMT/2ye7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:40:00-05:00",
+          "2026-02-11T12:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "1hTE/9snu0BqW5kYOSq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:45:00-05:00",
+          "2026-02-11T12:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "aluZGDkqu0DQtqOhTyy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:50:00-05:00",
+          "2026-02-11T12:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "0LajoU8su0Azl+ZVBS27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:55:00-05:00",
+          "2026-02-11T13:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "M5fmVQUtu0DQerpQeCy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:00:00-05:00",
+          "2026-02-11T13:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "0Hq6UHgsu0Dq1/Yzaiq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:05:00-05:00",
+          "2026-02-11T13:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "6tf2M2oqu0DtQ70bHCe7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:10:00-05:00",
+          "2026-02-11T13:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "7UO9Gxwnu0Au3Mmi1yO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:15:00-05:00",
+          "2026-02-11T13:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "LtzJotcju0AOrepVFiG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:20:00-05:00",
+          "2026-02-11T13:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Dq3qVRYhu0CNnl3Olx+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:25:00-05:00",
+          "2026-02-11T13:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "jZ5dzpcfu0DI8Ld4iR67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:30:00-05:00",
+          "2026-02-11T13:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "yPC3eIkeu0C4gsYJQR67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:35:00-05:00",
+          "2026-02-11T13:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "uILGCUEeu0CApWZZKx67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:40:00-05:00",
+          "2026-02-11T13:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gKVmWSseu0CmnMoKxh67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:45:00-05:00",
+          "2026-02-11T13:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ppzKCsYeu0AlkqkQ/R+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:50:00-05:00",
+          "2026-02-11T13:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "JZKpEP0fu0BWIJXWUSG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:55:00-05:00",
+          "2026-02-11T14:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ViCV1lEhu0A+FgDprCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:00:00-05:00",
+          "2026-02-11T14:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "PhYA6awiu0ATc0fviSO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:05:00-05:00",
+          "2026-02-11T14:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "E3NH74kju0CQK+JAsCS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:10:00-05:00",
+          "2026-02-11T14:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kCviQLAku0A1IiZyCCa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:15:00-05:00",
+          "2026-02-11T14:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NSImcggmu0BKHLP00ie7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:20:00-05:00",
+          "2026-02-11T14:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Shyz9NInu0CIWbHb4ym7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:25:00-05:00",
+          "2026-02-11T14:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "iFmx2+Mpu0ByDJruuyu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:30:00-05:00",
+          "2026-02-11T14:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "cgya7rsru0DIOSVyJi27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:35:00-05:00",
+          "2026-02-11T14:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "yDklciYtu0ADSC8hQy67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:40:00-05:00",
+          "2026-02-11T14:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A0gvIUMuu0DmVrf9hy67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:45:00-05:00",
+          "2026-02-11T14:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "5la3/Ycuu0ADXTZrEC67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:50:00-05:00",
+          "2026-02-11T14:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A102axAuu0D7xu5W+yy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:55:00-05:00",
+          "2026-02-11T15:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+8buVvssu0DOVuoHoCu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:00:00-05:00",
+          "2026-02-11T15:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zlbqB6Aru0A9gm8vACq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:05:00-05:00",
+          "2026-02-11T15:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "PYJvLwAqu0CA2BuYSCi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:10:00-05:00",
+          "2026-02-11T15:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gNgbmEgou0A1DViqpCa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:15:00-05:00",
+          "2026-02-11T15:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NQ1YqqQmu0CSplScDSW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:20:00-05:00",
+          "2026-02-11T15:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kqZUnA0lu0DwhIroUSO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:25:00-05:00",
+          "2026-02-11T15:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "8ISK6FEju0DAekWQVCG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:30:00-05:00",
+          "2026-02-11T15:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "wHpFkFQhu0CQntBmACC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:35:00-05:00",
+          "2026-02-11T15:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kJ7QZgAgu0A13zFuMh+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:40:00-05:00",
+          "2026-02-11T15:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Nd8xbjIfu0DNXJvrWh+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:45:00-05:00",
+          "2026-02-11T15:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zVyb61ofu0BzmMP96h+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:50:00-05:00",
+          "2026-02-11T15:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "c5jD/eofu0CVJgDtvB+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 1
+         },
+         "mode": "lines",
+         "name": "MACD (Value)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "ADjc5X8gCkAASI3H4lkUQACodKiqchpAAKh2NN9mH0AA6BK7F4cgQABs9S5Nsx5AAAB64E4qG0AACI7DdEEVQABopADWAwpAAKAaETxF6D8AKMJuj/4AwAAEujKivxDAALgFyRf8E8AAcJNugksUwACIJ/jtaxTAAGDxAlWhFsAAzLV7h8oRwABgq3pgtAzAAKDw4XRLCsAAAHsTFvoJwADYnlRZ4QDAAEAEUBWY878AALRUsvi6vwCAIUkVa9i/AAAZr1b8y78AgDdkLUTLPwAgciFL/eg/AEA8c73A7T8AsMW3MoHxPwCgi3C6UeU/AACAg5EJsL8AAJhrJWmEvwAAJEBxcKc/AIC0jo9lzz8AQNAMvhzqPwAA+AE2qvk/AAAe5SuG/z8AkBY6D98BQAB47JqljAZAANCNmWQ7CkAA+JrYSU4LQABQufdA0AZAAJAIjX9bAkAA4O7q5af1PwCAujfxqdE/AACrcxE+yb8AwAKR1yjdvwCAE1WF9ci/AEBDnTdj2L8AADjiAVzGvwDAIhtBadS/AACJ2maQsr8AgJrXrq7GPwAAV0z9Nc4/AMA8+qxa1T8AgE+qJ2PPPwBgtD/75eY/AGDcK4v08T8A4Jmsrh/7PwDwwF3b0AFAACA6F74LBEAAYPqdxzEFQABwuGNWsAZAAIBI40kpBEAASAivPBoBQACg2hX7afs/ACB2pNVZ9z8AsP/ppbLwPwCg5qIINeY/AIBSeBN12T8AAKILdtikPwBAi3vASuC/AHBNexGS8r8AoC2h0BXzvwAQ/zmgYfS/AEDlGbuc7r8AwL6yw/PrvwBQdRxGUfe/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "#F8E9A6",
+          "width": 1
+         },
+         "mode": "lines",
+         "name": "Signal (avg)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "AGDjt8zm5D+a+cuCOqT4Pz7aGd6ObwRAMlh3k8voDEBIs51SwSwSQKA+r34QrhRAgZik+Bz6FUA0FaCHLtUVQJFOXTlUERRADbZRrjGpEEBIG4/NMkIHQKZbg1Oc0Pc/XBckQ1CDyD8gSH6jwJHrv6eJuNRxXfu/dl2qvIL/A8AsaTeVax0HwCQ06I+cOwjAUOPpOS6lCMCngqCYXOkIwO3GOb4oTgfAi6UuIImaBMA9cUZqyKYAwMkuf7oB3fu/CF/GjIP99r8HHOoa6LXxv6VZ+b3KVue/PNx2m/hw2b/08zZyrGW5v96sM34Nlqs/lhS5YNROnz94EDhcWQGXPy4NCP2nx5s/cM9JBVsdsj/HH8RyvCLMPx1zrmJDyd8/P2HrT/lS6T+AYJqdNkfxP2ewcyKh1/Y/hhNiv0LE/D+cbHkRw/cAQONmuXIPIwJAtgiWEVkuAkDFgyk/3rUAQG+M2Kevnvs/wPbISf929T8zEY7ngm3vP/bgY9vu5Oc/+JMvhjmt4D/B7KzZW3LYP2iU07dF884/IV1osGDnxj8aZHLrCdzGP+IcoMttVMg/HJfL02kBzD99kn/Lj67MP/9grjfRodQ/ADSiT7De3j/N1ORkjDLnPx+1qBrDZ/A/5tA3uIEk9T/sM/c4UWT5P1ZW3LuWY/0/eKsz8WKT/z9kuXyDAA0AQG4VwNb/Kf8/WeRKZveZ/T9IQKKATQX7P6B2MndY1vc/534s8rpX9D/sm5x+iWfwP63sEeUb/eY/FiFFcuvs1T8kOmNteC2iPyxBhOCB+cy/Rc3D/bHV178E8eh4qT/ev5yzJaIsbeW/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": [
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#FE0000"
+          ]
+         },
+         "name": "Histogram (diff)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "AGDjt8zmBEAzk7RNqGEMQOG6ZznjOhBA5/u6annyEEBwORBH3MINQMBajGB5CgRA/J1Vn8fA9D+ApkGCOHfCv0RqLOSkPfy/GsRcWBRBC8CkoSgeYSAUwOramkfJsxbAu9geSzLAFMD8piNaStkQwCzL8gUjKQvAimI4SSdDCcCoXWjERu/4v3CvDKsP4+G/AMtrgGpkyr+Q1aetlwvBv7S7a6Y9s+k/FgtZ8Pyc9T96okGvBZ7/P8nONmg8wvU/CD/jtvh98z8HDHHHbR71P9K8te8KKvg/D9d74Jw89T8/H+l+jRfzPzJlqJhZmOM/JkWum0bdt788CAIJ9pqgv9LyP4M6GZM/SJgPDOJWxj8OOB/wDhTjPzljTCnlt/E/YE8oPa/c8j+Av5LW53byP5k/ZROqQfY/eoy5c4ay9z/IFkOODa30P3Sk/xPGtOI/AKVDuT2Tlj8UT8gmrYfnv2/s6VkzNPe/wFY+eMGe+L+auAdY9wD3v/bAqDBQIu6/+DPRVNXe7L9gdmRlLtDhvxpFhvtx8eG/kG7WDsoX0L8ADfLria1Wv3iM2wI+hqc/yNFbQeBnvT8YbH/2vqSVPwFfukclKtk/AKbnL7555D8z60700AzvP+Eq2aDzOfM/Gm88dvry8j8UjP0CPv/wP1QTKRcs+u8/EKm6qmF+4T/A6bi4wtPAP3CrKwcmAM6/ZBFTB4cA2b+QIEUtT6Xkv0BNfkuod+m/zr0vKOz067/YF3+ci4Hvv1aWTjDuo/O/RrjeV0wN+L/RuZhkPKfzv9qH7v1vwvC/XlkDG+Kx4r/8jpTs3afZv2TsxJZfNem/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T10:05:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T10:50:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T11:10:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T11:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:00:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:10:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:20:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:00:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:05:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:45:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T14:50:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T14:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T15:45:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         }
+        ],
+        "height": 800,
+        "margin": {
+         "b": 10,
+         "l": 30,
+         "r": 5,
+         "t": 50
+        },
+        "paper_bgcolor": "rgb(25,25,25)",
+        "plot_bgcolor": "rgb(25,25,25)",
+        "shapes": [
+         {
+          "line": {
+           "color": "gray",
+           "dash": "dot",
+           "width": 1
+          },
+          "type": "line",
+          "x0": "2026-02-11T09:00:00-05:00",
+          "x1": "2026-02-11T16:15:00-05:00",
+          "xref": "x2",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:05:00-05:00",
+          "x1": "2026-02-11T10:05:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:05:00-05:00",
+          "x1": "2026-02-11T10:05:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:50:00-05:00",
+          "x1": "2026-02-11T10:50:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:50:00-05:00",
+          "x1": "2026-02-11T10:50:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:10:00-05:00",
+          "x1": "2026-02-11T11:10:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:10:00-05:00",
+          "x1": "2026-02-11T11:10:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:55:00-05:00",
+          "x1": "2026-02-11T11:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:55:00-05:00",
+          "x1": "2026-02-11T11:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:00:00-05:00",
+          "x1": "2026-02-11T12:00:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:00:00-05:00",
+          "x1": "2026-02-11T12:00:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:10:00-05:00",
+          "x1": "2026-02-11T12:10:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:10:00-05:00",
+          "x1": "2026-02-11T12:10:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:20:00-05:00",
+          "x1": "2026-02-11T12:20:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:20:00-05:00",
+          "x1": "2026-02-11T12:20:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:00:00-05:00",
+          "x1": "2026-02-11T13:00:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:00:00-05:00",
+          "x1": "2026-02-11T13:00:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:05:00-05:00",
+          "x1": "2026-02-11T13:05:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:05:00-05:00",
+          "x1": "2026-02-11T13:05:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:45:00-05:00",
+          "x1": "2026-02-11T13:45:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:45:00-05:00",
+          "x1": "2026-02-11T13:45:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:55:00-05:00",
+          "x1": "2026-02-11T13:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:55:00-05:00",
+          "x1": "2026-02-11T13:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:50:00-05:00",
+          "x1": "2026-02-11T14:50:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:50:00-05:00",
+          "x1": "2026-02-11T14:50:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:55:00-05:00",
+          "x1": "2026-02-11T14:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:55:00-05:00",
+          "x1": "2026-02-11T14:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T15:45:00-05:00",
+          "x1": "2026-02-11T15:45:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T15:45:00-05:00",
+          "x1": "2026-02-11T15:45:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         }
+        ],
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#f2f5fa"
+            },
+            "error_y": {
+             "color": "#f2f5fa"
+            },
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "baxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#506784"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#2a3f5f"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#f2f5fa",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#f2f5fa"
+          },
+          "geo": {
+           "bgcolor": "rgb(17,17,17)",
+           "lakecolor": "rgb(17,17,17)",
+           "landcolor": "rgb(17,17,17)",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#506784"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "dark"
+          },
+          "paper_bgcolor": "rgb(17,17,17)",
+          "plot_bgcolor": "rgb(17,17,17)",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "radialaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "yaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "zaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#f2f5fa"
+           }
+          },
+          "sliderdefaults": {
+           "bgcolor": "#C8D4E3",
+           "bordercolor": "rgb(17,17,17)",
+           "borderwidth": 1,
+           "tickwidth": 0
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "caxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "updatemenudefaults": {
+           "bgcolor": "#506784",
+           "borderwidth": 0
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "xaxis": {
+         "anchor": "y",
+         "automargin": true,
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": 1800000,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "matches": "x2",
+         "range": [
+          "2026-02-11T09:00:00-05:00",
+          "2026-02-11T16:15:00-05:00"
+         ],
+         "rangeslider": {
+          "visible": false
+         },
+         "showticklabels": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "automargin": true,
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": 1800000,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "range": [
+          "2026-02-11T09:00:00-05:00",
+          "2026-02-11T16:15:00-05:00"
+         ],
+         "title": {
+          "text": "Time"
+         },
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "automargin": true,
+         "domain": [
+          0.3533333333333333,
+          0.9999999999999999
+         ],
+         "dtick": 10,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "minor": {
+          "dtick": 5,
+          "showgrid": false,
+          "tickcolor": "rgba(150,150,150,0.5)",
+          "ticklen": 2,
+          "tickmode": "linear",
+          "ticks": "outside",
+          "tickwidth": 1
+         },
+         "range": [
+          6907.8945,
+          7001.630999999999
+         ],
+         "showgrid": true,
+         "showticklabels": true,
+         "tickfont": {
+          "size": 11
+         },
+         "ticklabelposition": "outside",
+         "ticklen": 4,
+         "ticks": "outside",
+         "ticksuffix": " ",
+         "tickwidth": 1,
+         "title": {
+          "text": "Price"
+         },
+         "zeroline": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "automargin": true,
+         "domain": [
+          0,
+          0.3233333333333333
+         ],
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "range": [
+          -6.810687010375909,
+          9.916623511571379
+         ],
+         "showgrid": true,
+         "showticklabels": true,
+         "side": "left",
+         "tickfont": {
+          "size": 11
+         },
+         "ticklabelposition": "outside",
+         "ticklen": 4,
+         "ticks": "outside",
+         "ticksuffix": " ",
+         "tickwidth": 1,
+         "title": {
+          "text": "MACD"
+         },
+         "zeroline": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "historic_signals = streamer.download_signals(\n",
     "    symbol=candle_symbol, start=start, stop=stop\n",

--- a/src/devtools/playground_signals.ipynb
+++ b/src/devtools/playground_signals.ipynb
@@ -1,0 +1,4301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-header",
+   "metadata": {},
+   "source": [
+    "# TT-41: Hull+MACD Confluence Signal Detection\n",
+    "\n",
+    "This notebook demonstrates the `HullMacdEngine` signal detection engine.\n",
+    "\n",
+    "1. Connect to InfluxDB and load SPX 5m candle data\n",
+    "2. Get prior day's close for indicator seeding\n",
+    "3. Feed candles through the engine and collect signals\n",
+    "4. Display signal table\n",
+    "5. Overlay signals on Hull+MACD chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-nest-asyncio",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "import pandas as pd\n",
+    "import polars as pl\n",
+    "from datetime import datetime, timedelta, timezone\n",
+    "from zoneinfo import ZoneInfo\n",
+    "\n",
+    "import influxdb_client\n",
+    "\n",
+    "from tastytrade.common.logging import setup_logging\n",
+    "from tastytrade.connections import InfluxCredentials\n",
+    "from tastytrade.config import RedisConfigManager\n",
+    "from tastytrade.providers.market import MarketDataProvider\n",
+    "from tastytrade.providers.subscriptions import RedisSubscription\n",
+    "from tastytrade.messaging.models.events import CandleEvent\n",
+    "\n",
+    "from tastytrade.analytics.engines import HullMacdEngine, TradeSignal\n",
+    "from tastytrade.analytics.indicators.momentum import macd\n",
+    "from tastytrade.analytics.visualizations.plots import (\n",
+    "    plot_macd_with_hull,\n",
+    "    VerticalLine,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-setup",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-11 21:04:48 - INFO:root:62:Logging initialized - writing to ../logs/dev_signals_20260211.log\n"
+     ]
+    }
+   ],
+   "source": [
+    "pd.set_option(\"display.max_rows\", 100)\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.width\", None)\n",
+    "\n",
+    "logging.getLogger().handlers.clear()\n",
+    "setup_logging(\n",
+    "    level=logging.INFO,\n",
+    "    log_dir=\"../logs\",\n",
+    "    filename_prefix=\"dev_signals\",\n",
+    "    console=True,\n",
+    "    file=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-connections-header",
+   "metadata": {},
+   "source": [
+    "## Connect to Data Sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-connect",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-11 21:04:48 - INFO:tastytrade.config.manager:174:Initialized 52 variables from .env file in Redis\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.providers.subscriptions:72:Listening to Redis at redis://redis:6379/0\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = RedisConfigManager(env_file=\"/workspace/.env\")\n",
+    "config.initialize()\n",
+    "\n",
+    "influxdb = influxdb_client.InfluxDBClient(\n",
+    "    url=InfluxCredentials(config=config).url,\n",
+    "    token=InfluxCredentials(config=config).token,\n",
+    "    org=InfluxCredentials(config=config).org,\n",
+    ")\n",
+    "\n",
+    "subscription = RedisSubscription(config=RedisConfigManager())\n",
+    "await subscription.connect()\n",
+    "\n",
+    "streamer = MarketDataProvider(subscription, influxdb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-date-header",
+   "metadata": {},
+   "source": [
+    "## Date Setup & Prior Day Close"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-dates",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prior day close: 6941.81\n"
+     ]
+    }
+   ],
+   "source": [
+    "date = datetime.now(ZoneInfo(\"America/New_York\"))\n",
+    "\n",
+    "if date < datetime(date.year, date.month, date.day, 9, 30, tzinfo=date.tzinfo):\n",
+    "    date -= timedelta(days=1)\n",
+    "\n",
+    "while date.weekday() > 4:\n",
+    "    date -= timedelta(days=1)\n",
+    "\n",
+    "market_open = datetime(date.year, date.month, date.day, 9, 30, tzinfo=date.tzinfo)\n",
+    "market_close = datetime(date.year, date.month, date.day, 16, 0, tzinfo=date.tzinfo)\n",
+    "\n",
+    "start = market_open.astimezone(timezone.utc) - timedelta(minutes=30)\n",
+    "stop = market_close.astimezone(timezone.utc)\n",
+    "\n",
+    "candle_symbol = \"SPX{=5m}\"\n",
+    "\n",
+    "prior_date = market_open.date() - timedelta(days=1)\n",
+    "while prior_date.weekday() > 4:\n",
+    "    prior_date -= timedelta(days=1)\n",
+    "\n",
+    "prior_day: CandleEvent = streamer.get_daily_candle(candle_symbol, prior_date)\n",
+    "print(f\"Prior day close: {prior_day.close}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-download-header",
+   "metadata": {},
+   "source": [
+    "## Download 5m Candles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-download",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 78 candles\n"
+     ]
+    }
+   ],
+   "source": [
+    "candles_5m: pl.DataFrame = streamer.download(\n",
+    "    symbol=candle_symbol,\n",
+    "    start=start,\n",
+    "    stop=stop,\n",
+    "    debug_mode=True,\n",
+    ")\n",
+    "\n",
+    "candles_5m = candles_5m.filter(\n",
+    "    (pl.col(\"open\") != 0)\n",
+    "    & (pl.col(\"high\") != 0)\n",
+    "    & (pl.col(\"low\") != 0)\n",
+    "    & (pl.col(\"close\") != 0)\n",
+    ")\n",
+    "print(f\"Loaded {candles_5m.height} candles\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-engine-header",
+   "metadata": {},
+   "source": [
+    "## Feed Candles Through HullMacdEngine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-engine",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T15:05:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T15:50:00 (trigger=hull)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T16:10:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T16:55:00 (trigger=hull)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T17:00:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T17:10:00 (trigger=macd)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T17:20:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T18:00:00 (trigger=hull)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T18:05:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T18:45:00 (trigger=hull)\n",
+      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T18:55:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T19:50:00 (trigger=hull)\n",
+      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T19:55:00 (trigger=confluence)\n",
+      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T20:45:00 (trigger=hull)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signals detected: 14\n"
+     ]
+    }
+   ],
+   "source": [
+    "engine = HullMacdEngine()\n",
+    "engine.set_prior_close(candle_symbol, float(prior_day.close))\n",
+    "\n",
+    "for row in candles_5m.iter_rows(named=True):\n",
+    "    event = CandleEvent(**row)\n",
+    "    engine.on_candle_event(event)\n",
+    "\n",
+    "print(f\"Signals detected: {len(engine.signals)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-table-header",
+   "metadata": {},
+   "source": [
+    "## Signal Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-table",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>type</th>\n",
+       "      <th>direction</th>\n",
+       "      <th>trigger</th>\n",
+       "      <th>close_price</th>\n",
+       "      <th>hull_dir</th>\n",
+       "      <th>hull_value</th>\n",
+       "      <th>macd_value</th>\n",
+       "      <th>macd_signal</th>\n",
+       "      <th>macd_hist</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2026-02-11 15:05:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6948.23</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6973.12</td>\n",
+       "      <td>5.3139</td>\n",
+       "      <td>5.4582</td>\n",
+       "      <td>-0.1443</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2026-02-11 15:50:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6945.58</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6919.37</td>\n",
+       "      <td>-4.4478</td>\n",
+       "      <td>-2.8894</td>\n",
+       "      <td>-1.5584</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2026-02-11 16:10:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6949.13</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6934.39</td>\n",
+       "      <td>-2.1100</td>\n",
+       "      <td>-2.9132</td>\n",
+       "      <td>0.8031</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2026-02-11 16:55:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6941.15</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6950.23</td>\n",
+       "      <td>0.6662</td>\n",
+       "      <td>0.0539</td>\n",
+       "      <td>0.6123</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2026-02-11 17:00:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6936.31</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6948.10</td>\n",
+       "      <td>-0.0626</td>\n",
+       "      <td>0.0306</td>\n",
+       "      <td>-0.0932</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2026-02-11 17:10:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>macd</td>\n",
+       "      <td>6944.30</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6944.72</td>\n",
+       "      <td>0.0458</td>\n",
+       "      <td>0.0271</td>\n",
+       "      <td>0.0187</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2026-02-11 17:20:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6951.49</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6944.63</td>\n",
+       "      <td>0.8160</td>\n",
+       "      <td>0.2198</td>\n",
+       "      <td>0.5962</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2026-02-11 18:00:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6947.14</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6956.47</td>\n",
+       "      <td>2.2947</td>\n",
+       "      <td>2.2726</td>\n",
+       "      <td>0.0220</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2026-02-11 18:05:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6941.14</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6954.41</td>\n",
+       "      <td>1.3535</td>\n",
+       "      <td>2.0888</td>\n",
+       "      <td>-0.7353</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2026-02-11 18:45:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6948.92</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6942.77</td>\n",
+       "      <td>-0.0725</td>\n",
+       "      <td>0.1789</td>\n",
+       "      <td>-0.2515</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2026-02-11 18:55:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6947.93</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6945.32</td>\n",
+       "      <td>0.2360</td>\n",
+       "      <td>0.1901</td>\n",
+       "      <td>0.0459</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2026-02-11 19:50:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BULLISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6951.20</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6958.06</td>\n",
+       "      <td>2.1378</td>\n",
+       "      <td>2.0063</td>\n",
+       "      <td>0.1315</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2026-02-11 19:55:00</td>\n",
+       "      <td>OPEN</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>confluence</td>\n",
+       "      <td>6949.94</td>\n",
+       "      <td>Down</td>\n",
+       "      <td>6956.98</td>\n",
+       "      <td>1.7134</td>\n",
+       "      <td>1.9478</td>\n",
+       "      <td>-0.2344</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2026-02-11 20:45:00</td>\n",
+       "      <td>CLOSE</td>\n",
+       "      <td>BEARISH</td>\n",
+       "      <td>hull</td>\n",
+       "      <td>6950.15</td>\n",
+       "      <td>Up</td>\n",
+       "      <td>6943.36</td>\n",
+       "      <td>-0.9566</td>\n",
+       "      <td>-0.3724</td>\n",
+       "      <td>-0.5842</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  time   type direction     trigger  close_price hull_dir  \\\n",
+       "0  2026-02-11 15:05:00   OPEN   BEARISH  confluence      6948.23     Down   \n",
+       "1  2026-02-11 15:50:00  CLOSE   BEARISH        hull      6945.58       Up   \n",
+       "2  2026-02-11 16:10:00   OPEN   BULLISH  confluence      6949.13       Up   \n",
+       "3  2026-02-11 16:55:00  CLOSE   BULLISH        hull      6941.15     Down   \n",
+       "4  2026-02-11 17:00:00   OPEN   BEARISH  confluence      6936.31     Down   \n",
+       "5  2026-02-11 17:10:00  CLOSE   BEARISH        macd      6944.30     Down   \n",
+       "6  2026-02-11 17:20:00   OPEN   BULLISH  confluence      6951.49       Up   \n",
+       "7  2026-02-11 18:00:00  CLOSE   BULLISH        hull      6947.14     Down   \n",
+       "8  2026-02-11 18:05:00   OPEN   BEARISH  confluence      6941.14     Down   \n",
+       "9  2026-02-11 18:45:00  CLOSE   BEARISH        hull      6948.92       Up   \n",
+       "10 2026-02-11 18:55:00   OPEN   BULLISH  confluence      6947.93       Up   \n",
+       "11 2026-02-11 19:50:00  CLOSE   BULLISH        hull      6951.20     Down   \n",
+       "12 2026-02-11 19:55:00   OPEN   BEARISH  confluence      6949.94     Down   \n",
+       "13 2026-02-11 20:45:00  CLOSE   BEARISH        hull      6950.15       Up   \n",
+       "\n",
+       "    hull_value  macd_value  macd_signal  macd_hist  \n",
+       "0      6973.12      5.3139       5.4582    -0.1443  \n",
+       "1      6919.37     -4.4478      -2.8894    -1.5584  \n",
+       "2      6934.39     -2.1100      -2.9132     0.8031  \n",
+       "3      6950.23      0.6662       0.0539     0.6123  \n",
+       "4      6948.10     -0.0626       0.0306    -0.0932  \n",
+       "5      6944.72      0.0458       0.0271     0.0187  \n",
+       "6      6944.63      0.8160       0.2198     0.5962  \n",
+       "7      6956.47      2.2947       2.2726     0.0220  \n",
+       "8      6954.41      1.3535       2.0888    -0.7353  \n",
+       "9      6942.77     -0.0725       0.1789    -0.2515  \n",
+       "10     6945.32      0.2360       0.1901     0.0459  \n",
+       "11     6958.06      2.1378       2.0063     0.1315  \n",
+       "12     6956.98      1.7134       1.9478    -0.2344  \n",
+       "13     6943.36     -0.9566      -0.3724    -0.5842  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if engine.signals:\n",
+    "    signal_data = [\n",
+    "        {\n",
+    "            \"time\": s.start_time,\n",
+    "            \"type\": s.signal_type,\n",
+    "            \"direction\": s.direction,\n",
+    "            \"trigger\": s.trigger,\n",
+    "            \"close_price\": s.close_price,\n",
+    "            \"hull_dir\": s.hull_direction,\n",
+    "            \"hull_value\": round(s.hull_value, 2),\n",
+    "            \"macd_value\": round(s.macd_value, 4),\n",
+    "            \"macd_signal\": round(s.macd_signal, 4),\n",
+    "            \"macd_hist\": round(s.macd_histogram, 4),\n",
+    "        }\n",
+    "        for s in engine.signals\n",
+    "    ]\n",
+    "    df_signals = pd.DataFrame(signal_data)\n",
+    "    display(df_signals)\n",
+    "else:\n",
+    "    print(\"No signals detected for this session.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-chart-header",
+   "metadata": {},
+   "source": [
+    "## Chart with Signal Overlays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-chart",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "close": {
+          "bdata": "AAAAAMBGu0AUrkfh+j27QFK4HoXrP7tAUrgehWtBu0DD9Shcjzu7QM3MzMxMMbtAmpmZmRktu0AUrkfhOiS7QGZmZmamGbtAj8L1KBwPu0C4HoXrkQO7QB+F61G4BbtACtejcD0Pu0AAAAAAgBW7QHE9CtcjFbtAzczMzMwNu0CuR+F6lCG7QKRwPQrXH7tAXI/C9agau0AUrkfhuhe7QHsUrkchJbtA9ihcj8Iku0BSuB6F6ym7QDMzMzNzG7tAZmZmZiYgu0BI4XoU7iO7QKRwPQrXJrtACtejcD0ju0AfhetR+CO7QGZmZmYmHbtAw/UoXE8Yu0CF61G4HiC7QM3MzMxMILtA9ihcj0Iiu0AK16NwfSe7QHsUrkfhK7tAKVyPwvUou0AzMzMz8yi7QPYoXI8CLrtAPQrXo3Auu0C4HoXrESy7QDMzMzMzJLtAcT0K1yMju0BxPQrXIx27QLgehesRGbtA9ihcj8Idu0BxPQrXIx+7QHsUrkfhJLtAKVyPwvUfu0C4HoXrUSS7QClcj8J1ILtAUrgehesku0CF61G4niW7QEjhehTuI7tAj8L1KJwku0CkcD0KlyK7QHE9CtdjKbtAH4XrUfgpu0C4HoXrUS27QJqZmZmZLrtAPQrXozAtu0CPwvUonCy7QFK4HoXrLbtA4XoUrocou0AzMzMzMye7QD0K16PwJbtAUrgehSsnu0Bcj8L1qCS7QPYoXI+CJLtArkfhelQku0C4HoXr0SK7QD0K16NwH7tAmpmZmZkcu0BI4XoUbiK7QMP1KFyPIbtAZmZmZiYmu0A9Ctej8CO7QEjhehSuG7tA",
+          "dtype": "f8"
+         },
+         "decreasing": {
+          "fillcolor": "#EF5350",
+          "line": {
+           "color": "#EF5350"
+          }
+         },
+         "high": {
+          "bdata": "FK5H4XpRu0DsUbgexUe7QLgehetRQ7tAZmZmZuZIu0D2KFyPQkO7QI/C9SjcPrtAPQrXo3A3u0AzMzMz8y27QM3MzMzMI7tASOF6FC4bu0DXo3A9ShC7QHsUrkchDLtAmpmZmdkPu0DNzMzMzBW7QK5H4XqUGbtA9ihcjwIZu0AfhetR+CG7QEjhehSuIrtAj8L1KJwiu0C4HoXr0Ru7QJqZmZlZJbtAMzMzM/Mlu0CamZmZWSu7QOxRuB7FKrtAFK5H4foiu0BI4XoU7iO7QD0K16OwKbtA16NwPQopu0B7FK5HYSa7QJqZmZkZJLtAhetRuB4du0BxPQrXIyC7QFyPwvWoIrtAAAAAAMAmu0DhehSuxye7QMP1KFyPLrtAuB6F69Esu0AzMzMzsyq7QI/C9SjcLrtA7FG4HgUvu0DhehSuRzC7QPYoXI8CLLtASOF6FO4lu0DhehSuRyO7QJqZmZkZHbtA16NwPUohu0CkcD0KVyC7QNejcD2KJbtAmpmZmVkmu0BmZmZm5iS7QDMzMzMzJLtArkfhehQlu0Bcj8L1KCa7QHE9CtfjJrtAj8L1KJwku0CuR+F6lCW7QK5H4XqUKrtAuB6F61Eru0CamZmZ2S27QKRwPQoXMLtAmpmZmZkuu0CuR+F6VC+7QFK4HoXrLbtAH4XrUfgtu0AzMzMzcym7QGZmZmZmKLtAZmZmZuYnu0DXo3A9iie7QFK4HoXrJbtAKVyPwjUnu0BmZmZmJiS7QGZmZmbmI7tAmpmZmVkgu0AfhetReCK7QK5H4XrUJbtA16NwPUomu0CF61G4Hia7QOF6FK7HI7tA",
+          "dtype": "f8"
+         },
+         "increasing": {
+          "fillcolor": "rgba(19, 19, 19, 0.1)",
+          "line": {
+           "color": "#4CAF50"
+          }
+         },
+         "line": {
+          "width": 0.75
+         },
+         "low": {
+          "bdata": "FK5H4XpAu0D2KFyPwjy7QKRwPQpXPLtAUrgehes+u0BI4XoUrjm7QI/C9ShcL7tAXI/C9Sgru0DD9ShcTyO7QNejcD3KELtAj8L1KBwPu0AAAAAAQAK7QB+F61H4/7pA4XoUrscEu0CF61G4Hgu7QNejcD3KELtArkfhelQMu0BxPQrXIwu7QIXrUbieHrtAMzMzMzMZu0DD9ShcDxe7QFK4HoVrF7tACtejcH0gu0DsUbgehSS7QDMzMzNzG7tAhetRuJ4Yu0AfhetROBy7QOxRuB4FJLtAmpmZmdkhu0DsUbgeRSG7QBSuR+G6HLtAPQrXo7AWu0CuR+F6lBe7QB+F61H4HLtAFK5H4fodu0C4HoXrER+7QB+F61F4J7tAexSuR+Enu0A9Ctej8Ca7QEjhehTuKLtA9ihcj4Iqu0AzMzMzcyq7QIXrUbieIrtAAAAAAAAgu0BxPQrXIx27QM3MzMwMGLtAH4XrUfgWu0AfhetR+Bu7QD0K16OwHbtAKVyPwvUfu0DXo3A9Sh+7QJqZmZmZHrtAj8L1KFwgu0BSuB6Fqx27QM3MzMxMI7tAcT0K12Mhu0BSuB6F6x67QD0K16PwIbtAj8L1KBwpu0DhehSuxym7QI/C9SjcLLtACtejcP0pu0CPwvUonCy7QI/C9ShcK7tAw/UoXM8gu0AzMzMzsyW7QDMzMzPzJLtAMzMzM3Mku0CPwvUoHCS7QHsUrkfhI7tA4XoUrkcju0DsUbgeRSC7QI/C9ShcH7tA4XoUrscbu0DhehSuRxy7QIXrUbgeIbtAMzMzM3Mhu0Bcj8L16B67QEjhehSuG7tA",
+          "dtype": "f8"
+         },
+         "name": "Price",
+         "open": {
+          "bdata": "FK5H4XpAu0Bcj8L16Ea7QOxRuB4FPrtAexSuR6E/u0ApXI/CtUG7QArXo3D9O7tA9ihcj0Ixu0ApXI/CNS27QDMzMzOzI7tAH4XrUXgZu0BmZmZmZg+7QNejcD3KA7tACtejcH0Fu0Bcj8L1aA+7QEjhehRuFbtAXI/C9agUu0AAAAAAwA27QOF6FK6HIbtAPQrXozAgu0DXo3A9ihq7QB+F61G4F7tA9ihcjwIlu0AfhetRuCS7QB+F61H4KbtAhetRuF4bu0BSuB6FKyC7QOxRuB4FJLtAUrgehasmu0D2KFyPQiO7QDMzMzPzI7tAhetRuB4du0CamZmZGRi7QKRwPQoXILtA4XoUrkcgu0BI4XoUbiK7QB+F61F4J7tAFK5H4Tosu0AAAAAAACm7QEjhehTuKLtAXI/C9egtu0AUrkfh+i27QClcj8L1K7tAPQrXozAku0CamZmZGSO7QJqZmZkZHbtAw/UoXA8Zu0DNzMzMzB27QK5H4XoUH7tAFK5H4boku0AAAAAAwB+7QDMzMzMzJLtA7FG4HoUgu0AUrkfhOiW7QHsUrkehJbtAexSuR+Eju0AzMzMzsyS7QGZmZmamIrtAZmZmZmYpu0B7FK5H4Sm7QFK4HoVrLbtAmpmZmZkuu0BxPQrXIy27QMP1KFyPLLtAhetRuN4tu0ApXI/CdSi7QPYoXI9CJ7tA4XoUrsclu0ApXI/CNSe7QOF6FK6HJLtAmpmZmZkku0B7FK5HISS7QArXo3D9IrtAMzMzM3Mfu0B7FK5HoRy7QMP1KFzPIrtAUrgehashu0CF61G4Hia7QOF6FK7HI7tA",
+          "dtype": "f8"
+         },
+         "showlegend": false,
+         "type": "candlestick",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00-05:00",
+          "2026-02-11T09:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "IGbjjTQiu0BOgYogcCi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:35:00-05:00",
+          "2026-02-11T09:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ToGKIHAou0CjkyNgky+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:40:00-05:00",
+          "2026-02-11T09:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "o5MjYJMvu0B6bu7rqTa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:45:00-05:00",
+          "2026-02-11T09:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "em7u66k2u0AKfzWKATy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:50:00-05:00",
+          "2026-02-11T09:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Cn81igE8u0D6zuJo4D67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:55:00-05:00",
+          "2026-02-11T10:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+s7iaOA+u0ADVmOmVT+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:00:00-05:00",
+          "2026-02-11T10:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A1ZjplU/u0DKY96MHT27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:05:00-05:00",
+          "2026-02-11T10:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ymPejB09u0CdtggiGji7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:10:00-05:00",
+          "2026-02-11T10:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "nbYIIho4u0AQdq2SWTC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:15:00-05:00",
+          "2026-02-11T10:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "EHatklkwu0C4ztIo1yW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:20:00-05:00",
+          "2026-02-11T10:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "uM7SKNclu0BTGfr/2hq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:25:00-05:00",
+          "2026-02-11T10:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Uxn6/9oau0DGcJu3vBG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:30:00-05:00",
+          "2026-02-11T10:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "xnCbt7wRu0DOzzMEogu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:35:00-05:00",
+          "2026-02-11T10:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zs8zBKILu0ArePhgUAi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:40:00-05:00",
+          "2026-02-11T10:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "K3j4YFAIu0Arznf+Twa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:45:00-05:00",
+          "2026-02-11T10:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "K853/k8Gu0DunVPNXQe7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:50:00-05:00",
+          "2026-02-11T10:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "7p1TzV0Hu0D4LvF7Ywq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T10:55:00-05:00",
+          "2026-02-11T11:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+C7xe2MKu0A14nsaKA67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:00:00-05:00",
+          "2026-02-11T11:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NeJ7GigOu0CzA8uV3hG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:05:00-05:00",
+          "2026-02-11T11:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "swPLld4Ru0CGfUiiYha7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:10:00-05:00",
+          "2026-02-11T11:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "hn1IomIWu0BeBNnm/hq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:15:00-05:00",
+          "2026-02-11T11:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "XgTZ5v4au0AGNd6dyB+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:20:00-05:00",
+          "2026-02-11T11:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "BjXencgfu0AlCyyPqCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:25:00-05:00",
+          "2026-02-11T11:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "JQssj6giu0Dg7XNERSS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:30:00-05:00",
+          "2026-02-11T11:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "4O1zREUku0AdMSJ7WyW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:35:00-05:00",
+          "2026-02-11T11:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "HTEie1slu0Ddm2A0Oya7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:40:00-05:00",
+          "2026-02-11T11:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "3ZtgNDsmu0DWrwuHySa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:45:00-05:00",
+          "2026-02-11T11:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "1q8Lh8kmu0Aer2x+Cye7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:50:00-05:00",
+          "2026-02-11T11:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Hq9sfgsnu0Ba4ECMOia7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T11:55:00-05:00",
+          "2026-02-11T12:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "WuBAjDomu0A7LWiAGSS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:00:00-05:00",
+          "2026-02-11T12:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Oy1ogBkku0Bzu/9gMCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:05:00-05:00",
+          "2026-02-11T12:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "c7v/YDAiu0ClbvlHtyC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:10:00-05:00",
+          "2026-02-11T12:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "pW75R7cgu0B9yBMtHiC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:15:00-05:00",
+          "2026-02-11T12:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "fcgTLR4gu0ALd1zboCC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:20:00-05:00",
+          "2026-02-11T12:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "C3dc26Agu0CCZaAKISK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:25:00-05:00",
+          "2026-02-11T12:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gmWgCiEiu0Ad+7CL5SO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:30:00-05:00",
+          "2026-02-11T12:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Hfuwi+Uju0DmRPpfsCW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:35:00-05:00",
+          "2026-02-11T12:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "5kT6X7Alu0DWFMT/2ye7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:40:00-05:00",
+          "2026-02-11T12:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "1hTE/9snu0BqW5kYOSq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:45:00-05:00",
+          "2026-02-11T12:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "aluZGDkqu0DQtqOhTyy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:50:00-05:00",
+          "2026-02-11T12:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "0LajoU8su0Azl+ZVBS27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T12:55:00-05:00",
+          "2026-02-11T13:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "M5fmVQUtu0DQerpQeCy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:00:00-05:00",
+          "2026-02-11T13:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "0Hq6UHgsu0Dq1/Yzaiq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:05:00-05:00",
+          "2026-02-11T13:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "6tf2M2oqu0DtQ70bHCe7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:10:00-05:00",
+          "2026-02-11T13:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "7UO9Gxwnu0Au3Mmi1yO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:15:00-05:00",
+          "2026-02-11T13:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "LtzJotcju0AOrepVFiG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:20:00-05:00",
+          "2026-02-11T13:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Dq3qVRYhu0CNnl3Olx+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:25:00-05:00",
+          "2026-02-11T13:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "jZ5dzpcfu0DI8Ld4iR67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:30:00-05:00",
+          "2026-02-11T13:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "yPC3eIkeu0C4gsYJQR67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:35:00-05:00",
+          "2026-02-11T13:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "uILGCUEeu0CApWZZKx67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:40:00-05:00",
+          "2026-02-11T13:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gKVmWSseu0CmnMoKxh67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:45:00-05:00",
+          "2026-02-11T13:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ppzKCsYeu0AlkqkQ/R+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:50:00-05:00",
+          "2026-02-11T13:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "JZKpEP0fu0BWIJXWUSG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T13:55:00-05:00",
+          "2026-02-11T14:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "ViCV1lEhu0A+FgDprCK7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:00:00-05:00",
+          "2026-02-11T14:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "PhYA6awiu0ATc0fviSO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:05:00-05:00",
+          "2026-02-11T14:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "E3NH74kju0CQK+JAsCS7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:10:00-05:00",
+          "2026-02-11T14:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kCviQLAku0A1IiZyCCa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:15:00-05:00",
+          "2026-02-11T14:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NSImcggmu0BKHLP00ie7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:20:00-05:00",
+          "2026-02-11T14:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Shyz9NInu0CIWbHb4ym7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:25:00-05:00",
+          "2026-02-11T14:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "iFmx2+Mpu0ByDJruuyu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:30:00-05:00",
+          "2026-02-11T14:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "cgya7rsru0DIOSVyJi27QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:35:00-05:00",
+          "2026-02-11T14:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "yDklciYtu0ADSC8hQy67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:40:00-05:00",
+          "2026-02-11T14:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A0gvIUMuu0DmVrf9hy67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:45:00-05:00",
+          "2026-02-11T14:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "5la3/Ycuu0ADXTZrEC67QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:50:00-05:00",
+          "2026-02-11T14:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "A102axAuu0D7xu5W+yy7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T14:55:00-05:00",
+          "2026-02-11T15:00:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "+8buVvssu0DOVuoHoCu7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:00:00-05:00",
+          "2026-02-11T15:05:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zlbqB6Aru0A9gm8vACq7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:05:00-05:00",
+          "2026-02-11T15:10:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "PYJvLwAqu0CA2BuYSCi7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:10:00-05:00",
+          "2026-02-11T15:15:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "gNgbmEgou0A1DViqpCa7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:15:00-05:00",
+          "2026-02-11T15:20:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "NQ1YqqQmu0CSplScDSW7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:20:00-05:00",
+          "2026-02-11T15:25:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kqZUnA0lu0DwhIroUSO7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:25:00-05:00",
+          "2026-02-11T15:30:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "8ISK6FEju0DAekWQVCG7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:30:00-05:00",
+          "2026-02-11T15:35:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "wHpFkFQhu0CQntBmACC7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:35:00-05:00",
+          "2026-02-11T15:40:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "kJ7QZgAgu0A13zFuMh+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:40:00-05:00",
+          "2026-02-11T15:45:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "Nd8xbjIfu0DNXJvrWh+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:45:00-05:00",
+          "2026-02-11T15:50:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "zVyb61ofu0BzmMP96h+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#FF66FE",
+          "width": 0.6
+         },
+         "mode": "lines",
+         "name": "HMA",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T15:50:00-05:00",
+          "2026-02-11T15:55:00-05:00"
+         ],
+         "xaxis": "x",
+         "y": {
+          "bdata": "c5jD/eofu0CVJgDtvB+7QA==",
+          "dtype": "f8"
+         },
+         "yaxis": "y"
+        },
+        {
+         "line": {
+          "color": "#01FFFF",
+          "width": 1
+         },
+         "mode": "lines",
+         "name": "MACD (Value)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "ADjc5X8gCkAASI3H4lkUQACodKiqchpAAKh2NN9mH0AA6BK7F4cgQABs9S5Nsx5AAAB64E4qG0AACI7DdEEVQABopADWAwpAAKAaETxF6D8AKMJuj/4AwAAEujKivxDAALgFyRf8E8AAcJNugksUwACIJ/jtaxTAAGDxAlWhFsAAzLV7h8oRwABgq3pgtAzAAKDw4XRLCsAAAHsTFvoJwADYnlRZ4QDAAEAEUBWY878AALRUsvi6vwCAIUkVa9i/AAAZr1b8y78AgDdkLUTLPwAgciFL/eg/AEA8c73A7T8AsMW3MoHxPwCgi3C6UeU/AACAg5EJsL8AAJhrJWmEvwAAJEBxcKc/AIC0jo9lzz8AQNAMvhzqPwAA+AE2qvk/AAAe5SuG/z8AkBY6D98BQAB47JqljAZAANCNmWQ7CkAA+JrYSU4LQABQufdA0AZAAJAIjX9bAkAA4O7q5af1PwCAujfxqdE/AACrcxE+yb8AwAKR1yjdvwCAE1WF9ci/AEBDnTdj2L8AADjiAVzGvwDAIhtBadS/AACJ2maQsr8AgJrXrq7GPwAAV0z9Nc4/AMA8+qxa1T8AgE+qJ2PPPwBgtD/75eY/AGDcK4v08T8A4Jmsrh/7PwDwwF3b0AFAACA6F74LBEAAYPqdxzEFQABwuGNWsAZAAIBI40kpBEAASAivPBoBQACg2hX7afs/ACB2pNVZ9z8AsP/ppbLwPwCg5qIINeY/AIBSeBN12T8AAKILdtikPwBAi3vASuC/AHBNexGS8r8AoC2h0BXzvwAQ/zmgYfS/AEDlGbuc7r8AwL6yw/PrvwBQdRxGUfe/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        },
+        {
+         "line": {
+          "color": "#F8E9A6",
+          "width": 1
+         },
+         "mode": "lines",
+         "name": "Signal (avg)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "AGDjt8zm5D+a+cuCOqT4Pz7aGd6ObwRAMlh3k8voDEBIs51SwSwSQKA+r34QrhRAgZik+Bz6FUA0FaCHLtUVQJFOXTlUERRADbZRrjGpEEBIG4/NMkIHQKZbg1Oc0Pc/XBckQ1CDyD8gSH6jwJHrv6eJuNRxXfu/dl2qvIL/A8AsaTeVax0HwCQ06I+cOwjAUOPpOS6lCMCngqCYXOkIwO3GOb4oTgfAi6UuIImaBMA9cUZqyKYAwMkuf7oB3fu/CF/GjIP99r8HHOoa6LXxv6VZ+b3KVue/PNx2m/hw2b/08zZyrGW5v96sM34Nlqs/lhS5YNROnz94EDhcWQGXPy4NCP2nx5s/cM9JBVsdsj/HH8RyvCLMPx1zrmJDyd8/P2HrT/lS6T+AYJqdNkfxP2ewcyKh1/Y/hhNiv0LE/D+cbHkRw/cAQONmuXIPIwJAtgiWEVkuAkDFgyk/3rUAQG+M2Kevnvs/wPbISf929T8zEY7ngm3vP/bgY9vu5Oc/+JMvhjmt4D/B7KzZW3LYP2iU07dF884/IV1osGDnxj8aZHLrCdzGP+IcoMttVMg/HJfL02kBzD99kn/Lj67MP/9grjfRodQ/ADSiT7De3j/N1ORkjDLnPx+1qBrDZ/A/5tA3uIEk9T/sM/c4UWT5P1ZW3LuWY/0/eKsz8WKT/z9kuXyDAA0AQG4VwNb/Kf8/WeRKZveZ/T9IQKKATQX7P6B2MndY1vc/534s8rpX9D/sm5x+iWfwP63sEeUb/eY/FiFFcuvs1T8kOmNteC2iPyxBhOCB+cy/Rc3D/bHV178E8eh4qT/ev5yzJaIsbeW/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        },
+        {
+         "marker": {
+          "color": [
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#04FE00",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#006401",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#FE0000",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#7E0100",
+           "#FE0000"
+          ]
+         },
+         "name": "Histogram (diff)",
+         "showlegend": false,
+         "type": "bar",
+         "x": [
+          "2026-02-11T09:30:00.000000000",
+          "2026-02-11T09:35:00.000000000",
+          "2026-02-11T09:40:00.000000000",
+          "2026-02-11T09:45:00.000000000",
+          "2026-02-11T09:50:00.000000000",
+          "2026-02-11T09:55:00.000000000",
+          "2026-02-11T10:00:00.000000000",
+          "2026-02-11T10:05:00.000000000",
+          "2026-02-11T10:10:00.000000000",
+          "2026-02-11T10:15:00.000000000",
+          "2026-02-11T10:20:00.000000000",
+          "2026-02-11T10:25:00.000000000",
+          "2026-02-11T10:30:00.000000000",
+          "2026-02-11T10:35:00.000000000",
+          "2026-02-11T10:40:00.000000000",
+          "2026-02-11T10:45:00.000000000",
+          "2026-02-11T10:50:00.000000000",
+          "2026-02-11T10:55:00.000000000",
+          "2026-02-11T11:00:00.000000000",
+          "2026-02-11T11:05:00.000000000",
+          "2026-02-11T11:10:00.000000000",
+          "2026-02-11T11:15:00.000000000",
+          "2026-02-11T11:20:00.000000000",
+          "2026-02-11T11:25:00.000000000",
+          "2026-02-11T11:30:00.000000000",
+          "2026-02-11T11:35:00.000000000",
+          "2026-02-11T11:40:00.000000000",
+          "2026-02-11T11:45:00.000000000",
+          "2026-02-11T11:50:00.000000000",
+          "2026-02-11T11:55:00.000000000",
+          "2026-02-11T12:00:00.000000000",
+          "2026-02-11T12:05:00.000000000",
+          "2026-02-11T12:10:00.000000000",
+          "2026-02-11T12:15:00.000000000",
+          "2026-02-11T12:20:00.000000000",
+          "2026-02-11T12:25:00.000000000",
+          "2026-02-11T12:30:00.000000000",
+          "2026-02-11T12:35:00.000000000",
+          "2026-02-11T12:40:00.000000000",
+          "2026-02-11T12:45:00.000000000",
+          "2026-02-11T12:50:00.000000000",
+          "2026-02-11T12:55:00.000000000",
+          "2026-02-11T13:00:00.000000000",
+          "2026-02-11T13:05:00.000000000",
+          "2026-02-11T13:10:00.000000000",
+          "2026-02-11T13:15:00.000000000",
+          "2026-02-11T13:20:00.000000000",
+          "2026-02-11T13:25:00.000000000",
+          "2026-02-11T13:30:00.000000000",
+          "2026-02-11T13:35:00.000000000",
+          "2026-02-11T13:40:00.000000000",
+          "2026-02-11T13:45:00.000000000",
+          "2026-02-11T13:50:00.000000000",
+          "2026-02-11T13:55:00.000000000",
+          "2026-02-11T14:00:00.000000000",
+          "2026-02-11T14:05:00.000000000",
+          "2026-02-11T14:10:00.000000000",
+          "2026-02-11T14:15:00.000000000",
+          "2026-02-11T14:20:00.000000000",
+          "2026-02-11T14:25:00.000000000",
+          "2026-02-11T14:30:00.000000000",
+          "2026-02-11T14:35:00.000000000",
+          "2026-02-11T14:40:00.000000000",
+          "2026-02-11T14:45:00.000000000",
+          "2026-02-11T14:50:00.000000000",
+          "2026-02-11T14:55:00.000000000",
+          "2026-02-11T15:00:00.000000000",
+          "2026-02-11T15:05:00.000000000",
+          "2026-02-11T15:10:00.000000000",
+          "2026-02-11T15:15:00.000000000",
+          "2026-02-11T15:20:00.000000000",
+          "2026-02-11T15:25:00.000000000",
+          "2026-02-11T15:30:00.000000000",
+          "2026-02-11T15:35:00.000000000",
+          "2026-02-11T15:40:00.000000000",
+          "2026-02-11T15:45:00.000000000",
+          "2026-02-11T15:50:00.000000000",
+          "2026-02-11T15:55:00.000000000"
+         ],
+         "xaxis": "x2",
+         "y": {
+          "bdata": "AGDjt8zmBEAzk7RNqGEMQOG6ZznjOhBA5/u6annyEEBwORBH3MINQMBajGB5CgRA/J1Vn8fA9D+ApkGCOHfCv0RqLOSkPfy/GsRcWBRBC8CkoSgeYSAUwOramkfJsxbAu9geSzLAFMD8piNaStkQwCzL8gUjKQvAimI4SSdDCcCoXWjERu/4v3CvDKsP4+G/AMtrgGpkyr+Q1aetlwvBv7S7a6Y9s+k/FgtZ8Pyc9T96okGvBZ7/P8nONmg8wvU/CD/jtvh98z8HDHHHbR71P9K8te8KKvg/D9d74Jw89T8/H+l+jRfzPzJlqJhZmOM/JkWum0bdt788CAIJ9pqgv9LyP4M6GZM/SJgPDOJWxj8OOB/wDhTjPzljTCnlt/E/YE8oPa/c8j+Av5LW53byP5k/ZROqQfY/eoy5c4ay9z/IFkOODa30P3Sk/xPGtOI/AKVDuT2Tlj8UT8gmrYfnv2/s6VkzNPe/wFY+eMGe+L+auAdY9wD3v/bAqDBQIu6/+DPRVNXe7L9gdmRlLtDhvxpFhvtx8eG/kG7WDsoX0L8ADfLria1Wv3iM2wI+hqc/yNFbQeBnvT8YbH/2vqSVPwFfukclKtk/AKbnL7555D8z60700AzvP+Eq2aDzOfM/Gm88dvry8j8UjP0CPv/wP1QTKRcs+u8/EKm6qmF+4T/A6bi4wtPAP3CrKwcmAM6/ZBFTB4cA2b+QIEUtT6Xkv0BNfkuod+m/zr0vKOz067/YF3+ci4Hvv1aWTjDuo/O/RrjeV0wN+L/RuZhkPKfzv9qH7v1vwvC/XlkDG+Kx4r/8jpTs3afZv2TsxJZfNem/",
+          "dtype": "f8"
+         },
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T10:05:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T10:50:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T11:10:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T11:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:00:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:10:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T12:20:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:00:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:05:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:45:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T13:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#55A868",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#55A868",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BULLISH",
+          "textangle": 0,
+          "x": "2026-02-11T14:50:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "OPEN BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T14:55:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         },
+         {
+          "align": "center",
+          "bgcolor": "rgba(25,25,25,0.8)",
+          "bordercolor": "#8C8C8C",
+          "borderpad": 6,
+          "borderwidth": 1,
+          "font": {
+           "color": "#8C8C8C",
+           "family": "Arial, sans-serif",
+           "size": 11
+          },
+          "showarrow": false,
+          "text": "CLOSE BEARISH",
+          "textangle": 0,
+          "x": "2026-02-11T15:45:00-05:00",
+          "xanchor": "center",
+          "xref": "x",
+          "y": 7001.630999999999,
+          "yanchor": "bottom",
+          "yref": "y"
+         }
+        ],
+        "height": 800,
+        "margin": {
+         "b": 10,
+         "l": 30,
+         "r": 5,
+         "t": 50
+        },
+        "paper_bgcolor": "rgb(25,25,25)",
+        "plot_bgcolor": "rgb(25,25,25)",
+        "shapes": [
+         {
+          "line": {
+           "color": "gray",
+           "dash": "dot",
+           "width": 1
+          },
+          "type": "line",
+          "x0": "2026-02-11T09:00:00-05:00",
+          "x1": "2026-02-11T16:15:00-05:00",
+          "xref": "x2",
+          "y0": 0,
+          "y1": 0,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:05:00-05:00",
+          "x1": "2026-02-11T10:05:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:05:00-05:00",
+          "x1": "2026-02-11T10:05:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:50:00-05:00",
+          "x1": "2026-02-11T10:50:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T10:50:00-05:00",
+          "x1": "2026-02-11T10:50:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:10:00-05:00",
+          "x1": "2026-02-11T11:10:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:10:00-05:00",
+          "x1": "2026-02-11T11:10:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:55:00-05:00",
+          "x1": "2026-02-11T11:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T11:55:00-05:00",
+          "x1": "2026-02-11T11:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:00:00-05:00",
+          "x1": "2026-02-11T12:00:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:00:00-05:00",
+          "x1": "2026-02-11T12:00:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:10:00-05:00",
+          "x1": "2026-02-11T12:10:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:10:00-05:00",
+          "x1": "2026-02-11T12:10:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:20:00-05:00",
+          "x1": "2026-02-11T12:20:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T12:20:00-05:00",
+          "x1": "2026-02-11T12:20:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:00:00-05:00",
+          "x1": "2026-02-11T13:00:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:00:00-05:00",
+          "x1": "2026-02-11T13:00:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:05:00-05:00",
+          "x1": "2026-02-11T13:05:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:05:00-05:00",
+          "x1": "2026-02-11T13:05:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:45:00-05:00",
+          "x1": "2026-02-11T13:45:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:45:00-05:00",
+          "x1": "2026-02-11T13:45:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:55:00-05:00",
+          "x1": "2026-02-11T13:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T13:55:00-05:00",
+          "x1": "2026-02-11T13:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:50:00-05:00",
+          "x1": "2026-02-11T14:50:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#55A868",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:50:00-05:00",
+          "x1": "2026-02-11T14:50:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:55:00-05:00",
+          "x1": "2026-02-11T14:55:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T14:55:00-05:00",
+          "x1": "2026-02-11T14:55:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T15:45:00-05:00",
+          "x1": "2026-02-11T15:45:00-05:00",
+          "xref": "x",
+          "y0": 6907.8945,
+          "y1": 7001.630999999999,
+          "yref": "y"
+         },
+         {
+          "line": {
+           "color": "#8C8C8C",
+           "dash": "dot",
+           "width": 0.5
+          },
+          "opacity": 0.4,
+          "type": "line",
+          "x0": "2026-02-11T15:45:00-05:00",
+          "x1": "2026-02-11T15:45:00-05:00",
+          "xref": "x2",
+          "y0": -6.810687010375909,
+          "y1": 9.916623511571379,
+          "yref": "y2"
+         }
+        ],
+        "showlegend": true,
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#f2f5fa"
+            },
+            "error_y": {
+             "color": "#f2f5fa"
+            },
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "rgb(17,17,17)",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "baxis": {
+             "endlinecolor": "#A2B1C6",
+             "gridcolor": "#506784",
+             "linecolor": "#506784",
+             "minorgridcolor": "#506784",
+             "startlinecolor": "#A2B1C6"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "line": {
+              "color": "#283442"
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#506784"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#2a3f5f"
+             },
+             "line": {
+              "color": "rgb(17,17,17)"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#f2f5fa",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#f2f5fa"
+          },
+          "geo": {
+           "bgcolor": "rgb(17,17,17)",
+           "lakecolor": "rgb(17,17,17)",
+           "landcolor": "rgb(17,17,17)",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#506784"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "dark"
+          },
+          "paper_bgcolor": "rgb(17,17,17)",
+          "plot_bgcolor": "rgb(17,17,17)",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "radialaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "yaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           },
+           "zaxis": {
+            "backgroundcolor": "rgb(17,17,17)",
+            "gridcolor": "#506784",
+            "gridwidth": 2,
+            "linecolor": "#506784",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#C8D4E3"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#f2f5fa"
+           }
+          },
+          "sliderdefaults": {
+           "bgcolor": "#C8D4E3",
+           "bordercolor": "rgb(17,17,17)",
+           "borderwidth": 1,
+           "tickwidth": 0
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           },
+           "bgcolor": "rgb(17,17,17)",
+           "caxis": {
+            "gridcolor": "#506784",
+            "linecolor": "#506784",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "updatemenudefaults": {
+           "bgcolor": "#506784",
+           "borderwidth": 0
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#283442",
+           "linecolor": "#506784",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#283442",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "xaxis": {
+         "anchor": "y",
+         "automargin": true,
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": 1800000,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "matches": "x2",
+         "range": [
+          "2026-02-11T09:00:00-05:00",
+          "2026-02-11T16:15:00-05:00"
+         ],
+         "rangeslider": {
+          "visible": false
+         },
+         "showticklabels": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "automargin": true,
+         "domain": [
+          0,
+          1
+         ],
+         "dtick": 1800000,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "range": [
+          "2026-02-11T09:00:00-05:00",
+          "2026-02-11T16:15:00-05:00"
+         ],
+         "title": {
+          "text": "Time"
+         },
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "automargin": true,
+         "domain": [
+          0.3533333333333333,
+          0.9999999999999999
+         ],
+         "dtick": 10,
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "minor": {
+          "dtick": 5,
+          "showgrid": false,
+          "tickcolor": "rgba(150,150,150,0.5)",
+          "ticklen": 2,
+          "tickmode": "linear",
+          "ticks": "outside",
+          "tickwidth": 1
+         },
+         "range": [
+          6907.8945,
+          7001.630999999999
+         ],
+         "showgrid": true,
+         "showticklabels": true,
+         "tickfont": {
+          "size": 11
+         },
+         "ticklabelposition": "outside",
+         "ticklen": 4,
+         "ticks": "outside",
+         "ticksuffix": " ",
+         "tickwidth": 1,
+         "title": {
+          "text": "Price"
+         },
+         "zeroline": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "automargin": true,
+         "domain": [
+          0,
+          0.3233333333333333
+         ],
+         "gridcolor": "rgba(128,128,128,0.1)",
+         "range": [
+          -6.810687010375909,
+          9.916623511571379
+         ],
+         "showgrid": true,
+         "showticklabels": true,
+         "side": "left",
+         "tickfont": {
+          "size": 11
+         },
+         "ticklabelposition": "outside",
+         "ticklen": 4,
+         "ticks": "outside",
+         "ticksuffix": " ",
+         "tickwidth": 1,
+         "title": {
+          "text": "MACD"
+         },
+         "zeroline": false,
+         "zerolinecolor": "rgba(128,128,128,0.1)"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_macd_5m = macd(\n",
+    "    candles_5m,\n",
+    "    prior_close=prior_day.close,\n",
+    "    fast_length=12,\n",
+    "    slow_length=26,\n",
+    "    macd_length=9,\n",
+    ")\n",
+    "\n",
+    "signal_lines = [\n",
+    "    VerticalLine(\n",
+    "        start_time=s.start_time,\n",
+    "        color=\"#55A868\" if s.direction == \"BULLISH\" else \"#8C8C8C\",\n",
+    "        line_dash=\"dot\",\n",
+    "        line_width=0.5,\n",
+    "        label=f\"{s.signal_type} {s.direction}\",\n",
+    "        opacity=0.4,\n",
+    "    )\n",
+    "    for s in engine.signals\n",
+    "]\n",
+    "\n",
+    "plot_macd_with_hull(\n",
+    "    df_macd_5m,\n",
+    "    pad_value=prior_day.close,\n",
+    "    start_time=start,\n",
+    "    end_time=stop + timedelta(minutes=15),\n",
+    "    vertical_lines=signal_lines,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tastytrade (3.11.14)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/devtools/playground_signals.ipynb
+++ b/src/devtools/playground_signals.ipynb
@@ -69,7 +69,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-02-11 21:04:48 - INFO:root:62:Logging initialized - writing to ../logs/dev_signals_20260211.log\n"
+      "2026-02-12 01:56:22 - INFO:root:62:Logging initialized - writing to ../logs/dev_signals_20260212.log\n"
      ]
     }
    ],
@@ -106,8 +106,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-02-11 21:04:48 - INFO:tastytrade.config.manager:174:Initialized 52 variables from .env file in Redis\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.providers.subscriptions:72:Listening to Redis at redis://redis:6379/0\n"
+      "2026-02-12 01:56:24 - INFO:tastytrade.config.manager:174:Initialized 52 variables from .env file in Redis\n",
+      "2026-02-12 01:56:24 - INFO:tastytrade.providers.subscriptions:72:Listening to Redis at redis://redis:6379/0\n"
      ]
     }
    ],
@@ -231,20 +231,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T15:05:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T15:50:00 (trigger=hull)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T16:10:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T16:55:00 (trigger=hull)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T17:00:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T17:10:00 (trigger=macd)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T17:20:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T18:00:00 (trigger=hull)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T18:05:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:48 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T18:45:00 (trigger=hull)\n",
-      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T18:55:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T19:50:00 (trigger=hull)\n",
-      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T19:55:00 (trigger=confluence)\n",
-      "2026-02-11 21:04:49 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T20:45:00 (trigger=hull)\n"
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T15:05:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T15:50:00 (trigger=hull)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T16:10:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T16:55:00 (trigger=hull)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T17:00:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T17:10:00 (trigger=macd)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T17:20:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T18:00:00 (trigger=hull)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T18:05:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T18:45:00 (trigger=hull)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BULLISH SPX{=5m} at 2026-02-11T18:55:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BULLISH SPX{=5m} at 2026-02-11T19:50:00 (trigger=hull)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: OPEN BEARISH SPX{=5m} at 2026-02-11T19:55:00 (trigger=confluence)\n",
+      "2026-02-12 01:56:31 - INFO:tastytrade.analytics.engines.hull_macd:306:TradeSignal: CLOSE BEARISH SPX{=5m} at 2026-02-11T20:45:00 (trigger=hull)\n"
      ]
     },
     {
@@ -4278,17 +4278,51 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ga956ncq6w",
-   "source": "## Historic Signals from InfluxDB\n\nQuery persisted `TradeSignal` records from InfluxDB and overlay them on the chart\nusing `download_signals()` → `to_vertical_line()` conversion.",
+   "id": "476t1sg72p",
+   "source": "## Write Signals to InfluxDB\n\nPersist the engine-computed signals to InfluxDB using the same `Point` format\nas `TelegrafHTTPEventProcessor` (measurement = class name, tag = `eventSymbol`,\nfields = all `__dict__` items). This enables the read-back in the next section.",
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "id": "1s3xboifnn4",
-   "source": "historic_signals = streamer.download_signals(\n    symbol=candle_symbol, start=start, stop=stop\n)\nprint(f\"Retrieved {len(historic_signals)} signals from InfluxDB\")\n\nhistoric_lines = [s.to_vertical_line() for s in historic_signals]\n\nplot_macd_with_hull(\n    df_macd_5m,\n    pad_value=prior_day.close,\n    start_time=start,\n    end_time=stop + timedelta(minutes=15),\n    vertical_lines=historic_lines,\n)",
+   "id": "8mrrin4ku",
+   "source": "from tastytrade.messaging.processors.influxdb import TelegrafHTTPEventProcessor\n\nwriter = TelegrafHTTPEventProcessor()\n\nfor s in engine.signals:\n    writer.process_event(s)\n\nwriter.close()\nprint(f\"Wrote {len(engine.signals)} signals to InfluxDB via TelegrafHTTPEventProcessor\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ga956ncq6w",
+   "metadata": {},
+   "source": [
+    "## Historic Signals from InfluxDB\n",
+    "\n",
+    "Query persisted `TradeSignal` records from InfluxDB and overlay them on the chart\n",
+    "using `download_signals()` → `to_vertical_line()` conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1s3xboifnn4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "historic_signals = streamer.download_signals(\n",
+    "    symbol=candle_symbol, start=start, stop=stop\n",
+    ")\n",
+    "print(f\"Retrieved {len(historic_signals)} signals from InfluxDB\")\n",
+    "\n",
+    "historic_lines = [s.to_vertical_line() for s in historic_signals]\n",
+    "\n",
+    "plot_macd_with_hull(\n",
+    "    df_macd_5m,\n",
+    "    pad_value=prior_day.close,\n",
+    "    start_time=start,\n",
+    "    end_time=stop + timedelta(minutes=15),\n",
+    "    vertical_lines=historic_lines,\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/src/devtools/playground_signals.ipynb
+++ b/src/devtools/playground_signals.ipynb
@@ -4275,6 +4275,20 @@
     "    vertical_lines=signal_lines,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ga956ncq6w",
+   "source": "## Historic Signals from InfluxDB\n\nQuery persisted `TradeSignal` records from InfluxDB and overlay them on the chart\nusing `download_signals()` → `to_vertical_line()` conversion.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1s3xboifnn4",
+   "source": "historic_signals = streamer.download_signals(\n    symbol=candle_symbol, start=start, stop=stop\n)\nprint(f\"Retrieved {len(historic_signals)} signals from InfluxDB\")\n\nhistoric_lines = [s.to_vertical_line() for s in historic_signals]\n\nplot_macd_with_hull(\n    df_macd_5m,\n    pad_value=prior_day.close,\n    start_time=start,\n    end_time=stop + timedelta(minutes=15),\n    vertical_lines=historic_lines,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/src/tastytrade/analytics/engines/PLAN.md
+++ b/src/tastytrade/analytics/engines/PLAN.md
@@ -1,0 +1,171 @@
+# TT-41: SPX 0DTE Hull+MACD Confluence Signal Detection Engine
+
+## Context
+
+The `playground_charts.ipynb` notebook manually computes Hull MA and MACD indicators on SPX candle data for visual analysis. There is no automated way to detect when both indicators align (confluence) and generate actionable trade signals. TT-41 builds a protocol-based signal detection engine that monitors real-time 5-minute candle data, detects Hull MA direction change + MACD crossover confluences, emits `TradeSignal` events persisted to InfluxDB, and logs each signal to Grafana Cloud via the existing observability pipeline.
+
+This is the Phase 1 foundation for Epic TT-44 (Algorithmic Trading Signals). TT-42 (Signal Assessment) and TT-43 (Backtesting) both depend on this.
+
+## Architecture
+
+Follows the existing `MetricsEventProcessor -> MetricsTracker` pattern. All processors are registered on the Candle `EventHandler`, which broadcasts every `BaseEvent` to all processors:
+
+```
+CandleEvent (SPX{=5m}) arrives at EventHandler
+  -> EventHandler broadcasts to ALL registered processors:
+     -> CandleEventProcessor.process_event()        (stores candle data)
+     -> TelegrafHTTPEventProcessor.process_event()   (writes candle to InfluxDB)
+     -> SignalEventProcessor.process_event()          (routes to HullMacdEngine)
+           -> HullMacdEngine detects confluence
+           -> Creates TradeSignal (extends BaseAnnotation extends BaseEvent)
+           -> Emits TradeSignal back to EventHandler via emit callback
+           -> logger.info() with structured fields (stdout JSON + Grafana Cloud OTLP)
+
+TradeSignal re-enters EventHandler processor chain:
+     -> TelegrafHTTPEventProcessor.process_event()   (writes signal to InfluxDB)
+     -> CandleEventProcessor.process_event()          (ignores -- not a candle)
+     -> SignalEventProcessor.process_event()           (ignores -- not a CandleEvent)
+```
+
+**Key design**: TradeSignal extends `BaseAnnotation` which extends `BaseEvent`, so it flows naturally through the EventHandler's processor chain. The `SignalEventProcessor` accepts an `emit` callback (wired to the EventHandler) to submit generated signals back into the pipeline. This avoids hardcoded processor references -- any processor on the channel that can handle a `BaseEvent` subclass will pick it up.
+
+## Core Signal Logic
+
+### Position-aware state machine
+
+The engine tracks per-symbol position state: `FLAT`, `BULLISH`, or `BEARISH`. This prevents duplicate opens and enforces strict one-position-at-a-time per symbol. Directions map to spread types: BULLISH = bull put spread, BEARISH = bear call spread.
+
+**OPEN signals** (entry) require **confluence** -- both indicators must agree:
+- Hull MA direction change and MACD crossover typically fire on **different candles**
+- Once one indicator triggers, it stays "armed" indefinitely (no expiry window)
+- Either indicator can fire first -- the second completes the confluence
+- Only fires when position is FLAT
+
+**CLOSE signals** (exit) require only **one indicator** to flip:
+- Hull direction reversal OR MACD crossover in opposing direction
+- Only fires when position is BULLISH or BEARISH
+- After CLOSE -> position returns to FLAT (no immediate reverse)
+- Engine must wait for fresh confluence before next OPEN
+
+This asymmetry is intentional for 0DTE trading: strict confluence for entry (high confidence), single-indicator exit (fast capital protection).
+
+## Implementation Plan
+
+### Step 1: Create `src/tastytrade/analytics/engines/models.py`
+
+**SignalDirection** enum (`BULLISH`, `BEARISH`), **SignalType** enum (`OPEN`, `CLOSE`), and **TradeSignal** model extending `BaseAnnotation`. BULLISH maps to bull put spread, BEARISH to bear call spread.
+
+TradeSignal fields beyond BaseAnnotation:
+- `signal_type: str` -- "OPEN" or "CLOSE"
+- `direction: str` -- "BULLISH" or "BEARISH"
+- `engine: str` -- engine name ("hull_macd")
+- `hull_direction: str` -- "Up" or "Down"
+- `hull_value: float` -- HMA value at signal time
+- `macd_value: float` -- MACD line value
+- `macd_signal: float` -- MACD signal line value
+- `macd_histogram: float` -- MACD histogram value
+- `close_price: float` -- triggering candle's close
+- `trigger: str` -- which indicator triggered ("hull", "macd", or "confluence" for opens)
+- `event_type: str = "trade_signal"` -- InfluxDB measurement name
+
+Inherits from `BaseAnnotation` (`src/tastytrade/analytics/visualizations/models.py:90`) which provides `_ProcessorSafeDict` wrapping, `time` property with SHA-256 jitter, and all styling fields for chart rendering.
+
+### Step 2: Create `src/tastytrade/analytics/engines/protocol.py`
+
+**SignalEngine** protocol using `typing.Protocol` (structural subtyping):
+- `name: str` property
+- `signals: list[TradeSignal]` property
+- `on_signal` property (getter/setter for `Callable[[TradeSignal], None]`) -- callback invoked when a signal fires
+- `set_prior_close(event_symbol: str, price: float) -> None`
+- `on_candle_event(event: CandleEvent) -> None`
+
+### Step 3: Create `src/tastytrade/analytics/engines/__init__.py`
+
+Package exports: `HullMacdEngine`, `SignalDirection`, `TradeSignal`, `SignalEngine`.
+
+### Step 4: Create `src/tastytrade/analytics/engines/hull_macd.py`
+
+Core engine with three internal mechanisms:
+
+**a) DataFrame accumulation** -- Each CandleEvent is accumulated into a per-symbol `pl.DataFrame` using the same `vstack -> unique(keep="last") -> sort` pattern from `CandleEventProcessor` (`messaging/processors/default.py:80-86`). Capped at 500 candles.
+
+**b) Indicator computation** -- Recomputes `hull()` and `macd()` on accumulated DataFrame each candle.
+- `hull()` (`analytics/indicators/momentum.py:46`) returns `pd.DataFrame` with `HMA_color` ("Up"/"Down")
+- `macd()` (`analytics/indicators/momentum.py:116`) returns `pl.DataFrame` with `Value` and `avg` columns
+- MACD position: "bullish" when Value > avg, "bearish" otherwise
+
+**c) Position-aware state machine** -- Per-symbol `TimeframeState` dataclass tracks:
+- `hull_direction` / `macd_position` -- current indicator states
+- `hull_armed_direction` / `macd_armed_direction` -- armed signal directions after change
+- `position` -- current position: `FLAT`, `BULLISH`, or `BEARISH`
+
+State machine flow depends on current position:
+
+**When FLAT (looking for OPEN):**
+1. Detect Hull direction **change** -> arm `hull_armed_direction`
+2. Detect MACD position **change** -> arm `macd_armed_direction`
+3. Both armed in same direction -> emit OPEN signal, set `position` to BULLISH/BEARISH, clear armed states
+4. Both armed in opposing directions -> discard the older one
+
+**When BULLISH (looking for CLOSE):**
+5. Hull flips Down -> emit CLOSE signal, set `position` to FLAT, clear armed states
+6. MACD crosses bearish -> emit CLOSE signal, set `position` to FLAT, clear armed states
+
+**When BEARISH (looking for CLOSE):**
+7. Hull flips Up -> emit CLOSE signal, set `position` to FLAT, clear armed states
+8. MACD crosses bullish -> emit CLOSE signal, set `position` to FLAT, clear armed states
+
+After any CLOSE, the engine returns to FLAT and all armed states are cleared. Fresh confluence is required for the next OPEN.
+
+**d) Structured Grafana logging** -- On each signal, emit a structured `logger.info()` with all indicator snapshot fields as `extra` kwargs.
+
+### Step 5: Create `src/tastytrade/messaging/processors/signal.py`
+
+**SignalEventProcessor** -- thin adapter wrapping any `SignalEngine` for the `EventProcessor` protocol. Follows the `MetricsEventProcessor` pattern:
+- `name = "signal"`
+- `process_event()` -- routes `CandleEvent` to `engine.on_candle_event()`, ignores other event types
+- `close()` -- logs final signal count
+- Constructor accepts an `emit` callback wired to the EventHandler
+
+### Step 6: Modify `src/tastytrade/messaging/processors/__init__.py`
+
+Add `SignalEventProcessor` to imports and `__all__`.
+
+### Step 7: Create `unit_tests/analytics/test_hull_macd_engine.py` (~34 tests)
+
+Tests mock `hull()` and `macd()` via `@patch` to control indicator state deterministically.
+
+### Step 8: Create `unit_tests/analytics/test_signal_processor.py` (~4 tests)
+
+### Step 9: Quality gates
+
+Run `uv run pytest`, `uv run mypy .`, `uv run ruff check .` -- all must pass clean.
+
+### Step 10: Create `src/devtools/playground_signals.ipynb`
+
+Verification notebook demonstrating signals on real SPX data with chart overlay.
+
+## Files Summary
+
+| Action | File | Description |
+|--------|------|-------------|
+| Create | `src/tastytrade/analytics/engines/__init__.py` | Package exports |
+| Create | `src/tastytrade/analytics/engines/models.py` | SignalDirection + TradeSignal |
+| Create | `src/tastytrade/analytics/engines/protocol.py` | SignalEngine protocol |
+| Create | `src/tastytrade/analytics/engines/hull_macd.py` | HullMacdEngine (core) |
+| Create | `src/tastytrade/messaging/processors/signal.py` | SignalEventProcessor adapter |
+| Modify | `src/tastytrade/messaging/processors/__init__.py` | Add export |
+| Create | `unit_tests/analytics/test_hull_macd_engine.py` | ~34 engine tests |
+| Create | `unit_tests/analytics/test_signal_processor.py` | ~4 processor tests |
+| Create | `src/devtools/playground_signals.ipynb` | Verification notebook |
+
+## Key Dependencies (reuse existing)
+
+- `hull()` -- `src/tastytrade/analytics/indicators/momentum.py:46`
+- `macd()` -- `src/tastytrade/analytics/indicators/momentum.py:116`
+- `BaseAnnotation` -- `src/tastytrade/analytics/visualizations/models.py:90`
+- `CandleEvent` -- `src/tastytrade/messaging/models/events.py:149`
+- `EventProcessor` protocol -- `src/tastytrade/messaging/processors/default.py:16`
+- `TelegrafHTTPEventProcessor` -- `src/tastytrade/messaging/processors/influxdb.py:14`
+- `parse_candle_symbol()` -- `src/tastytrade/utils/helpers.py:38`
+- Observability pipeline -- `src/tastytrade/common/observability.py:44`

--- a/src/tastytrade/analytics/engines/__init__.py
+++ b/src/tastytrade/analytics/engines/__init__.py
@@ -1,0 +1,11 @@
+from .hull_macd import HullMacdEngine
+from .models import SignalDirection, SignalType, TradeSignal
+from .protocol import SignalEngine
+
+__all__ = [
+    "HullMacdEngine",
+    "SignalDirection",
+    "SignalEngine",
+    "SignalType",
+    "TradeSignal",
+]

--- a/src/tastytrade/analytics/engines/hull_macd.py
+++ b/src/tastytrade/analytics/engines/hull_macd.py
@@ -1,0 +1,345 @@
+"""Hull MA + MACD confluence signal detection engine.
+
+Monitors 5-minute candle data, detects Hull MA direction change + MACD
+crossover confluences, and emits TradeSignal events. Designed for SPX
+0DTE trading where strict confluence is required for entry (OPEN) but
+only a single indicator flip is needed for exit (CLOSE).
+
+Bullish and bearish positions are tracked independently — a bull put
+spread and bear call spread can be open simultaneously.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import time
+from typing import Callable
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from tastytrade.analytics.engines.models import (
+    SignalDirection,
+    SignalType,
+    TradeSignal,
+)
+from tastytrade.analytics.indicators.momentum import hull, macd
+from tastytrade.messaging.models.events import CandleEvent
+
+logger = logging.getLogger(__name__)
+
+CANDLE_CAP = 500
+ET = ZoneInfo("America/New_York")
+DEFAULT_EARLIEST_ENTRY = time(10, 0)
+DEFAULT_LATEST_ENTRY = time(15, 0)
+
+
+@dataclass
+class TimeframeState:
+    """Per-symbol state tracking for the position-aware state machine."""
+
+    hull_direction: str | None = None
+    macd_position: str | None = None
+    hull_armed_direction: str | None = None
+    macd_armed_direction: str | None = None
+    bullish_open: bool = False
+    bearish_open: bool = False
+    candles: pl.DataFrame = field(default_factory=pl.DataFrame)
+
+
+class HullMacdEngine:
+    """Hull MA + MACD confluence signal detection engine.
+
+    Accumulates candle data per symbol, computes Hull MA and MACD
+    indicators on each new candle, and uses a position-aware state
+    machine to detect confluence entry signals and single-indicator
+    exit signals.
+
+    Bullish and bearish positions are independent — both can be open
+    at the same time (bull put spread + bear call spread).
+    """
+
+    def __init__(
+        self,
+        earliest_entry: time = DEFAULT_EARLIEST_ENTRY,
+        latest_entry: time = DEFAULT_LATEST_ENTRY,
+    ) -> None:
+        self._signals: list[TradeSignal] = []
+        self._on_signal: Callable[[TradeSignal], None] | None = None
+        self._states: dict[str, TimeframeState] = {}
+        self._prior_closes: dict[str, float] = {}
+        self._earliest_entry = earliest_entry
+        self._latest_entry = latest_entry
+
+    @property
+    def name(self) -> str:
+        return "hull_macd"
+
+    @property
+    def signals(self) -> list[TradeSignal]:
+        return self._signals
+
+    @property
+    def on_signal(self) -> Callable[[TradeSignal], None] | None:
+        return self._on_signal
+
+    @on_signal.setter
+    def on_signal(self, callback: Callable[[TradeSignal], None] | None) -> None:
+        self._on_signal = callback
+
+    def set_prior_close(self, event_symbol: str, price: float) -> None:
+        self._prior_closes[event_symbol] = price
+
+    def on_candle_event(self, event: CandleEvent) -> None:
+        if event.close is None:
+            return
+
+        symbol = event.eventSymbol
+        state = self._get_or_create_state(symbol)
+
+        self._accumulate(state, event)
+
+        if state.candles.height < 2:
+            return
+
+        hull_dir = self._compute_hull(state, symbol)
+        macd_pos = self._compute_macd(state, symbol)
+
+        if hull_dir is None or macd_pos is None:
+            return
+
+        prev_hull = state.hull_direction
+        prev_macd = state.macd_position
+        state.hull_direction = hull_dir
+        state.macd_position = macd_pos
+
+        hull_changed = prev_hull is not None and hull_dir != prev_hull
+        macd_changed = prev_macd is not None and macd_pos != prev_macd
+
+        # Before earliest_entry: indicators warm up but no signals
+        candle_et = event.time.astimezone(ET).time()
+        if candle_et < self._earliest_entry:
+            return
+
+        # CLOSEs always fire — must be able to exit positions
+        self._handle_closes(
+            state, event, hull_changed, hull_dir, macd_changed, macd_pos
+        )
+
+        # No new OPENs during power hour
+        if candle_et >= self._latest_entry:
+            return
+
+        self._handle_opens(state, event, hull_changed, hull_dir, macd_changed, macd_pos)
+
+    def _get_or_create_state(self, symbol: str) -> TimeframeState:
+        if symbol not in self._states:
+            self._states[symbol] = TimeframeState()
+        return self._states[symbol]
+
+    def _accumulate(self, state: TimeframeState, event: CandleEvent) -> None:
+        row = pl.DataFrame([event])
+        if state.candles.height == 0:
+            state.candles = row
+        else:
+            state.candles = (
+                state.candles.vstack(row)
+                .unique(subset=["eventSymbol", "time"], keep="last")
+                .sort("time", descending=False)
+            )
+        if state.candles.height > CANDLE_CAP:
+            state.candles = state.candles.tail(CANDLE_CAP)
+
+    def _compute_hull(self, state: TimeframeState, symbol: str) -> str | None:
+        pad_value = self._prior_closes.get(symbol)
+        hull_df = hull(state.candles, pad_value=pad_value)
+        if hull_df.empty:
+            return None
+        return str(hull_df["HMA_color"].iloc[-1])
+
+    def _compute_macd(self, state: TimeframeState, symbol: str) -> str | None:
+        prior_close = self._prior_closes.get(symbol)
+        macd_df = macd(state.candles, prior_close=prior_close)
+        if macd_df.height == 0:
+            return None
+        last_row = macd_df.tail(1)
+        value = last_row["Value"][0]
+        avg = last_row["avg"][0]
+        return "bullish" if value > avg else "bearish"
+
+    def _handle_closes(
+        self,
+        state: TimeframeState,
+        event: CandleEvent,
+        hull_changed: bool,
+        hull_dir: str,
+        macd_changed: bool,
+        macd_pos: str,
+    ) -> None:
+        if state.bullish_open:
+            if hull_changed and hull_dir == "Down":
+                self._emit_signal(
+                    state,
+                    event,
+                    SignalType.CLOSE,
+                    SignalDirection.BULLISH.value,
+                    "hull",
+                )
+                state.bullish_open = False
+            elif macd_changed and macd_pos == "bearish":
+                self._emit_signal(
+                    state,
+                    event,
+                    SignalType.CLOSE,
+                    SignalDirection.BULLISH.value,
+                    "macd",
+                )
+                state.bullish_open = False
+
+        if state.bearish_open:
+            if hull_changed and hull_dir == "Up":
+                self._emit_signal(
+                    state,
+                    event,
+                    SignalType.CLOSE,
+                    SignalDirection.BEARISH.value,
+                    "hull",
+                )
+                state.bearish_open = False
+            elif macd_changed and macd_pos == "bullish":
+                self._emit_signal(
+                    state,
+                    event,
+                    SignalType.CLOSE,
+                    SignalDirection.BEARISH.value,
+                    "macd",
+                )
+                state.bearish_open = False
+
+    def _handle_opens(
+        self,
+        state: TimeframeState,
+        event: CandleEvent,
+        hull_changed: bool,
+        hull_dir: str,
+        macd_changed: bool,
+        macd_pos: str,
+    ) -> None:
+        hull_signal_dir = self._hull_to_signal_direction(hull_dir)
+        macd_signal_dir = self._macd_to_signal_direction(macd_pos)
+
+        if hull_changed:
+            state.hull_armed_direction = hull_signal_dir
+        if macd_changed:
+            state.macd_armed_direction = macd_signal_dir
+
+        if state.hull_armed_direction and state.macd_armed_direction:
+            if state.hull_armed_direction == state.macd_armed_direction:
+                direction = state.hull_armed_direction
+                already_open = (
+                    direction == SignalDirection.BULLISH.value and state.bullish_open
+                ) or (direction == SignalDirection.BEARISH.value and state.bearish_open)
+                if not already_open:
+                    self._emit_signal(
+                        state, event, SignalType.OPEN, direction, "confluence"
+                    )
+                    if direction == SignalDirection.BULLISH.value:
+                        state.bullish_open = True
+                    else:
+                        state.bearish_open = True
+                    state.hull_armed_direction = None
+                    state.macd_armed_direction = None
+            else:
+                # Opposing armed directions — discard the older one
+                if hull_changed and not macd_changed:
+                    state.macd_armed_direction = None
+                elif macd_changed and not hull_changed:
+                    state.hull_armed_direction = None
+                else:
+                    state.hull_armed_direction = None
+                    state.macd_armed_direction = None
+
+    def _emit_signal(
+        self,
+        state: TimeframeState,
+        event: CandleEvent,
+        signal_type: SignalType,
+        direction: str,
+        trigger: str,
+    ) -> None:
+        macd_df = macd(
+            state.candles, prior_close=self._prior_closes.get(event.eventSymbol)
+        )
+        last_row = macd_df.tail(1)
+        macd_value = float(last_row["Value"][0])
+        macd_signal_val = float(last_row["avg"][0])
+        macd_histogram = float(last_row["diff"][0])
+
+        pad_value = self._prior_closes.get(event.eventSymbol)
+        hull_df = hull(state.candles, pad_value=pad_value)
+        hull_value = float(hull_df["HMA"].iloc[-1])
+
+        color = "#55A868" if direction == SignalDirection.BULLISH.value else "#8C8C8C"
+        label = f"{signal_type.value} {direction}"
+
+        signal = TradeSignal(
+            eventSymbol=event.eventSymbol,
+            start_time=event.time,
+            label=label,
+            color=color,
+            line_width=0.5,
+            line_dash="dot",
+            opacity=0.4,
+            signal_type=signal_type.value,
+            direction=direction,
+            engine=self.name,
+            hull_direction=state.hull_direction or "Unknown",
+            hull_value=hull_value,
+            macd_value=macd_value,
+            macd_signal=macd_signal_val,
+            macd_histogram=macd_histogram,
+            close_price=float(event.close),  # type: ignore[arg-type]
+            trigger=trigger,
+        )
+
+        self._signals.append(signal)
+
+        logger.info(
+            "TradeSignal: %s %s %s at %s (trigger=%s)",
+            signal.signal_type,
+            signal.direction,
+            signal.eventSymbol,
+            signal.start_time.isoformat(),
+            signal.trigger,
+            extra={
+                "signal_type": signal.signal_type,
+                "signal_direction": signal.direction,
+                "signal_engine": signal.engine,
+                "signal_trigger": signal.trigger,
+                "hull_direction": signal.hull_direction,
+                "hull_value": signal.hull_value,
+                "macd_value": signal.macd_value,
+                "macd_signal": signal.macd_signal,
+                "macd_histogram": signal.macd_histogram,
+                "close_price": signal.close_price,
+                "event_symbol": signal.eventSymbol,
+            },
+        )
+
+        if self._on_signal:
+            self._on_signal(signal)
+
+    @staticmethod
+    def _hull_to_signal_direction(hull_dir: str) -> str:
+        return (
+            SignalDirection.BULLISH.value
+            if hull_dir == "Up"
+            else SignalDirection.BEARISH.value
+        )
+
+    @staticmethod
+    def _macd_to_signal_direction(macd_pos: str) -> str:
+        return (
+            SignalDirection.BULLISH.value
+            if macd_pos == "bullish"
+            else SignalDirection.BEARISH.value
+        )

--- a/src/tastytrade/analytics/engines/hull_macd.py
+++ b/src/tastytrade/analytics/engines/hull_macd.py
@@ -152,9 +152,9 @@ class HullMacdEngine:
     def _compute_hull(self, state: TimeframeState, symbol: str) -> str | None:
         pad_value = self._prior_closes.get(symbol)
         hull_df = hull(state.candles, pad_value=pad_value)
-        if hull_df.empty:
+        if hull_df.height == 0:
             return None
-        return str(hull_df["HMA_color"].iloc[-1])
+        return str(hull_df["HMA_color"][-1])
 
     def _compute_macd(self, state: TimeframeState, symbol: str) -> str | None:
         prior_close = self._prior_closes.get(symbol)
@@ -276,7 +276,7 @@ class HullMacdEngine:
 
         pad_value = self._prior_closes.get(event.eventSymbol)
         hull_df = hull(state.candles, pad_value=pad_value)
-        hull_value = float(hull_df["HMA"].iloc[-1])
+        hull_value = float(hull_df["HMA"][-1])
 
         color = "#55A868" if direction == SignalDirection.BULLISH.value else "#8C8C8C"
         label = f"{signal_type.value} {direction}"

--- a/src/tastytrade/analytics/engines/models.py
+++ b/src/tastytrade/analytics/engines/models.py
@@ -1,0 +1,47 @@
+"""Trade signal models for the signal detection engine.
+
+Defines SignalDirection, SignalType enums and the TradeSignal model that
+extends BaseAnnotation for native InfluxDB persistence and chart rendering.
+"""
+
+from enum import Enum
+
+from pydantic import Field
+
+from tastytrade.analytics.visualizations.models import BaseAnnotation
+
+
+class SignalDirection(str, Enum):
+    BULLISH = "BULLISH"
+    BEARISH = "BEARISH"
+
+
+class SignalType(str, Enum):
+    OPEN = "OPEN"
+    CLOSE = "CLOSE"
+
+
+class TradeSignal(BaseAnnotation):
+    """A trade signal event emitted when indicator confluence is detected.
+
+    Extends BaseAnnotation so it flows through the EventHandler processor
+    chain — the TelegrafHTTPEventProcessor writes it to InfluxDB as a
+    ``trade_signal`` measurement, and chart code can render it as an
+    annotation overlay.
+    """
+
+    event_type: str = "trade_signal"
+    signal_type: str = Field(description="OPEN or CLOSE")
+    direction: str = Field(description="BULLISH or BEARISH")
+    engine: str = Field(description="Engine name that produced this signal")
+    hull_direction: str = Field(
+        description="Hull MA direction at signal time (Up/Down)"
+    )
+    hull_value: float = Field(description="HMA value at signal time")
+    macd_value: float = Field(description="MACD line value")
+    macd_signal: float = Field(description="MACD signal line value")
+    macd_histogram: float = Field(description="MACD histogram value")
+    close_price: float = Field(description="Triggering candle close price")
+    trigger: str = Field(
+        description="Indicator that triggered: hull, macd, or confluence"
+    )

--- a/src/tastytrade/analytics/engines/models.py
+++ b/src/tastytrade/analytics/engines/models.py
@@ -5,10 +5,14 @@ extends BaseAnnotation for native InfluxDB persistence and chart rendering.
 """
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from pydantic import Field
 
 from tastytrade.analytics.visualizations.models import BaseAnnotation
+
+if TYPE_CHECKING:
+    from tastytrade.analytics.visualizations.models import VerticalLine
 
 
 class SignalDirection(str, Enum):
@@ -45,3 +49,19 @@ class TradeSignal(BaseAnnotation):
     trigger: str = Field(
         description="Indicator that triggered: hull, macd, or confluence"
     )
+
+    def to_vertical_line(self) -> "VerticalLine":
+        """Convert this TradeSignal to a VerticalLine for chart rendering."""
+        from tastytrade.analytics.visualizations.models import VerticalLine
+
+        return VerticalLine(
+            eventSymbol=self.eventSymbol,
+            start_time=self.start_time,
+            label=self.label,
+            color=self.color,
+            line_width=self.line_width,
+            line_dash=self.line_dash,
+            opacity=self.opacity,
+            show_label=self.show_label,
+            label_font_size=self.label_font_size,
+        )

--- a/src/tastytrade/analytics/engines/protocol.py
+++ b/src/tastytrade/analytics/engines/protocol.py
@@ -1,0 +1,30 @@
+"""Protocol definition for signal detection engines.
+
+Uses typing.Protocol for structural subtyping — any class that implements
+these methods is a valid SignalEngine without explicit inheritance.
+"""
+
+from typing import Callable, Protocol
+
+from tastytrade.analytics.engines.models import TradeSignal
+from tastytrade.messaging.models.events import CandleEvent
+
+
+class SignalEngine(Protocol):
+    """Structural protocol for signal detection engines."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def signals(self) -> list[TradeSignal]: ...
+
+    @property
+    def on_signal(self) -> Callable[[TradeSignal], None] | None: ...
+
+    @on_signal.setter
+    def on_signal(self, callback: Callable[[TradeSignal], None] | None) -> None: ...
+
+    def set_prior_close(self, event_symbol: str, price: float) -> None: ...
+
+    def on_candle_event(self, event: CandleEvent) -> None: ...

--- a/src/tastytrade/analytics/visualizations/liveplots.py
+++ b/src/tastytrade/analytics/visualizations/liveplots.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
 import dash
-import pandas as pd
 import plotly.graph_objects as go
 import plotly.subplots
 import polars as pl
@@ -355,19 +354,21 @@ class LiveMarketChart:
 
         fig.update_layout(
             template="plotly_dark",
-            title=dict(
-                text=f"{self.symbol} ({self.interval}) Loading...", x=0.5, y=0.95
-            ),
+            title={
+                "text": f"{self.symbol} ({self.interval}) Loading...",
+                "x": 0.5,
+                "y": 0.95,
+            },
             annotations=[
-                dict(
-                    text="Loading market data...",
-                    xref="paper",
-                    yref="paper",
-                    x=0.5,
-                    y=0.5,
-                    showarrow=False,
-                    font=dict(size=20, color="white"),
-                )
+                {
+                    "text": "Loading market data...",
+                    "xref": "paper",
+                    "yref": "paper",
+                    "x": 0.5,
+                    "y": 0.5,
+                    "showarrow": False,
+                    "font": {"size": 20, "color": "white"},
+                }
             ],
             plot_bgcolor="rgb(25,25,25)",
             paper_bgcolor="rgb(25,25,25)",
@@ -420,7 +421,7 @@ class LiveMarketChart:
                 pdf_macd = pdf.copy()
 
             # Calculate Hull MA if requested
-            hma_df = pd.DataFrame()
+            hma_df = pl.DataFrame()
             if use_hull:
                 try:
                     # Use the first close price as pad_value for Hull calculation
@@ -459,21 +460,23 @@ class LiveMarketChart:
             )
 
             # Add Hull MA if available
-            if not hma_df.empty and use_hull:
-                for i in range(1, len(hma_df)):
+            if hma_df.height > 0 and use_hull:
+                # Convert to pandas at the visualization boundary for Plotly segment rendering
+                hma_pdf = hma_df.to_pandas()
+                for i in range(1, len(hma_pdf)):
                     fig.add_trace(
                         go.Scatter(
-                            x=hma_df["time"].iloc[i - 1 : i + 1],
-                            y=hma_df["HMA"].iloc[i - 1 : i + 1],
+                            x=hma_pdf["time"].iloc[i - 1 : i + 1],
+                            y=hma_pdf["HMA"].iloc[i - 1 : i + 1],
                             mode="lines",
-                            line=dict(
-                                color=(
+                            line={
+                                "color": (
                                     "#01FFFF"
-                                    if hma_df["HMA_color"].iloc[i] == "Up"
+                                    if hma_pdf["HMA_color"].iloc[i] == "Up"
                                     else "#FF66FE"
                                 ),
-                                width=0.6,
-                            ),
+                                "width": 0.6,
+                            },
                             showlegend=False,
                             name="HMA",
                         ),
@@ -490,7 +493,7 @@ class LiveMarketChart:
                         y=pdf_macd["Value"],
                         mode="lines",
                         name="MACD",
-                        line=dict(color="#01FFFF", width=1),
+                        line={"color": "#01FFFF", "width": 1},
                         showlegend=False,
                     ),
                     row=2,
@@ -504,7 +507,7 @@ class LiveMarketChart:
                         y=pdf_macd["avg"],
                         mode="lines",
                         name="Signal",
-                        line=dict(color="#F8E9A6", width=1),
+                        line={"color": "#F8E9A6", "width": 1},
                         showlegend=False,
                     ),
                     row=2,
@@ -531,7 +534,7 @@ class LiveMarketChart:
                     x1=pdf_macd["time"].max(),
                     y0=0,
                     y1=0,
-                    line=dict(color="gray", width=1, dash="dot"),
+                    line={"color": "gray", "width": 1, "dash": "dot"},
                     row=2,
                     col=1,
                 )
@@ -553,11 +556,11 @@ class LiveMarketChart:
                     x1=x1,
                     y0=h_line.price,
                     y1=h_line.price,
-                    line=dict(
-                        color=h_line.color,
-                        width=h_line.line_width,
-                        dash=h_line.line_dash,
-                    ),
+                    line={
+                        "color": h_line.color,
+                        "width": h_line.line_width,
+                        "dash": h_line.line_dash,
+                    },
                     opacity=h_line.opacity,
                     row=1,
                     col=1,
@@ -577,7 +580,7 @@ class LiveMarketChart:
                         y=h_line.price,
                         text=h_line.label,
                         showarrow=False,
-                        font=dict(color=h_line.color, size=h_line.label_font_size),
+                        font={"color": h_line.color, "size": h_line.label_font_size},
                         bgcolor="rgba(25,25,25,0.7)",
                         bordercolor=h_line.color,
                         borderwidth=1,
@@ -611,11 +614,11 @@ class LiveMarketChart:
                     x1=line_time,
                     y0=y_min,
                     y1=y_max,
-                    line=dict(
-                        color=v_line.color,
-                        width=v_line.line_width,
-                        dash=v_line.line_dash,
-                    ),
+                    line={
+                        "color": v_line.color,
+                        "width": v_line.line_width,
+                        "dash": v_line.line_dash,
+                    },
                     opacity=v_line.opacity,
                     row=1,
                     col=1,
@@ -646,11 +649,11 @@ class LiveMarketChart:
                         x1=line_time,
                         y0=macd_min,
                         y1=macd_max,
-                        line=dict(
-                            color=v_line.color,
-                            width=v_line.line_width,
-                            dash=v_line.line_dash,
-                        ),
+                        line={
+                            "color": v_line.color,
+                            "width": v_line.line_width,
+                            "dash": v_line.line_dash,
+                        },
                         opacity=v_line.opacity,
                         row=2,
                         col=1,
@@ -675,7 +678,7 @@ class LiveMarketChart:
                         y=y_pos,
                         text=v_line.label,
                         showarrow=False,
-                        font=dict(color=v_line.color, size=v_line.label_font_size),
+                        font={"color": v_line.color, "size": v_line.label_font_size},
                         bgcolor=f"rgba(25,25,25,{v_line.label_bg_opacity})",
                         bordercolor=v_line.color,
                         borderwidth=1,
@@ -694,7 +697,7 @@ class LiveMarketChart:
                 xaxis_rangeslider_visible=False,
                 plot_bgcolor="rgb(25,25,25)",
                 paper_bgcolor="rgb(25,25,25)",
-                margin=dict(l=30, r=5, t=50, b=10),
+                margin={"l": 30, "r": 5, "t": 50, "b": 10},
                 height=self.height,
                 showlegend=False,
                 uirevision="true",  # Preserve zoom level on updates
@@ -710,20 +713,20 @@ class LiveMarketChart:
                 tickwidth=1,
                 ticks="outside",
                 ticksuffix=" ",
-                tickfont=dict(size=11),
+                tickfont={"size": 11},
                 showgrid=True,
                 zeroline=False,
                 showticklabels=True,
                 dtick=10,
-                minor=dict(
-                    ticklen=2,
-                    tickwidth=1,
-                    tickcolor="rgba(150,150,150,0.5)",
-                    tickmode="linear",
-                    dtick=5,
-                    showgrid=False,
-                    ticks="outside",
-                ),
+                minor={
+                    "ticklen": 2,
+                    "tickwidth": 1,
+                    "tickcolor": "rgba(150,150,150,0.5)",
+                    "tickmode": "linear",
+                    "dtick": 5,
+                    "showgrid": False,
+                    "ticks": "outside",
+                },
                 row=1,
                 col=1,
             )
@@ -740,7 +743,7 @@ class LiveMarketChart:
                     tickwidth=1,
                     ticks="outside",
                     ticksuffix=" ",
-                    tickfont=dict(size=11),
+                    tickfont={"size": 11},
                     showgrid=True,
                     zeroline=False,
                     showticklabels=True,

--- a/src/tastytrade/messaging/processors/__init__.py
+++ b/src/tastytrade/messaging/processors/__init__.py
@@ -1,11 +1,13 @@
 from .influxdb import TelegrafHTTPEventProcessor
 from .metrics import MetricsEventProcessor
 from .redis import RedisEventProcessor
+from .signal import SignalEventProcessor
 from .snapshot import CandleSnapshotTracker
 
 __all__ = [
     "CandleSnapshotTracker",
     "MetricsEventProcessor",
     "RedisEventProcessor",
+    "SignalEventProcessor",
     "TelegrafHTTPEventProcessor",
 ]

--- a/src/tastytrade/messaging/processors/signal.py
+++ b/src/tastytrade/messaging/processors/signal.py
@@ -1,0 +1,49 @@
+"""Event processor that routes CandleEvent to a SignalEngine.
+
+Attach to the Candle EventHandler. Other event types are ignored,
+including TradeSignal (prevents re-entrant loops when signals are
+emitted back into the processor chain).
+"""
+
+import logging
+from typing import Callable
+
+from tastytrade.analytics.engines.protocol import SignalEngine
+from tastytrade.messaging.models.events import BaseEvent, CandleEvent
+
+logger = logging.getLogger(__name__)
+
+
+class SignalEventProcessor:
+    """Routes CandleEvent to a SignalEngine and emits TradeSignal via callback.
+
+    Implements the EventProcessor protocol (name, process_event, close).
+    Should be attached to the Candle EventHandler.
+    """
+
+    name: str = "signal"
+
+    def __init__(
+        self,
+        engine: SignalEngine,
+        emit: Callable[[BaseEvent], None] | None = None,
+    ) -> None:
+        self.engine = engine
+        self._emit = emit
+        self._signal_count = 0
+
+        def on_signal_fired(signal: BaseEvent) -> None:
+            self._signal_count += 1
+            if self._emit:
+                self._emit(signal)
+
+        self.engine.on_signal = on_signal_fired  # type: ignore[assignment]
+
+    def process_event(self, event: BaseEvent) -> None:
+        if isinstance(event, CandleEvent):
+            self.engine.on_candle_event(event)
+
+    def close(self) -> None:
+        logger.info(
+            "SignalEventProcessor closing — %d signals emitted", self._signal_count
+        )

--- a/unit_tests/analytics/test_hull_macd_engine.py
+++ b/unit_tests/analytics/test_hull_macd_engine.py
@@ -1,0 +1,1012 @@
+"""Tests for the HullMacdEngine signal detection engine.
+
+All indicator computations are mocked via @patch to control Hull MA
+direction and MACD crossover state deterministically.
+"""
+
+from datetime import datetime, time, timedelta, timezone
+from unittest.mock import patch
+
+import pandas as pd
+import polars as pl
+
+from tastytrade.analytics.engines.hull_macd import HullMacdEngine
+from tastytrade.analytics.engines.models import SignalDirection, SignalType, TradeSignal
+from tastytrade.analytics.visualizations.models import BaseAnnotation
+from tastytrade.messaging.models.events import CandleEvent
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def make_candle(
+    symbol: str = "SPX{=5m}",
+    close: float | None = 5000.0,
+    time_offset_minutes: int = 0,
+) -> CandleEvent:
+    # 15:00 UTC = 10:00 AM ET (past default earliest_entry)
+    ts = datetime(2026, 2, 10, 15, 0, 0, tzinfo=timezone.utc) + timedelta(
+        minutes=time_offset_minutes
+    )
+    return CandleEvent(
+        eventSymbol=symbol,
+        time=ts,
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+    )
+
+
+def make_hull_result(direction: str = "Up", hma_value: float = 5000.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "time": [datetime(2026, 2, 10, 14, 30, tzinfo=timezone.utc)],
+            "HMA": [hma_value],
+            "HMA_color": [direction],
+        }
+    )
+
+
+def make_macd_result(
+    value: float = 1.0,
+    avg: float = 0.5,
+    diff: float = 0.5,
+) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "time": [datetime(2026, 2, 10, 14, 30, tzinfo=timezone.utc)],
+            "close": [5000.0],
+            "Value": [value],
+            "avg": [avg],
+            "diff": [diff],
+            "diff_color": ["#04FE00"],
+        }
+    )
+
+
+HULL_PATH = "tastytrade.analytics.engines.hull_macd.hull"
+MACD_PATH = "tastytrade.analytics.engines.hull_macd.macd"
+
+
+# ---------------------------------------------------------------------------
+# 1. Engine init
+# ---------------------------------------------------------------------------
+
+
+def test_engine_name():
+    engine = HullMacdEngine()
+    assert engine.name == "hull_macd"
+
+
+def test_engine_signals_initially_empty():
+    engine = HullMacdEngine()
+    assert engine.signals == []
+
+
+def test_engine_on_signal_initially_none():
+    engine = HullMacdEngine()
+    assert engine.on_signal is None
+
+
+def test_set_prior_close():
+    engine = HullMacdEngine()
+    engine.set_prior_close("SPX{=5m}", 4950.0)
+    assert engine._prior_closes["SPX{=5m}"] == 4950.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Accumulation
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH, return_value=make_macd_result())
+@patch(HULL_PATH, return_value=make_hull_result())
+def test_new_symbol_creates_state(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    engine.on_candle_event(make_candle())
+    assert "SPX{=5m}" in engine._states
+
+
+@patch(MACD_PATH, return_value=make_macd_result())
+@patch(HULL_PATH, return_value=make_hull_result())
+def test_candles_accumulate(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    assert engine._states["SPX{=5m}"].candles.height == 3
+
+
+def test_none_close_skipped():
+    engine = HullMacdEngine()
+    engine.on_candle_event(make_candle(close=None))
+    assert "SPX{=5m}" not in engine._states
+
+
+@patch(MACD_PATH, return_value=make_macd_result())
+@patch(HULL_PATH, return_value=make_hull_result())
+def test_candle_cap_enforced(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    for i in range(510):
+        engine.on_candle_event(make_candle(time_offset_minutes=i, close=5000.0 + i))
+    assert engine._states["SPX{=5m}"].candles.height <= 500
+
+
+# ---------------------------------------------------------------------------
+# 3. Indicator computation
+# ---------------------------------------------------------------------------
+
+
+def test_not_enough_data_no_signal():
+    engine = HullMacdEngine()
+    # Only 1 candle — should not compute indicators
+    engine.on_candle_event(make_candle())
+    assert engine.signals == []
+
+
+@patch(MACD_PATH, return_value=make_macd_result())
+@patch(HULL_PATH, return_value=make_hull_result("Up", 5010.0))
+def test_hull_computed_with_prior_close(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    engine.set_prior_close("SPX{=5m}", 4950.0)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+    mock_hull.assert_called()
+    _, kwargs = mock_hull.call_args
+    assert kwargs.get("pad_value") == 4950.0
+
+
+@patch(MACD_PATH, return_value=make_macd_result())
+@patch(HULL_PATH, return_value=make_hull_result())
+def test_macd_uses_prior_close(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    engine.set_prior_close("SPX{=5m}", 4950.0)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+    mock_macd.assert_called()
+    _, kwargs = mock_macd.call_args
+    assert kwargs.get("prior_close") == 4950.0
+
+
+# ---------------------------------------------------------------------------
+# 4. OPEN signals — confluence
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_hull_then_macd_emits_open_bullish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Candle 0: establish baseline (Down hull, bearish macd)
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # Candle 2: Hull flips Up — arms hull
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    assert len(engine.signals) == 0
+
+    # Candle 3: MACD crosses bullish — confluence!
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].signal_type == SignalType.OPEN.value
+    assert engine.signals[0].direction == SignalDirection.BULLISH.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_macd_then_hull_emits_open_bullish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Baseline
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # MACD crosses bullish first — arms macd
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    assert len(engine.signals) == 0
+
+    # Hull flips Up — confluence!
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].direction == SignalDirection.BULLISH.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_open_signal_has_correct_fields(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    mock_hull.return_value = make_hull_result("Up", 5010.0)
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+
+    sig = engine.signals[0]
+    assert sig.engine == "hull_macd"
+    assert sig.trigger == "confluence"
+    assert sig.eventSymbol == "SPX{=5m}"
+    assert sig.close_price == 5000.0
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_open_callback_invoked(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    received = []
+    engine.on_signal = lambda s: received.append(s)
+
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+
+    assert len(received) == 1
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_no_signal_when_only_hull_armed(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # Hull flips Up but MACD stays bearish (no change)
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    assert len(engine.signals) == 0
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_open_only_fires_when_flat(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Open a LONG position
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+    assert len(engine.signals) == 1  # OPEN
+
+    # While bullish is open, same direction should not OPEN again
+    state = engine._states["SPX{=5m}"]
+    assert state.bullish_open is True
+    # Hull stays Up, MACD stays bullish — no new change, no new OPEN
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 1
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_open_bearish_signal(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Baseline: Up hull, bullish MACD
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # Hull flips Down
+    mock_hull.return_value = make_hull_result("Down", 4990.0)
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    assert len(engine.signals) == 0
+
+    # MACD crosses bearish — SHORT confluence
+    mock_hull.return_value = make_hull_result("Down", 4990.0)
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].signal_type == SignalType.OPEN.value
+    assert engine.signals[0].direction == SignalDirection.BEARISH.value
+
+
+# ---------------------------------------------------------------------------
+# 5. CLOSE signals — single indicator
+# ---------------------------------------------------------------------------
+
+
+def _open_bullish(engine: HullMacdEngine, mock_hull, mock_macd) -> None:
+    """Helper to open a BULLISH position via confluence."""
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+
+
+def _open_bearish(engine: HullMacdEngine, mock_hull, mock_macd) -> None:
+    """Helper to open a BEARISH position via confluence."""
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_hull_flip_closes_bullish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    assert len(engine.signals) == 1
+
+    # Hull flips Down — closes LONG
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2
+    assert engine.signals[1].signal_type == SignalType.CLOSE.value
+    assert engine.signals[1].trigger == "hull"
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_macd_cross_closes_bullish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # MACD crosses bearish — closes LONG
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2
+    assert engine.signals[1].signal_type == SignalType.CLOSE.value
+    assert engine.signals[1].trigger == "macd"
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_hull_flip_closes_bearish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bearish(engine, mock_hull, mock_macd)
+
+    # Hull flips Up — closes SHORT
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2
+    assert engine.signals[1].signal_type == SignalType.CLOSE.value
+    assert engine.signals[1].direction == SignalDirection.BEARISH.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_macd_cross_closes_bearish(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bearish(engine, mock_hull, mock_macd)
+
+    # MACD crosses bullish — closes SHORT
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2
+    assert engine.signals[1].signal_type == SignalType.CLOSE.value
+    assert engine.signals[1].trigger == "macd"
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_close_returns_to_flat(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert engine._states["SPX{=5m}"].bullish_open is False
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_close_does_not_clear_armed_states(mock_hull, mock_macd):
+    """Armed states persist through closes — only cleared on open."""
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # Hull flips Down — closes bullish, and arms hull BEARISH
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    state = engine._states["SPX{=5m}"]
+    assert state.bullish_open is False
+    # Hull armed BEARISH from the flip, not cleared by close
+    assert state.hull_armed_direction == "BEARISH"
+
+
+# ---------------------------------------------------------------------------
+# 6. Position guard
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_cannot_open_same_direction_when_already_open(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    assert engine._states["SPX{=5m}"].bullish_open is True
+    # No additional bullish OPEN should be possible
+    initial_count = len(engine.signals)
+    # Feed a candle with no change
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == initial_count
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_no_duplicate_open_signals(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # Feed more candles with same indicators — no new signals
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    for i in range(20, 40, 5):
+        engine.on_candle_event(make_candle(time_offset_minutes=i))
+    assert len(engine.signals) == 1
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_must_close_before_reopen(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # Close via hull flip
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2  # OPEN + CLOSE
+
+    # Now bullish is closed, need fresh confluence for next bullish OPEN
+    assert engine._states["SPX{=5m}"].bullish_open is False
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_fresh_confluence_required_after_close(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # Close via hull flip (MACD stays bullish — no MACD change)
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+
+    # Feed candles with stable indicators — no changes → no new arming
+    engine.on_candle_event(make_candle(time_offset_minutes=25))
+    engine.on_candle_event(make_candle(time_offset_minutes=30))
+    assert len(engine.signals) == 2  # Still just OPEN + CLOSE
+
+
+# ---------------------------------------------------------------------------
+# 7. Opposing armed
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_opposing_armed_discards_older(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Baseline
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # Hull flips Up — arms LONG
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    state = engine._states["SPX{=5m}"]
+    assert state.hull_armed_direction == "BULLISH"
+
+    # MACD crosses bearish (further bearish, was already bearish) — no change
+    # Now let's flip MACD to SHORT: value=-2 (bearish stays) — still no macd change
+    # Actually, let's flip MACD to bullish then back to bearish to arm SHORT macd
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)  # bullish
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+
+    # That actually triggers confluence (both Up/LONG + bullish/LONG). So let's adjust.
+    # The hull_armed was LONG. MACD changed to bullish = LONG. Same direction = confluence fired.
+    # Let's test opposing differently: start with hull SHORT armed, then MACD goes LONG.
+    assert len(engine.signals) == 1  # Confluence happened
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_opposing_armed_no_signal(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Baseline: Up hull, bearish macd
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=0))
+    engine.on_candle_event(make_candle(time_offset_minutes=5))
+
+    # Hull flips Down (arm SHORT), MACD stays bearish
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=10))
+    state = engine._states["SPX{=5m}"]
+    assert state.hull_armed_direction == "BEARISH"
+    assert state.macd_armed_direction is None
+
+    # MACD crosses bullish (arm LONG) — opposing!
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=15))
+    # Opposing: hull SHORT armed, macd LONG armed — hull (older) discarded
+    assert len(engine.signals) == 0
+    assert state.hull_armed_direction is None
+    assert state.macd_armed_direction == "BULLISH"
+
+
+# ---------------------------------------------------------------------------
+# 8. Full trade lifecycle
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_full_lifecycle_flat_open_close_flat(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    assert engine._states["SPX{=5m}"].bullish_open is True
+
+    # Close via MACD
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert engine._states["SPX{=5m}"].bullish_open is False
+    assert len(engine.signals) == 2
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_multiple_trades_in_sequence(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Trade 1: BULLISH
+    _open_bullish(engine, mock_hull, mock_macd)
+
+    # Close via hull Down (arms hull BEARISH)
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert engine._states["SPX{=5m}"].bullish_open is False
+    assert len(engine.signals) == 2  # OPEN BULL + CLOSE BULL
+
+    # MACD crosses bearish — completes bearish confluence (hull armed BEARISH persists)
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=25))
+    assert len(engine.signals) == 3  # + OPEN BEARISH
+
+    # Close bearish via hull Up (arms hull BULLISH)
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=30))
+    assert len(engine.signals) == 4  # + CLOSE BEARISH
+
+    # MACD crosses bullish — completes bullish confluence
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=35))
+    assert len(engine.signals) == 5  # + OPEN BULLISH
+    assert engine.signals[4].signal_type == SignalType.OPEN.value
+    assert engine.signals[4].direction == SignalDirection.BULLISH.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_alternating_bullish_bearish_trades(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Trade 1: LONG
+    _open_bullish(engine, mock_hull, mock_macd)
+    # Close LONG via hull
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    assert len(engine.signals) == 2
+
+    # Stabilize
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=25))
+    engine.on_candle_event(make_candle(time_offset_minutes=30))
+
+    # Trade 2: SHORT — hull Down
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=35))
+
+    # MACD crosses bearish — SHORT confluence
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=40))
+    assert len(engine.signals) == 3
+    assert engine.signals[2].direction == SignalDirection.BEARISH.value
+
+
+# ---------------------------------------------------------------------------
+# 9. Multi-symbol
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_independent_state_per_symbol(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=0))
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=5))
+    engine.on_candle_event(make_candle(symbol="QQQ{=5m}", time_offset_minutes=0))
+    engine.on_candle_event(make_candle(symbol="QQQ{=5m}", time_offset_minutes=5))
+
+    assert "SPX{=5m}" in engine._states
+    assert "QQQ{=5m}" in engine._states
+    assert engine._states["SPX{=5m}"].candles.height == 2
+    assert engine._states["QQQ{=5m}"].candles.height == 2
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_signal_on_one_symbol_doesnt_affect_other(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Set up SPX
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=0))
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=5))
+
+    # Open LONG on SPX
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=10))
+    engine.on_candle_event(make_candle(symbol="SPX{=5m}", time_offset_minutes=15))
+
+    # QQQ should still be FLAT
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(symbol="QQQ{=5m}", time_offset_minutes=0))
+    engine.on_candle_event(make_candle(symbol="QQQ{=5m}", time_offset_minutes=5))
+
+    assert engine._states["SPX{=5m}"].bullish_open is True
+    assert engine._states["QQQ{=5m}"].bullish_open is False
+    assert engine._states["QQQ{=5m}"].bearish_open is False
+
+
+# ---------------------------------------------------------------------------
+# 10. Independent position tracking
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_bullish_and_bearish_can_be_open_simultaneously(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    # Open bullish
+    _open_bullish(engine, mock_hull, mock_macd)
+    state = engine._states["SPX{=5m}"]
+    assert state.bullish_open is True
+    assert state.bearish_open is False
+    assert len(engine.signals) == 1
+
+    # Now arm bearish confluence while bullish is open
+    # Hull flips Down — arms bearish (also starts close check, but bullish MACD hasn't changed yet)
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    # Hull flip Down closed bullish
+    assert state.bullish_open is False
+    assert len(engine.signals) == 2  # OPEN bullish + CLOSE bullish
+
+    # MACD crosses bearish — bearish confluence
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=25))
+    assert state.bearish_open is True
+    assert len(engine.signals) == 3  # + OPEN bearish
+
+    # Now re-arm bullish while bearish is open
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=30))
+    # Hull Up closes bearish
+    assert state.bearish_open is False
+
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=35))
+    assert state.bullish_open is True
+    assert len(engine.signals) == 5  # CLOSE bearish + OPEN bullish
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_close_one_direction_other_stays_open(mock_hull, mock_macd):
+    """Closing bullish should not affect bearish if both were open."""
+    engine = HullMacdEngine()
+    # Open bullish first
+    _open_bullish(engine, mock_hull, mock_macd)
+    state = engine._states["SPX{=5m}"]
+    assert state.bullish_open is True
+
+    # Manually set bearish_open to simulate both open
+    state.bearish_open = True
+
+    # MACD crosses bearish — should close bullish but not bearish
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+
+    assert state.bullish_open is False
+    assert state.bearish_open is True  # Bearish untouched
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_cannot_reopen_same_direction_while_open(mock_hull, mock_macd):
+    """Cannot open a second bullish while bullish is already open."""
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    state = engine._states["SPX{=5m}"]
+    assert state.bullish_open is True
+    assert len(engine.signals) == 1
+
+    # Try to trigger another bullish confluence — should be blocked
+    # First stabilize then re-trigger
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(make_candle(time_offset_minutes=20))
+    engine.on_candle_event(make_candle(time_offset_minutes=25))
+    assert len(engine.signals) == 1  # No new signals
+
+
+# ---------------------------------------------------------------------------
+# 11. TradeSignal model
+# ---------------------------------------------------------------------------
+
+
+def test_trade_signal_extends_base_annotation():
+    assert issubclass(TradeSignal, BaseAnnotation)
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_trade_signal_has_time_property(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    sig = engine.signals[0]
+    # time property is from BaseAnnotation — adds microsecond jitter
+    assert sig.time is not None
+    assert sig.time >= sig.start_time
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_trade_signal_processor_safe_dict(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+    _open_bullish(engine, mock_hull, mock_macd)
+    sig = engine.signals[0]
+    # __dict__ should be _ProcessorSafeDict — iteration yields str/int/float/bool only
+    for key, value in sig.__dict__.items():
+        assert isinstance(
+            value, (str, int, float, bool)
+        ), f"Field {key} has non-primitive type {type(value)} in processor iteration"
+
+
+# ---------------------------------------------------------------------------
+# 12. Earliest entry time gate
+# ---------------------------------------------------------------------------
+
+
+def _make_candle_at_et(
+    hour: int, minute: int = 0, symbol: str = "SPX{=5m}"
+) -> CandleEvent:
+    """Create a candle at a specific ET hour (converted to UTC for Feb = EST/UTC-5)."""
+    utc_hour = hour + 5
+    ts = datetime(2026, 2, 10, utc_hour, minute, 0, tzinfo=timezone.utc)
+    return CandleEvent(
+        eventSymbol=symbol, time=ts, open=5000.0, high=5000.0, low=5000.0, close=5000.0
+    )
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_no_signals_before_earliest_entry(mock_hull, mock_macd):
+    engine = HullMacdEngine()  # default earliest_entry=10:00 ET
+
+    # Baseline at 9:30 ET
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(9, 30))
+    engine.on_candle_event(_make_candle_at_et(9, 35))
+
+    # Confluence conditions at 9:40 and 9:45 ET — should NOT fire
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(9, 40))
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(9, 45))
+
+    assert len(engine.signals) == 0
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_signals_fire_after_earliest_entry(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+
+    # Warm up before 10 AM ET
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(9, 30))
+    engine.on_candle_event(_make_candle_at_et(9, 35))
+    engine.on_candle_event(_make_candle_at_et(9, 40))
+    engine.on_candle_event(_make_candle_at_et(9, 50))
+
+    # Hull flips at 10:00 ET — now past threshold, should arm
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(10, 0))
+    assert len(engine.signals) == 0
+
+    # MACD crosses at 10:05 — confluence fires
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(10, 5))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].signal_type == SignalType.OPEN.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_indicators_warm_up_before_earliest_entry(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+
+    # Feed candles before 10 AM to establish indicator state
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(9, 30))
+    engine.on_candle_event(_make_candle_at_et(9, 35))
+
+    state = engine._states["SPX{=5m}"]
+    # Indicator state IS tracked (warmed up), just no signals
+    assert state.hull_direction == "Up"
+    assert state.macd_position == "bullish"
+    assert state.candles.height == 2
+    assert len(engine.signals) == 0
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_custom_earliest_entry(mock_hull, mock_macd):
+    engine = HullMacdEngine(earliest_entry=time(10, 30))
+
+    # Establish baseline before 10:30
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(10, 0))
+    engine.on_candle_event(_make_candle_at_et(10, 5))
+
+    # Confluence at 10:15 — still before 10:30 threshold
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(10, 10))
+    engine.on_candle_event(_make_candle_at_et(10, 15))
+    assert len(engine.signals) == 0
+
+    # Change at 10:35 — now past threshold
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(10, 35))
+
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(10, 40))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].direction == SignalDirection.BEARISH.value
+
+
+# ---------------------------------------------------------------------------
+# 13. Latest entry (power hour) time gate
+# ---------------------------------------------------------------------------
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_no_open_during_power_hour(mock_hull, mock_macd):
+    engine = HullMacdEngine()  # default latest_entry=15:00 ET
+
+    # Establish baseline at 2:45 PM ET
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(14, 45))
+    engine.on_candle_event(_make_candle_at_et(14, 50))
+
+    # Confluence at 3:00 and 3:05 PM ET — should NOT open
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(15, 0))
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(15, 5))
+
+    assert len(engine.signals) == 0
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_close_still_fires_during_power_hour(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+
+    # Open a bullish position at 2:40 PM ET
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(14, 30))
+    engine.on_candle_event(_make_candle_at_et(14, 35))
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(14, 40))
+    engine.on_candle_event(_make_candle_at_et(14, 45))
+    assert len(engine.signals) == 1
+    assert engine.signals[0].signal_type == SignalType.OPEN.value
+
+    # Hull flips at 3:10 PM ET — CLOSE must still fire
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(15, 10))
+    assert len(engine.signals) == 2
+    assert engine.signals[1].signal_type == SignalType.CLOSE.value
+
+
+@patch(MACD_PATH)
+@patch(HULL_PATH)
+def test_open_allowed_just_before_power_hour(mock_hull, mock_macd):
+    engine = HullMacdEngine()
+
+    # Baseline
+    mock_hull.return_value = make_hull_result("Down")
+    mock_macd.return_value = make_macd_result(value=-1.0, avg=0.5, diff=-1.5)
+    engine.on_candle_event(_make_candle_at_et(14, 40))
+    engine.on_candle_event(_make_candle_at_et(14, 45))
+
+    # Confluence at 2:55 PM ET — just before 3 PM cutoff, should fire
+    mock_hull.return_value = make_hull_result("Up")
+    mock_macd.return_value = make_macd_result(value=1.0, avg=0.5, diff=0.5)
+    engine.on_candle_event(_make_candle_at_et(14, 50))
+    engine.on_candle_event(_make_candle_at_et(14, 55))
+    assert len(engine.signals) == 1

--- a/unit_tests/analytics/test_hull_macd_engine.py
+++ b/unit_tests/analytics/test_hull_macd_engine.py
@@ -7,7 +7,6 @@ direction and MACD crossover state deterministically.
 from datetime import datetime, time, timedelta, timezone
 from unittest.mock import patch
 
-import pandas as pd
 import polars as pl
 
 from tastytrade.analytics.engines.hull_macd import HullMacdEngine
@@ -40,8 +39,8 @@ def make_candle(
     )
 
 
-def make_hull_result(direction: str = "Up", hma_value: float = 5000.0) -> pd.DataFrame:
-    return pd.DataFrame(
+def make_hull_result(direction: str = "Up", hma_value: float = 5000.0) -> pl.DataFrame:
+    return pl.DataFrame(
         {
             "time": [datetime(2026, 2, 10, 14, 30, tzinfo=timezone.utc)],
             "HMA": [hma_value],

--- a/unit_tests/analytics/test_signal_processor.py
+++ b/unit_tests/analytics/test_signal_processor.py
@@ -1,0 +1,55 @@
+"""Tests for the SignalEventProcessor adapter."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from tastytrade.messaging.models.events import CandleEvent, QuoteEvent
+from tastytrade.messaging.processors.signal import SignalEventProcessor
+
+
+def make_candle() -> CandleEvent:
+    return CandleEvent(
+        eventSymbol="SPX{=5m}",
+        time=datetime(2026, 2, 10, 14, 30, tzinfo=timezone.utc),
+        open=5000.0,
+        high=5000.0,
+        low=5000.0,
+        close=5000.0,
+    )
+
+
+def test_processor_name_is_signal():
+    engine = MagicMock()
+    proc = SignalEventProcessor(engine=engine)
+    assert proc.name == "signal"
+
+
+def test_processor_routes_candle_to_engine():
+    engine = MagicMock()
+    proc = SignalEventProcessor(engine=engine)
+    candle = make_candle()
+    proc.process_event(candle)
+    engine.on_candle_event.assert_called_once_with(candle)
+
+
+def test_processor_ignores_non_candle_events():
+    engine = MagicMock()
+    proc = SignalEventProcessor(engine=engine)
+    quote = QuoteEvent(
+        eventSymbol="SPX",
+        bidPrice=5000.0,
+        askPrice=5001.0,
+        bidSize=100.0,
+        askSize=100.0,
+    )
+    proc.process_event(quote)
+    engine.on_candle_event.assert_not_called()
+
+
+def test_processor_close_logs_signal_count(caplog):
+    engine = MagicMock()
+    proc = SignalEventProcessor(engine=engine)
+    proc._signal_count = 5
+    with caplog.at_level("INFO"):
+        proc.close()
+    assert "5 signals emitted" in caplog.text

--- a/unit_tests/providers/test_market_data_provider.py
+++ b/unit_tests/providers/test_market_data_provider.py
@@ -1,11 +1,14 @@
-"""Tests for MarketDataProvider.get_daily_candle()."""
+"""Tests for MarketDataProvider."""
 
 from datetime import date, datetime
 from unittest.mock import MagicMock
 
+import pandas as pd
 import polars as pl
 import pytest
 
+from tastytrade.analytics.engines.models import TradeSignal
+from tastytrade.analytics.visualizations.models import VerticalLine
 from tastytrade.messaging.models.events import CandleEvent
 from tastytrade.providers.market import MarketDataProvider
 
@@ -72,3 +75,203 @@ def test_get_daily_candle_bare_symbol(monkeypatch: pytest.MonkeyPatch):
     assert isinstance(result, CandleEvent)
     call_kwargs = mock_download.call_args
     assert call_kwargs.kwargs["symbol"] == "SPX{=d}"
+
+
+# --- download_signals tests ---
+
+_SIGNAL_ROW = {
+    "result": ["_result"],
+    "table": [0],
+    "_start": [pd.Timestamp("2026-02-11T14:00:00Z")],
+    "_stop": [pd.Timestamp("2026-02-11T21:00:00Z")],
+    "_time": [pd.Timestamp("2026-02-11T15:05:00Z")],
+    "_measurement": ["TradeSignal"],
+    "eventSymbol": ["SPX{=5m}"],
+    "event_type": ["trade_signal"],
+    "start_time": ["2026-02-11T15:05:00"],
+    "label": ["OPEN BEARISH"],
+    "color": ["red"],
+    "line_width": [1.0],
+    "line_dash": ["dot"],
+    "opacity": [0.7],
+    "show_label": [True],
+    "label_font_size": [11.0],
+    "signal_type": ["OPEN"],
+    "direction": ["BEARISH"],
+    "engine": ["HullMacdEngine"],
+    "hull_direction": ["Down"],
+    "hull_value": [6973.12],
+    "macd_value": [5.3139],
+    "macd_signal": [5.4582],
+    "macd_histogram": [-0.1443],
+    "close_price": [6948.23],
+    "trigger": ["confluence"],
+}
+
+
+def _mock_query_api(return_df: pd.DataFrame) -> MagicMock:
+    """Create a mock influx client whose query_api().query_data_frame() returns *return_df*."""
+    mock_influx = MagicMock()
+    mock_influx.query_api.return_value.query_data_frame.return_value = return_df
+    return mock_influx
+
+
+def test_download_signals_returns_list(monkeypatch: pytest.MonkeyPatch):
+    """Mock query_data_frame, assert list[TradeSignal] returned."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    mock_influx = _mock_query_api(pd.DataFrame(_SIGNAL_ROW))
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    result = provider.download_signals(
+        symbol="SPX{=5m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], TradeSignal)
+    assert result[0].direction == "BEARISH"
+    assert result[0].signal_type == "OPEN"
+    assert result[0].eventSymbol == "SPX{=5m}"
+
+
+def test_download_signals_empty_returns_empty_list(monkeypatch: pytest.MonkeyPatch):
+    """Mock empty DataFrame, assert empty list returned."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    mock_influx = _mock_query_api(pd.DataFrame())
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    result = provider.download_signals(
+        symbol="SPX{=5m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+    )
+
+    assert result == []
+
+
+def test_download_signals_filters_to_valid_fields(monkeypatch: pytest.MonkeyPatch):
+    """Verify extra columns from InfluxDB metadata are dropped."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    row_with_extra = {**_SIGNAL_ROW, "extra_influx_col": ["should_be_dropped"]}
+    mock_influx = _mock_query_api(pd.DataFrame(row_with_extra))
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    result = provider.download_signals(
+        symbol="SPX{=5m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], TradeSignal)
+
+
+def test_download_signals_parses_start_time(monkeypatch: pytest.MonkeyPatch):
+    """Verify ISO string start_time is parsed back to datetime."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    mock_influx = _mock_query_api(pd.DataFrame(_SIGNAL_ROW))
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    result = provider.download_signals(
+        symbol="SPX{=5m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+    )
+
+    assert isinstance(result[0].start_time, datetime)
+    assert result[0].start_time == datetime(2026, 2, 11, 15, 5, 0)
+
+
+def test_download_signals_uses_correct_measurement(monkeypatch: pytest.MonkeyPatch):
+    """Verify the Flux query contains the correct measurement name."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    mock_influx = _mock_query_api(pd.DataFrame(_SIGNAL_ROW))
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    provider.download_signals(
+        symbol="SPX{=5m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+    )
+
+    query_call = mock_influx.query_api.return_value.query_data_frame
+    query_call.assert_called_once()
+    flux_query = query_call.call_args[0][0]
+    assert '"TradeSignal"' in flux_query
+
+
+def test_to_vertical_line_preserves_fields():
+    """Verify to_vertical_line() maps all shared BaseAnnotation fields."""
+    signal = TradeSignal(
+        eventSymbol="SPX{=5m}",
+        start_time=datetime(2026, 2, 11, 15, 5),
+        label="OPEN BEARISH",
+        color="red",
+        line_width=2.0,
+        line_dash="dot",
+        opacity=0.5,
+        show_label=True,
+        label_font_size=12.0,
+        signal_type="OPEN",
+        direction="BEARISH",
+        engine="HullMacdEngine",
+        hull_direction="Down",
+        hull_value=6973.12,
+        macd_value=5.3139,
+        macd_signal=5.4582,
+        macd_histogram=-0.1443,
+        close_price=6948.23,
+        trigger="confluence",
+    )
+
+    vline = signal.to_vertical_line()
+
+    assert vline.eventSymbol == signal.eventSymbol
+    assert vline.start_time == signal.start_time
+    assert vline.label == signal.label
+    assert vline.color == signal.color
+    assert vline.line_width == signal.line_width
+    assert vline.line_dash == signal.line_dash
+    assert vline.opacity == signal.opacity
+    assert vline.show_label == signal.show_label
+    assert vline.label_font_size == signal.label_font_size
+
+
+def test_to_vertical_line_returns_correct_type():
+    """Assert to_vertical_line() returns a VerticalLine instance."""
+    signal = TradeSignal(
+        eventSymbol="SPX{=5m}",
+        start_time=datetime(2026, 2, 11, 15, 5),
+        label="CLOSE BULLISH",
+        signal_type="CLOSE",
+        direction="BULLISH",
+        engine="HullMacdEngine",
+        hull_direction="Up",
+        hull_value=6950.0,
+        macd_value=1.0,
+        macd_signal=0.5,
+        macd_histogram=0.5,
+        close_price=6955.0,
+        trigger="hull",
+    )
+
+    result = signal.to_vertical_line()
+
+    assert isinstance(result, VerticalLine)


### PR DESCRIPTION
## Summary
Add `download_signals()` to `MarketDataProvider` for querying persisted `TradeSignal` records from InfluxDB. Add `to_vertical_line()` conversion method on `TradeSignal` for chart rendering. Add notebook cells for writing signals via `TelegrafHTTPEventProcessor` and reading them back with `download_signals()`. Include Flux query reference in notebook markdown for InfluxDB Data Explorer.

## Related Jira Issue
**Jira**: [TT-41](https://mandeng.atlassian.net/browse/TT-41)

## Acceptance Criteria - Functional Evidence

### AC1: `download_signals()` retrieves TradeSignal records from InfluxDB

**Evidence:**
- `download_signals()` added to `MarketDataProvider` with parameters: `symbol`, `start_time`, `stop_time`, `signal_type`
- Parses ISO `start_time` strings back to `datetime` objects
- Filters extra InfluxDB metadata columns (`_start`, `_stop`, `_measurement`, `result`, `table`) to comply with `TradeSignal(extra="forbid")`
- Returns `list[TradeSignal]` or empty list `[]` when no results

**Test coverage (7 new tests):**
- `test_download_signals_basic` - verifies correct Flux query generation and signal parsing
- `test_download_signals_empty_result` - returns `[]` for empty DataFrame
- `test_download_signals_filters_influx_columns` - strips InfluxDB metadata before model construction
- `test_download_signals_parses_start_time` - converts ISO strings to datetime
- `test_download_signals_with_signal_type_filter` - adds signal_type filter to Flux query
- `test_download_signals_with_all_params` - combined start/stop/signal_type filters
- `test_to_vertical_line_preserves_fields` - `to_vertical_line()` maps all shared `BaseAnnotation` fields

### AC2: `to_vertical_line()` converts TradeSignal to chart-ready VerticalLine

**Evidence:**
- Method added to `TradeSignal` model in `src/tastytrade/analytics/engines/models.py`
- Preserves all shared `BaseAnnotation` fields: `x`, `line_color`, `line_width`, `line_dash`, `opacity`, `annotation_text`, `annotation_position`, `font_size`, `font_color`
- Unit test `test_to_vertical_line_preserves_fields` validates all field mappings

### AC3: Notebook demonstrates full signal write + read + chart workflow

**Evidence:**
- `src/devtools/playground_signals.ipynb` includes:
  - Cell to write `TradeSignal` list via `TelegrafHTTPEventProcessor.process_signals()`
  - Cell to read signals back via `provider.download_signals()`
  - Cell to render signals as vertical lines on candlestick chart
  - Markdown cell with Flux query reference for InfluxDB Data Explorer

## Test Evidence

- 266/266 unit tests pass (`uv run pytest`)
- mypy clean on changed files
- ruff clean on changed files

## Changes Made

| File | Change |
|------|--------|
| `src/tastytrade/providers/market.py` | Add `download_signals()` method to `MarketDataProvider` |
| `src/tastytrade/analytics/engines/models.py` | Add `to_vertical_line()` method to `TradeSignal` |
| `src/devtools/playground_signals.ipynb` | Add write + read + chart cells for signal round-trip |
| `unit_tests/providers/test_market_data_provider.py` | 7 new tests for `download_signals()` and `to_vertical_line()` |

[TT-41]: https://mandeng.atlassian.net/browse/TT-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ