### PR TITLE
Fix devcontainer plugin path compatibility and update deps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
     "allow": [
       "Bash(uv --version:*)",
       "Bash(tree:*)",
-      "Bash(env)"
+      "Bash(env)",
+      "mcp__ide__executeCode"
     ],
     "deny": [
       "Skill(jira-operations)",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,11 +15,14 @@ services:
       - ~/.ssh:/home/developer/.ssh:ro
       # Persist uv cache between container rebuilds
       - uv-cache:/home/developer/.cache/uv
-      # Share Claude authentication (read-write so CLI can refresh tokens)
-      - ~/.claude/.credentials.json:/home/developer/.claude/.credentials.json
+      # Share full Claude config directory (plugins, marketplaces, credentials)
+      - ~/.claude:/home/developer/.claude
       - ~/.claude.json:/home/developer/.claude.json
       # Docker-from-Docker: mount host Docker socket
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      # Host home directory for Claude plugin path compatibility
+      HOST_HOME: "${HOME}"
     working_dir: /workspace
     command: /bin/bash
     stdin_open: true

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -240,6 +240,28 @@ EOF
     fi
 }
 
+# Create symlinks so Claude plugin paths from host resolve in container
+# Claude Code writes absolute paths (with $HOME) into plugin config files.
+# When $HOME differs between host and container, those paths break.
+# This creates a symlink so paths written on the host still resolve here.
+fix_claude_plugin_paths() {
+    if [ -z "$HOST_HOME" ] || [ "$HOST_HOME" = "$HOME" ]; then
+        echo "  No HOST_HOME mismatch, skipping"
+        return 0
+    fi
+
+    echo "Creating symlink for Claude plugin path compatibility..."
+    if [ -d "$HOME/.claude" ] && [ ! -e "$HOST_HOME/.claude" ]; then
+        sudo mkdir -p "$HOST_HOME"
+        sudo ln -sfn "$HOME/.claude" "$HOST_HOME/.claude"
+        echo "  Linked $HOST_HOME/.claude -> $HOME/.claude"
+    elif [ -L "$HOST_HOME/.claude" ]; then
+        echo "  Symlink already exists at $HOST_HOME/.claude"
+    else
+        echo "  Skipped: $HOST_HOME/.claude already exists"
+    fi
+}
+
 # Fix Docker socket permissions for Docker-from-Docker
 fix_docker_socket_permissions() {
     if [ ! -S /var/run/docker.sock ]; then
@@ -331,11 +353,15 @@ echo ""
 add_convenience_aliases
 echo ""
 
-# Step 7: Fix Docker socket permissions for Docker-from-Docker (MCP servers)
+# Step 7: Fix Claude plugin path compatibility between host and container
+fix_claude_plugin_paths
+echo ""
+
+# Step 8: Fix Docker socket permissions for Docker-from-Docker (MCP servers)
 fix_docker_socket_permissions
 echo ""
 
-# Step 8: Initialize quber-workflow (Claude settings, hooks, skills)
+# Step 9: Initialize quber-workflow (Claude settings, hooks, skills)
 initialize_quber_workflow
 echo ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -3512,7 +3512,7 @@ wheels = [
 
 [[package]]
 name = "quber-workflow"
-version = "0.3.0"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3520,9 +3520,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/91/885eb99a1d6f9e3571f79201cfea3015a93713c3f6c9245ef39af37dffd0/quber_workflow-0.3.0.tar.gz", hash = "sha256:60034a4f7a6a205ae0964c1da80c8ad5c0e5e1bc3a5c943dc0276ef8b7a2fd0d", size = 79781, upload-time = "2026-02-17T01:15:14.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/04/5a570ee2352dff54066c2cf31ff30764422af7204f9a7fe4917a96e39e4e/quber_workflow-0.3.2.tar.gz", hash = "sha256:e11a3fe4a3f9b2f369addfa400acae2db2bb73b43a84aee9417377ca712d659a", size = 80421, upload-time = "2026-02-18T05:30:48.326Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/7e/51c8cff040436db5a6485d6ed36268e87b2534163c79b0dbb986ca2c244a/quber_workflow-0.3.0-py3-none-any.whl", hash = "sha256:a87b6e9dc9eec1cb0e417cd70e6299fd6d9aa27382cdca2a0fd7a5254ba464dc", size = 109777, upload-time = "2026-02-17T01:15:13.143Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5c/ac4243efa9b178afbe5498bc041a10cc14898d8fd82410a3455ad2372075/quber_workflow-0.3.2-py3-none-any.whl", hash = "sha256:7c821e59434b1a4c3d3a045c435747db69b1aaf7f64ebbfa1ba2dc5aadccd6e8", size = 110456, upload-time = "2026-02-18T05:30:46.895Z" },
 ]
 
 [[package]]
@@ -4210,16 +4210,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.37.0"
+version = "20.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/03/a94d404ca09a89a7301a7008467aed525d4cdeb9186d262154dd23208709/virtualenv-20.38.0.tar.gz", hash = "sha256:94f39b1abaea5185bf7ea5a46702b56f1d0c9aa2f41a6c2b8b0af4ddc74c10a7", size = 5864558, upload-time = "2026-02-19T07:48:02.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/394801755d4c8684b655d35c665aea7836ec68320304f62ab3c94395b442/virtualenv-20.38.0-py3-none-any.whl", hash = "sha256:d6e78e5889de3a4742df2d3d44e779366325a90cf356f15621fddace82431794", size = 5837778, upload-time = "2026-02-19T07:47:59.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Share full `~/.claude` directory in container instead of just credentials file, enabling plugins/marketplace access
- Add `HOST_HOME` environment variable and symlink resolution in `startup.sh` so Claude plugin paths written on the host resolve correctly inside the container
- Update `quber-workflow` to 0.3.2 and `virtualenv` to 20.38.0
- Allow `mcp__ide__executeCode` in Claude settings

## Test Plan

- Rebuild devcontainer and verify Claude plugins load correctly
- Verify `startup.sh` creates symlink when HOST_HOME differs from HOME
- Verify `uv sync` completes with updated lockfile