### PR TITLE
TT-51: Fix TelegrafHTTPEventProcessor configuration initialization

### DIFF
--- a/src/tastytrade/messaging/processors/influxdb.py
+++ b/src/tastytrade/messaging/processors/influxdb.py
@@ -14,13 +14,20 @@ logger = logging.getLogger(__name__)
 class TelegrafHTTPEventProcessor(BaseEventProcessor):
     name = "telegraf_http"
 
-    def __init__(self):
+    def __init__(
+        self,
+        url: str = "http://influxdb:8086",
+        token: str | None = None,
+        org: str | None = None,
+        bucket: str | None = None,
+    ):
         self.client = InfluxDBClient(
-            url="http://influxdb:8086",
-            token=os.environ["INFLUX_DB_TOKEN"],
-            org=os.environ["INFLUX_DB_ORG"],
+            url=url,
+            token=token or os.environ.get("INFLUX_DB_TOKEN", ""),
+            org=org or os.environ.get("INFLUX_DB_ORG", ""),
         )
         self.write_api = self.client.write_api()
+        self.bucket = bucket or os.environ.get("INFLUX_DB_BUCKET", "")
 
     def process_event(self, event: BaseEvent) -> None:
         point = Point(event.__class__.__name__)
@@ -37,7 +44,7 @@ class TelegrafHTTPEventProcessor(BaseEventProcessor):
             ]:
                 point.field(attr, value)
 
-        self.write_api.write(bucket=os.environ["INFLUX_DB_BUCKET"], record=point)
+        self.write_api.write(bucket=self.bucket, record=point)
 
     def close(self) -> None:
         """Flush pending writes and close the InfluxDB client."""

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -271,7 +271,14 @@ async def _run_subscription_once(
             raise RuntimeError("DXLink router.handler mapping not initialized")
 
         for handler in handlers_dict.values():
-            handler.add_processor(TelegrafHTTPEventProcessor())
+            handler.add_processor(
+                TelegrafHTTPEventProcessor(
+                    url=config.get("INFLUX_DB_URL", "http://influxdb:8086"),
+                    token=config.get("INFLUX_DB_TOKEN"),
+                    org=config.get("INFLUX_DB_ORG"),
+                    bucket=config.get("INFLUX_DB_BUCKET"),
+                )
+            )
             handler.add_processor(RedisEventProcessor())
 
         logger.info("Processors attached to all handlers")


### PR DESCRIPTION
## Summary
Fixed critical bug where subscription service was failing on startup with KeyError for InfluxDB configuration variables.

## Related Jira Issue
**Jira**: [TT-51](https://mandeng.atlassian.net/browse/TT-51)

## Changes
- Modified `TelegrafHTTPEventProcessor.__init__()` to accept configuration parameters (url, token, org, bucket)
- Updated `orchestrator.py` to pass config values from `RedisConfigManager` when instantiating the processor
- Changed processor to store bucket value as instance variable

## Technical Details
The processor was trying to access InfluxDB configuration directly from `os.environ`, but these values were stored in Redis by `RedisConfigManager` and not available in the OS environment. This caused immediate failure on startup and an infinite retry loop.

## Test Evidence
### Before Fix
- Subscription service failed immediately with: `KeyError: 'INFLUX_DB_TOKEN'`
- Service entered infinite retry loop
- No data processing occurred

### After Fix
- ✅ Subscription service starts successfully
- ✅ Configuration properly loaded from Redis
- ✅ All processors attached without errors
- ✅ Market data subscriptions established
- ✅ Data processing working correctly

### Functional Evidence
Tested with command:
```bash
uv run tasty-subscription run --symbols "AAPL" --intervals 1d --start-date 2026-02-15 --log-level INFO
```

**Results**:
- Service initialized successfully
- All channel listeners started (Control, Quote, Trade, Greeks, Profile, Summary, Candle)
- Subscriptions established for ticker and candle feeds
- No KeyError exceptions
- Data processing active

### Regression Testing
- ✅ Existing processor functionality unchanged
- ✅ RedisEventProcessor still works correctly
- ✅ All channel handlers operational
- ✅ No impact on other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TT-51]: https://mandeng.atlassian.net/browse/TT-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ