### PR TITLE
TT-58: Add Ctrl+C copy metadata as JSON in architecture playground

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,22 @@ You MUST delegate ALL GitHub operations to the github-workflow agent. No excepti
 
 See [docs/PR_EVIDENCE_GUIDELINES.md](docs/PR_EVIDENCE_GUIDELINES.md) and [docs/PR_EVIDENCE_CHECKLIST.md](docs/PR_EVIDENCE_CHECKLIST.md) for evidence standards.
 
+### Architecture Documentation — MANDATORY GATE
+
+Changes that introduce, modify, or remove architectural components MUST be reflected in the [Architecture Playground](docs/architecture-map/architecture_playground.html) before the PR is created (unless the user explicitly directs otherwise).
+
+**Why:** The playground is the visual source of truth for how concepts are organized. It serves as a gate-check — if the design cannot be clearly represented in the map, it has not been thought through.
+
+**Rules:**
+
+1. **Propose visually first.** When a change touches architectural components (new modules, renamed layers, altered data flows, added/removed services), update the playground's `nodes`, `edges`, and `insights` arrays to reflect the proposed design. Present this to the user for visual review and approval before proceeding with implementation.
+2. **Code must match the map.** At PR creation time, the architecture playground MUST precisely reflect the implemented code. What is on paper must match what is in the codebase — no stale nodes, no missing edges, no outdated layer assignments.
+3. **Commit together.** Changes to `architecture_playground.html` and `architecture_layouts.json` MUST be included in the same PR as the code they describe. Architecture and implementation ship as one unit.
+4. **Insights are required.** Every new or significantly modified node must include an insight capturing the design rationale (author: **Mandeng** for user decisions, **Claude** for implementation analysis).
+
+**Workflow:**
+- Detect architectural scope → update playground → present for review → implement code → verify map matches code → include in PR
+
 ### Branch & Commit Rules
 
 **Branching:**
@@ -169,3 +185,4 @@ Bare commands (`pytest`, `mypy`, `ruff`) only work inside an activated `.venv`. 
 - [docs/GITHUB_WORKFLOW_SPEC.md](docs/GITHUB_WORKFLOW_SPEC.md) - GitHub workflow standards
 - [docs/PR_EVIDENCE_GUIDELINES.md](docs/PR_EVIDENCE_GUIDELINES.md) - PR evidence standards
 - [docs/PR_EVIDENCE_CHECKLIST.md](docs/PR_EVIDENCE_CHECKLIST.md) - PR evidence checklist
+- [docs/architecture-map/](docs/architecture-map/) - Architecture playground and visual concept map

--- a/docs/architecture-map/README.md
+++ b/docs/architecture-map/README.md
@@ -42,6 +42,7 @@ If using VS Code Remote SSH, the port will auto-forward — check the **Ports** 
 | **Shift+Click** nodes | Add/remove from group |
 | **Shift+Drag** canvas | Lasso select multiple nodes |
 | **Cmd/Ctrl+A** | Select all visible nodes |
+| **Cmd/Ctrl+C** | Copy selected node(s) metadata as JSON |
 | Drag any grouped node | Moves the entire group |
 | **Escape** or click canvas | Clear group |
 

--- a/docs/architecture-map/architecture_playground.html
+++ b/docs/architecture-map/architecture_playground.html
@@ -1586,6 +1586,45 @@ function updateGroupVisuals() {
   }
 }
 
+function getNodeMetadata(nodeId) {
+  const node = nodes.find(n => n.id === nodeId);
+  if (!node) return null;
+  const meta = { id: node.id, label: node.label, type: node.type };
+  if (node.file) meta.file = node.file;
+  if (node.layer) meta.layer = node.layer;
+  if (node.badge) meta.badge = node.badge;
+  if (node.desc) meta.description = node.desc;
+  if (node.details) meta.details = node.details;
+  if (node.code) meta.code = node.code;
+  if (node.insights?.length) meta.insights = node.insights;
+  const incoming = edges.filter(e => e.to === nodeId).map(e => {
+    const src = nodes.find(n => n.id === e.from);
+    return { from: src?.label || e.from, label: e.label || null };
+  });
+  const outgoing = edges.filter(e => e.from === nodeId).map(e => {
+    const tgt = nodes.find(n => n.id === e.to);
+    return { to: tgt?.label || e.to, label: e.label || null };
+  });
+  if (incoming.length) meta.incoming = incoming;
+  if (outgoing.length) meta.outgoing = outgoing;
+  return meta;
+}
+
+async function copySelectedMetadata() {
+  let metadata;
+  if (groupSelected.size > 0) {
+    metadata = [...groupSelected].map(getNodeMetadata).filter(Boolean);
+  } else if (selectedNode) {
+    metadata = getNodeMetadata(selectedNode);
+  } else {
+    return false;
+  }
+  await navigator.clipboard.writeText(JSON.stringify(metadata, null, 2));
+  const count = groupSelected.size || 1;
+  showToast(`Copied ${count} node${count > 1 ? 's' : ''} metadata`);
+  return true;
+}
+
 // Lasso state
 let isLassoing = false;
 let lassoStartX, lassoStartY; // screen coords
@@ -2660,6 +2699,14 @@ window.addEventListener('keydown', (e) => {
     nodes.forEach(n => { if (layerVisibility[n.layer]) groupSelected.add(n.id); });
     updateGroupVisuals();
     return;
+  }
+  if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT' || e.target.tagName === 'TEXTAREA') return;
+    if (groupSelected.size > 0 || selectedNode) {
+      e.preventDefault();
+      copySelectedMetadata();
+      return;
+    }
   }
   // Ctrl+Z / Cmd+Z = undo, Ctrl+Shift+Z / Cmd+Shift+Z = redo
   if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); return; }


### PR DESCRIPTION
## Summary

Add keyboard shortcut (Ctrl/Cmd+C) to the architecture playground that copies selected node metadata as JSON to the clipboard. This enables users to quickly extract structured node data (properties, edges, insights) for use in documentation, prompts, or external tools.

## Related Jira Issue
**Jira**: [TT-58](https://mandeng.atlassian.net/browse/TT-58)

## Acceptance Criteria - Functional Evidence

### AC1: Ctrl/Cmd+C copies selected node metadata as JSON

**Functional Behavior:**

When a single node is selected and Ctrl/Cmd+C is pressed, a JSON object is copied to the clipboard containing the node's id, label, type, file, layer, badge, description, details, code, insights, and incoming/outgoing edges. When multiple nodes are group-selected, a JSON array of metadata objects is copied.

**Implementation Details:**

```javascript
// getNodeMetadata(nodeId) extracts:
// - Core properties: id, label, type, file, layer, badge, description, details, code, insights
// - Relationships: incoming edges (with source label), outgoing edges (with target label)

// copySelectedMetadata() handles:
// - groupSelected.size > 0 → maps all selected nodes → JSON array
// - selectedNode only → single JSON object
// - Uses navigator.clipboard.writeText() for async clipboard write
// - Shows toast: "Copied N node(s) metadata"
```

**Evidence:**
- `getNodeMetadata()` extracts all relevant node properties conditionally (only includes non-empty fields)
- Edge relationships resolved to human-readable labels (not raw IDs)
- JSON formatted with 2-space indentation for readability
- Toast notification provides visual feedback on copy action
- Input fields (INPUT, SELECT, TEXTAREA) are not intercepted, preserving normal copy behavior

### AC2: Keyboard shortcut documented in README

**Evidence:**
- Added `| **Cmd/Ctrl+C** | Copy selected node(s) metadata as JSON |` to the keyboard shortcuts table in `docs/architecture-map/README.md`

## Test Evidence

- Pre-commit hooks passed (trim trailing whitespace, end-of-file fixer, YAML/TOML checks)
- No Python source files changed, so ruff/mypy/pytest not applicable
- Changes are limited to HTML/JS (architecture playground) and Markdown (README, CLAUDE.md)

## Changes Made

- **`docs/architecture-map/architecture_playground.html`**: Added `getNodeMetadata()` helper function that extracts node properties and resolves edge relationships to labels; added `copySelectedMetadata()` async function that writes JSON to clipboard via `navigator.clipboard.writeText()`; added Ctrl/Cmd+C keyboard handler in the `keydown` event listener that skips input fields and delegates to `copySelectedMetadata()`
- **`docs/architecture-map/README.md`**: Added Cmd/Ctrl+C entry to the keyboard shortcuts documentation table
- **`CLAUDE.md`**: Added "Architecture Documentation -- MANDATORY GATE" section establishing the playground as visual source of truth, and added architecture-map reference to the Reference Documents section

[TT-58]: https://mandeng.atlassian.net/browse/TT-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ