### PR TITLE
TT-62: Deterministic option strategy classification engine

### DIFF
--- a/config/strategy_health.toml
+++ b/config/strategy_health.toml
@@ -1,0 +1,23 @@
+# Strategy health monitoring thresholds.
+# Each strategy type can override the [default] section.
+# Strategy keys use snake_case matching StrategyType enum names.
+
+[default]
+dte_warning = 21
+dte_critical = 7
+max_loss_warning = 0.75
+max_loss_critical = 0.90
+delta_drift_warning = 0.30
+
+[iron_condor]
+dte_warning = 30
+dte_critical = 14
+delta_drift_warning = 0.20
+
+[short_strangle]
+dte_warning = 25
+dte_critical = 10
+delta_drift_warning = 0.25
+
+[jade_lizard]
+delta_drift_warning = 0.35

--- a/config/strategy_health.toml
+++ b/config/strategy_health.toml
@@ -3,20 +3,20 @@
 # Strategy keys use snake_case matching StrategyType enum names.
 
 [default]
-dte_warning = 21
+dte_warning = 14
 dte_critical = 7
 max_loss_warning = 0.75
 max_loss_critical = 0.90
 delta_drift_warning = 0.30
 
 [iron_condor]
-dte_warning = 30
-dte_critical = 14
+dte_warning = 14
+dte_critical = 7
 delta_drift_warning = 0.20
 
 [short_strangle]
-dte_warning = 25
-dte_critical = 10
+dte_warning = 14
+dte_critical = 7
 delta_drift_warning = 0.25
 
 [jade_lizard]

--- a/docs/architecture-map/architecture_playground.html
+++ b/docs/architecture-map/architecture_playground.html
@@ -910,6 +910,7 @@ const LAYERS = {
   processor:   { label: 'Processors',  color: '#3fb950' },
   persistence: { label: 'Persistence', color: '#f85149' },
   signal:      { label: 'Signal',      color: '#39d2c0' },
+  analytics:   { label: 'Analytics',   color: '#e8b004' },
   config:      { label: 'Config',      color: '#f778ba' },
 };
 
@@ -1343,6 +1344,93 @@ const nodes = [
     connections: []
   },
 
+  // ── ANALYTICS LAYER (TT-62: Strategy Engine) ──
+  { id: 'acct-publisher', x: 1700, y: -80, layer: 'analytics',
+    label: 'AccountStreamPublisher', type: 'Redis Writer',
+    badge: 'TT-62',
+    file: 'accounts/publisher.py',
+    desc: 'Publishes account events (positions, balances, instruments) to Redis HSET for on-demand reads. Single responsibility: account data → Redis.',
+    details: `Three Redis HSET keys:\n• tastytrade:positions — keyed by streamer_symbol\n• tastytrade:balances — keyed by account\n• tastytrade:instruments — keyed by symbol\n\nPositions: removes closed (qty=0) positions.\nInstruments: accepts any instrument model type\n(EquityOptionInstrument, FutureOptionInstrument, etc.)`,
+    code: `class AccountStreamPublisher:\n  POSITIONS_KEY = "tastytrade:positions"\n  BALANCES_KEY = "tastytrade:balances"\n  INSTRUMENTS_KEY = "tastytrade:instruments"\n\n  async def publish_position(self, position):\n    if position.quantity == 0.0:\n      await redis.hdel(POSITIONS_KEY, key)\n    else:\n      await redis.hset(POSITIONS_KEY, key, json)\n\n  async def publish_instruments(self, instruments):\n    for inst in instruments:\n      await redis.hset(INSTRUMENTS_KEY, inst.symbol, json)`,
+    insights: [
+      { author: 'claude', text: 'Instruments are keyed by the Position symbol (OCC format for equity options, broker format for futures). This allows PositionMetricsReader to look up instrument data by the same key used for positions.' },
+    ],
+    connections: ['redis']
+  },
+  { id: 'pos-reader', x: 1700, y: 1140, layer: 'analytics',
+    label: 'PositionMetricsReader', type: 'Redis Consumer',
+    badge: 'TT-62',
+    file: 'analytics/positions.py',
+    desc: 'Pure Redis consumer — reads positions, quotes, Greeks, and instrument details from Redis HSET. Joins via MetricsTracker into a DataFrame. Provides strategy classification and health monitoring.',
+    details: `read() loads from 4 Redis HSETs:\n1. tastytrade:positions → Position models\n2. tastytrade:latest:QuoteEvent → QuoteEvent\n3. tastytrade:latest:GreeksEvent → GreeksEvent\n4. tastytrade:instruments → instrument metadata\n\nProperties:\n• position_metrics_df — raw joined DataFrame\n• summary — grouped by underlying (net delta, legs)\n• strategies → list[Strategy] via StrategyClassifier\n• strategy_summary → DataFrame with Greeks, DTE, P&L, health`,
+    code: `class PositionMetricsReader:\n  async def read(self) -> pd.DataFrame:\n    positions = redis.hgetall(POSITIONS_KEY)\n    tracker = MetricsTracker()\n    tracker.load_positions(positions)\n    # Apply quotes + Greeks\n    for q in redis.hgetall(QUOTES_KEY): ...\n    for g in redis.hgetall(GREEKS_KEY): ...\n    # Load instruments\n    self.instruments = redis.hgetall(INSTRUMENTS_KEY)\n    return tracker.df\n\n  @property\n  def strategies(self) -> list[Strategy]:\n    return StrategyClassifier().classify(\n      self.tracker.securities, self.instruments)`,
+    insights: [
+      { author: 'claude', text: 'No API calls, no socket connections. Pure consumer pattern — reads what AccountStreamPublisher wrote. Can be called from CLI, notebook, or dashboard without starting any streaming infrastructure.' },
+      { author: 'xmandeng', text: 'This is the read side of the account data CQRS pattern. The publisher writes; the reader reads. They never share state directly — Redis is the contract boundary.' },
+    ],
+    connections: ['strategy-classifier', 'metrics-tracker']
+  },
+  { id: 'strategy-classifier', x: 1700, y: 1320, layer: 'analytics',
+    label: 'StrategyClassifier', type: 'Classification Engine',
+    badge: 'TT-62',
+    file: 'analytics/strategies/classifier.py',
+    desc: 'Greedy pattern matching engine. Groups positions by underlying, applies matchers from most-complex (4-leg) to simplest (1-leg), consuming matched legs at each step.',
+    details: `classify(securities, instruments) → list[Strategy]:\n\n1. Build ParsedLeg for each SecurityMetrics + instrument data\n2. Group by underlying_symbol\n3. For each underlying: greedy match (most complex first)\n4. Consume matched legs, repeat until no more matches\n5. Remaining legs → single-leg strategies\n\nbuild_parsed_leg() joins:\n• SecurityMetrics (position + real-time market data)\n• Instrument metadata (strike, expiration, option type)\n• Contract multiplier (shares-per-contract or notional-multiplier)`,
+    code: `class StrategyClassifier:\n  def classify(self, securities, instruments):\n    all_legs = [build_parsed_leg(s, instruments)\n                for s in securities.values()]\n    by_underlying = group_by(all_legs, key=underlying)\n\n    for underlying, legs in by_underlying.items():\n      remaining = list(legs)\n      for matcher in MULTI_LEG_MATCHERS:\n        while remaining:\n          result = matcher(remaining)\n          if result is None: break\n          strategies.append(result)\n          remaining -= result.matched_legs\n      # Remaining → single-leg strategies\n    return strategies`,
+    insights: [
+      { author: 'claude', text: 'Greedy matching order is critical: iron condor (4 legs) must match before strangle (2 legs), otherwise the short put + short call would get consumed as a strangle leaving two orphan wings.' },
+      { author: 'claude', text: 'ParsedLeg is a frozen dataclass — once built, it flows through matchers and into Strategy objects immutably. No mutation bugs possible across the classification pipeline.' },
+    ],
+    connections: ['strategy-patterns', 'strategy-models']
+  },
+  { id: 'strategy-patterns', x: 1500, y: 1490, layer: 'analytics',
+    label: 'Pattern Matchers', type: 'Match Functions',
+    badge: 'TT-62',
+    file: 'analytics/strategies/patterns.py',
+    desc: '25+ pattern matchers organized by complexity. Each returns MatchResult (strategy type + consumed legs) or None. Exported as MULTI_LEG_MATCHERS list in priority order.',
+    details: `Priority order (greedy — most legs first):\n\n4-leg: Iron Condor, Iron Butterfly, Covered Jade Lizard,\n       Big Lizard, Call/Put Butterfly\n3-leg: Jade Lizard, Collar\n2-leg (stock+option): Covered Call, Protective Put\n2-leg (same exp, same type): Bull/Bear Call/Put Spread\n2-leg (same exp, diff type): Straddle, Strangle, Synthetic\n2-leg (diff exp): Calendar, Diagonal\n1-leg: Long/Short Stock/Call/Put, Naked Call/Put\n\nHelpers: same_expiration(), same_abs_quantity()`,
+    code: `@dataclass(frozen=True)\nclass MatchResult:\n  strategy_type: StrategyType\n  matched_legs: tuple[ParsedLeg, ...]\n\ndef match_iron_condor(legs) -> MatchResult | None:\n  options = [l for l in legs if l.is_option]\n  for combo in combinations(options, 4):\n    puts = sorted([l for l in combo if l.is_put],\n                  key=lambda l: l.strike)\n    calls = sorted([l for l in combo if l.is_call],\n                   key=lambda l: l.strike)\n    if (len(puts)==2 and len(calls)==2\n        and puts[0].is_long and puts[1].is_short\n        and calls[0].is_short and calls[1].is_long\n        and same_expiration(combo)\n        and same_abs_quantity(combo)):\n      return MatchResult(IRON_CONDOR, tuple(combo))\n  return None\n\nMULTI_LEG_MATCHERS = [\n  match_iron_condor, match_iron_butterfly,\n  match_jade_lizard, match_collar,\n  match_covered_call, match_protective_put,\n  match_vertical_spread, match_straddle_strangle,\n  ...\n]`,
+    insights: [
+      { author: 'claude', text: 'Uses combinations() from itertools to try all possible leg groupings. For 4-leg patterns on an underlying with 6 positions, that is C(6,4)=15 attempts — fast enough for real portfolios but would not scale to thousands of positions per underlying.' },
+      { author: 'xmandeng', text: 'Jade lizard recognition was the key driver for building this. The LLM-based classifier kept misidentifying jade lizards as collars or strangles. Deterministic pattern matching gets it right every time.' },
+    ],
+    connections: []
+  },
+  { id: 'strategy-models', x: 1900, y: 1490, layer: 'analytics',
+    label: 'Strategy Models', type: 'Dataclasses',
+    badge: 'TT-62',
+    file: 'analytics/strategies/models.py',
+    desc: 'StrategyType enum (30+ types), ParsedLeg (frozen dataclass enriched with instrument metadata), Strategy (dataclass with computed Greeks, P&L, and DTE properties).',
+    details: `StrategyType enum:\n• Delta-1: Long/Short Stock, Crypto, Future\n• Single-leg: Long/Naked Call/Put\n• Covered: Covered Call, Protective Put, Collar\n• Verticals: Bull/Bear Call/Put Spread\n• Straddle/Strangle: Long/Short variants\n• Tastytrade: Jade Lizard, Big Lizard\n• Iron: Iron Condor, Iron Butterfly\n• Other: Butterfly, Calendar, Diagonal, Ratio, Synthetic\n\nParsedLeg (frozen):\n• Position: symbol, underlying, instrument_type, signed_quantity\n• Instrument: option_type, strike, expiration, DTE, multiplier\n• Market: delta, gamma, theta, vega, mid_price\n• Entry: average_open_price\n\nStrategy computed properties:\n• net_delta, net_gamma, net_theta (dollar-scaled), net_vega\n• max_profit, max_loss (dollar amounts via entry prices)\n• days_to_expiration, nearest_expiration, width`,
+    code: `class Strategy:\n  strategy_type: StrategyType\n  underlying: str\n  legs: tuple[ParsedLeg, ...]\n\n  @property\n  def net_theta(self) -> Optional[float]:\n    # Dollar-denominated: theta × qty × multiplier\n    return round(sum(\n      leg.theta * leg.signed_quantity * float(leg.multiplier)\n      for leg in self.legs if leg.theta\n    ), 2)\n\n  @property\n  def max_profit(self) -> Optional[Decimal]:\n    return compute_max_profit(self)  # entry-price based`,
+    insights: [
+      { author: 'claude', text: 'max_profit and max_loss use average_open_price (actual fill price) — not the current mark. Max profit is fixed at entry and does not change with market moves. This matches how brokers report it.' },
+      { author: 'claude', text: 'net_theta is dollar-denominated by multiplying by the contract multiplier. A /ZB put with theta=-0.03 and multiplier=1000 contributes $30/day of theta, not $0.03.' },
+    ],
+    connections: []
+  },
+  { id: 'strategy-health', x: 1700, y: 1650, layer: 'analytics',
+    label: 'StrategyHealthMonitor', type: 'Health Monitor',
+    badge: 'TT-62',
+    file: 'analytics/strategies/health.py',
+    desc: 'Monitors strategy health against TOML-configurable thresholds. Per-strategy-type overrides for DTE warnings, delta drift, and max loss proximity.',
+    details: `HealthThresholds (frozen dataclass):\n• dte_warning: 14 days\n• dte_critical: 7 days\n• delta_drift_warning: 0.30\n• max_loss_warning: 0.75 (future)\n\nChecks:\n1. DTE — warning/critical thresholds\n2. Delta drift — |net_delta| exceeds threshold\n   (exempt: delta-1, covered strategies)\n3. Max loss proximity (placeholder for future P&L tracking)\n\nConfig: config/strategy_health.toml\nPer-type overrides: iron_condor, short_strangle, jade_lizard`,
+    code: `class StrategyHealthMonitor:\n  def __init__(self, config_path=None):\n    self.load_config()  # TOML → thresholds\n\n  def thresholds_for(self, strategy_type):\n    key = strategy_type.name.lower()\n    return self.thresholds_map.get(\n      key, self.default_thresholds)\n\n  def check(self, strategy) -> list[HealthAlert]:\n    thresholds = self.thresholds_for(strategy.strategy_type)\n    # DTE check\n    if dte <= thresholds.dte_critical: → CRITICAL\n    elif dte <= thresholds.dte_warning: → WARNING\n    # Delta drift (skip delta-exempt types)\n    if |net_delta| > thresholds.delta_drift_warning: → WARNING`,
+    insights: [
+      { author: 'claude', text: 'Delta-1 strategies (Long Stock, Covered Call, etc.) are exempt from delta drift warnings. Their high absolute delta is inherent to the strategy, not a risk signal — flagging them would be noise.' },
+      { author: 'xmandeng', text: 'TOML-based thresholds let me tune per-strategy-type without code changes. Iron condors get a tighter delta drift threshold (0.20) than strangles (0.25) because condors are meant to be more neutral.' },
+    ],
+    connections: ['health-config']
+  },
+  { id: 'health-config', x: 1900, y: 1650, layer: 'config',
+    label: 'strategy_health.toml', type: 'TOML Config',
+    badge: 'TT-62',
+    file: 'config/strategy_health.toml',
+    desc: 'Per-strategy-type health thresholds. Default section as fallback, per-type sections override specific fields.',
+    details: `[default]\ndte_warning = 14\ndte_critical = 7\ndelta_drift_warning = 0.30\n\n[iron_condor]\ndelta_drift_warning = 0.20\n\n[short_strangle]\ndelta_drift_warning = 0.25\n\n[jade_lizard]\ndelta_drift_warning = 0.35\n\nStrategies not listed inherit from [default].`,
+    connections: []
+  },
+
   // ── ORCHESTRATION LAYER ──
   { id: 'sub-orchestrator', x: 1500, y: 230, layer: 'routing',
     label: 'SubscriptionOrchestrator', type: 'Async Coordinator',
@@ -1491,6 +1579,17 @@ const edges = [
   { from: 'acct-streamer', to: 'tastytrade-api', label: 'streamer token', style: 'dashed' },
   { from: 'proc-metrics', to: 'metrics-tracker', label: 'on_quote / on_greeks' },
 
+  // Account data → Redis → Strategy Engine (TT-62)
+  { from: 'acct-streamer', to: 'acct-publisher', label: 'positions + instruments' },
+  { from: 'acct-publisher', to: 'redis', label: 'HSET positions/instruments' },
+  { from: 'redis', to: 'pos-reader', label: 'HGETALL positions/quotes/greeks/instruments' },
+  { from: 'pos-reader', to: 'metrics-tracker', label: 'load_positions + events' },
+  { from: 'pos-reader', to: 'strategy-classifier', label: '.strategies property' },
+  { from: 'strategy-classifier', to: 'strategy-patterns', label: 'MULTI_LEG_MATCHERS' },
+  { from: 'strategy-classifier', to: 'strategy-models', label: 'ParsedLeg → Strategy' },
+  { from: 'pos-reader', to: 'strategy-health', label: '.strategy_summary property', style: 'dashed' },
+  { from: 'strategy-health', to: 'health-config', label: 'load TOML thresholds', style: 'dashed' },
+
   // Orchestrator
   { from: 'sub-orchestrator', to: 'dxlink-mgr', label: 'open / close' },
   { from: 'sub-orchestrator', to: 'proc-influx', label: 'wire processor', style: 'dashed' },
@@ -1574,6 +1673,16 @@ const FUNCTIONAL_VIEWS = {
       'acct-streamer', 'tastytrade-api', 'credentials',
       'queue-quote', 'queue-greeks', 'msg-router', 'evt-handler',
       'proc-metrics', 'metrics-tracker', 'proc-latest',
+      'acct-publisher',
+    ]),
+  },
+  'Strategy Engine': {
+    color: '#e8b004',
+    nodes: new Set([
+      'acct-streamer', 'acct-publisher', 'redis',
+      'pos-reader', 'metrics-tracker',
+      'strategy-classifier', 'strategy-patterns', 'strategy-models',
+      'strategy-health', 'health-config',
     ]),
   },
 };

--- a/docs/plans/TT-62-strategy-engine.md
+++ b/docs/plans/TT-62-strategy-engine.md
@@ -1,0 +1,413 @@
+# TT-62: Option Strategy Classification Engine — Implementation Plan
+
+> **Jira:** [TT-62](https://mandeng.atlassian.net/browse/TT-62)
+
+## Context
+
+The current `positions-summary` property groups legs by underlying and shows net delta + leg count, but doesn't identify strategies — that's delegated to an LLM via `just positions-strategies`. This is slow, expensive, and sometimes wrong (misidentifying jade lizards as collars).
+
+**Goal:** Build a deterministic strategy classifier that assembles all underlying positions, enriches them with broker-provided instrument metadata (strike, call/put, expiration), and classifies them into recognized option strategy recipes — including tastytrade varieties. Full lifecycle: identification, aggregate Greeks, P&L metrics, health monitoring.
+
+**Key design decision:** Get option metadata from the TastyTrade API (`GET /instruments/equity-options`) instead of parsing OCC symbols locally. Persist instrument details to Redis so all consumers read structured data.
+
+---
+
+## Architecture Overview
+
+```
+TT API                    Redis                         Analytics
+───────                   ─────                         ─────────
+/instruments/             tastytrade:instruments        PositionMetricsReader
+  equity-options  ──▶     (HSET: symbol → JSON)    ──▶   .strategies property
+                                                          StrategyClassifier
+/accounts/.../            tastytrade:positions              │
+  positions       ──▶     (HSET: symbol → JSON)    ──▶   ParsedLeg objects
+                                                          │
+DXLink stream     ──▶     tastytrade:latest:*      ──▶   Greeks/Quotes
+                                                          │
+                                                        Strategy objects
+                                                        (type, legs, Greeks, P&L, health)
+```
+
+**Data flow:**
+1. Account-stream starts → hydrates positions from API → for each option position, batch-fetches instrument details from `GET /instruments/equity-options` → writes both to Redis
+2. On live position updates (new option positions), fetches instrument details and writes to Redis
+3. `PositionMetricsReader.read()` loads positions + instruments + quotes + Greeks from Redis
+4. `StrategyClassifier` uses enriched data to identify strategies via greedy pattern matching
+
+---
+
+## Step 1: Instrument Models & Client
+
+### Per-type instrument models
+
+**File:** `src/tastytrade/market/models.py` (new)
+
+Each model maps 1:1 to its TT API `/instruments/*` endpoint. All extend `TastyTradeApiModel` (frozen Pydantic).
+
+```python
+class OptionType(str, Enum):
+    CALL = "C"
+    PUT = "P"
+
+class EquityOptionInstrument(TastyTradeApiModel):
+    symbol: str                              # OCC symbol
+    instrument_type: str                     # "Equity Option"
+    strike_price: Decimal                    # e.g., 305.0
+    option_type: OptionType                  # "C" or "P"
+    root_symbol: str                         # e.g., "SPY"
+    underlying_symbol: str                   # e.g., "SPY"
+    expiration_date: date                    # YYYY-MM-DD
+    days_to_expiration: int                  # computed by broker
+    expires_at: datetime                     # full timestamp
+    exercise_style: str                      # "American"
+    settlement_type: str                     # "PM"
+    shares_per_contract: int                 # 100
+    streamer_symbol: str                     # ".SPY260220C185"
+    active: bool
+    is_closing_only: bool
+
+class FutureOptionInstrument(TastyTradeApiModel):
+    symbol: str                              # e.g., "./MESM6EX3H6 260320P6450"
+    underlying_symbol: str                   # e.g., "/MESM6"
+    product_code: str                        # e.g., "EX3"
+    expiration_date: date
+    strike_price: Decimal
+    option_type: OptionType                  # "C" or "P"
+    exchange: str                            # e.g., "CME"
+    streamer_symbol: str                     # e.g., "./EX3H26P6450:XCME"
+
+class EquityInstrument(TastyTradeApiModel):
+    symbol: str
+    instrument_type: str
+    description: Optional[str]
+    is_etf: bool
+    active: bool
+
+class FutureInstrument(TastyTradeApiModel):
+    symbol: str
+    product_code: str
+    contract_size: Decimal
+    notional_multiplier: Decimal
+    expiration_date: date
+    active: bool
+
+class CryptocurrencyInstrument(TastyTradeApiModel):
+    symbol: str
+    instrument_type: str
+    description: Optional[str]
+    active: bool
+```
+
+### InstrumentsClient — one method per type
+
+**File:** `src/tastytrade/market/instruments.py` (extend existing)
+
+```python
+class InstrumentsClient:
+    def __init__(self, session: AsyncSessionHandler): ...
+
+    async def get_equity_options(self, symbols: list[str]) -> list[EquityOptionInstrument]:
+        """GET /instruments/equity-options?symbol[]={sym1}&symbol[]={sym2}..."""
+
+    async def get_future_options(self, symbols: list[str]) -> list[FutureOptionInstrument]:
+        """GET /instruments/future-options?symbol[]={sym1}&symbol[]={sym2}..."""
+
+    async def get_equities(self, symbols: list[str]) -> list[EquityInstrument]:
+        """GET /instruments/equities?symbol[]={sym1}&symbol[]={sym2}..."""
+
+    async def get_futures(self, symbols: list[str]) -> list[FutureInstrument]:
+        """GET /instruments/futures?symbol[]={sym1}&symbol[]={sym2}..."""
+
+    async def get_cryptocurrencies(self, symbols: list[str]) -> list[CryptocurrencyInstrument]:
+        """GET /instruments/cryptocurrencies?symbol[]={sym1}&symbol[]={sym2}..."""
+```
+
+**Batch size:** TT API may have URL length limits. Batch into groups of ~50 symbols per request.
+
+---
+
+## Step 2: Instrument Publisher (Redis persistence)
+
+### Extend `AccountStreamPublisher`
+
+**File:** `src/tastytrade/accounts/publisher.py`
+
+Add a new Redis HSET key and publish method:
+
+```python
+INSTRUMENTS_KEY = "tastytrade:instruments"  # Single HSET, keyed by symbol
+
+async def publish_instruments(self, instruments: list) -> None:
+    """Write instrument details to Redis HSET. Key = symbol, value = JSON.
+
+    Accepts any instrument model type (EquityOptionInstrument,
+    FutureOptionInstrument, EquityInstrument, etc.).
+    """
+```
+
+Single HSET is sufficient — symbol is globally unique across types, and consumers can look up by the Position's symbol field.
+
+### Orchestrator integration
+
+**File:** `src/tastytrade/accounts/orchestrator.py`
+
+After `streamer.start()` and position hydration, create an `InstrumentsClient` using `streamer.session` and enrich all position types:
+
+```
+run_account_stream_once():
+    await streamer.start()       # positions hydrated into queue
+
+    # NEW: Enrich positions with instrument details per type
+    instruments_client = InstrumentsClient(streamer.session)
+
+    # Group position symbols by instrument type
+    equity_option_syms = [p.symbol for p in positions if p.instrument_type == EQUITY_OPTION]
+    future_option_syms = [p.symbol for p in positions if p.instrument_type == FUTURE_OPTION]
+    equity_syms = [p.symbol for p in positions if p.instrument_type == EQUITY]
+    # ... etc for futures, crypto
+
+    # Batch-fetch from each endpoint
+    instruments = []
+    if equity_option_syms:
+        instruments += await instruments_client.get_equity_options(equity_option_syms)
+    if future_option_syms:
+        instruments += await instruments_client.get_future_options(future_option_syms)
+    if equity_syms:
+        instruments += await instruments_client.get_equities(equity_syms)
+    # ...
+
+    await publisher.publish_instruments(instruments)
+
+    # Continue with existing consume loops...
+```
+
+For live position updates: when `_consume_positions()` sees a new position not already in the instruments HSET, fetch and publish its instrument details using the appropriate type-specific method.
+
+---
+
+## Step 3: Strategy Models
+
+**File:** `src/tastytrade/analytics/strategies/models.py`
+
+### StrategyType enum (comprehensive)
+
+| Category | Strategies |
+|----------|-----------|
+| Delta-1 | Long Stock, Short Stock, Long Crypto, Short Crypto |
+| Single-leg | Long Call, Long Put, Naked Call, Naked Put |
+| Covered | Covered Call, Protective Put, Collar |
+| Verticals | Bull Call Spread, Bear Call Spread, Bull Put Spread, Bear Put Spread |
+| Straddle/Strangle | Long/Short Straddle, Long/Short Strangle |
+| Tastytrade | Jade Lizard, Covered Jade Lizard, Big Lizard |
+| Iron | Iron Condor, Iron Butterfly |
+| Butterfly/Condor | Call Butterfly, Put Butterfly, Condor |
+| Calendar/Diagonal | Calendar Spread, Diagonal Spread |
+| Other | Ratio Spread, Synthetic Long, Synthetic Short, Custom |
+
+### ParsedLeg (frozen dataclass)
+
+Built by joining `SecurityMetrics` + `EquityOptionInstrument` from Redis:
+
+- Position fields: `streamer_symbol`, `symbol`, `underlying`, `instrument_type`, `signed_quantity`
+- Instrument fields (from broker): `option_type`, `strike` (Decimal), `expiration` (date), `days_to_expiration`
+- Market data fields: `delta`, `gamma`, `theta`, `vega`, `mid_price`
+
+### Strategy (dataclass)
+
+- `strategy_type`, `underlying`, `legs: tuple[ParsedLeg, ...]`
+- Computed properties: `net_delta`, `net_gamma`, `net_theta`, `net_vega`
+- P&L: `max_profit`, `max_loss`, `breakeven_prices` (strategy-type-specific formulas)
+- Time: `days_to_expiration`, `nearest_expiration`
+- `width` (strike width for spreads)
+
+---
+
+## Step 4: Pattern Matchers
+
+**File:** `src/tastytrade/analytics/strategies/patterns.py`
+
+Each pattern: `match_X(legs: list[ParsedLeg]) -> MatchResult | None`
+
+**Priority order (greedy — most legs first):**
+
+1. **4+ legs:** Iron Condor, Iron Butterfly, Covered Jade Lizard, Big Lizard, Butterfly, Condor
+2. **3 legs:** Jade Lizard, Collar
+3. **2 legs (with stock):** Covered Call, Protective Put
+4. **2 legs (same exp, same type):** Vertical spreads, Ratio Spread
+5. **2 legs (same exp, diff type):** Straddle, Strangle, Synthetic
+6. **2 legs (diff exp):** Calendar, Diagonal
+7. **1 leg:** Long/Short Stock, Long/Short Call/Put, Naked Call/Put
+
+**Key matching rules:**
+- All legs in a pattern must have matching absolute quantities (except ratio spreads)
+- Straddle = same strike; Strangle = different strikes
+- Iron condor = put strikes < call strikes, short inner + long outer
+- Jade lizard = short OTM put + bear call spread (short call + long higher call)
+- Quantity handling: 3 short puts + 1 short call → 1 strangle + 2 naked puts
+
+---
+
+## Step 5: Classification Engine
+
+**File:** `src/tastytrade/analytics/strategies/classifier.py`
+
+```
+StrategyClassifier:
+    classify(securities, instruments) -> list[Strategy]:
+        1. Build ParsedLeg for each SecurityMetrics + instrument lookup
+        2. Group by underlying_symbol
+        3. For each underlying: greedy match patterns (most complex first)
+        4. Consume matched legs, repeat until no more matches
+        5. Remaining legs → single-leg strategies
+```
+
+---
+
+## Step 6: Health Monitor
+
+**File:** `src/tastytrade/analytics/strategies/health.py`
+**Config:** `config/strategy_health.toml`
+
+Thresholds are configurable per strategy type via TOML. Each strategy type can have its own thresholds, with a `[default]` section as fallback.
+
+```toml
+# config/strategy_health.toml
+
+[default]
+dte_warning = 21
+dte_critical = 7
+max_loss_warning = 0.75
+max_loss_critical = 0.90
+delta_drift_warning = 0.30
+
+[iron_condor]
+dte_warning = 30
+dte_critical = 14
+delta_drift_warning = 0.20
+
+[short_strangle]
+dte_warning = 25
+dte_critical = 10
+delta_drift_warning = 0.25
+
+[jade_lizard]
+delta_drift_warning = 0.35
+
+# Strategies not listed here inherit from [default]
+```
+
+**HealthThresholds** loaded from TOML at startup. Key = `StrategyType` name in snake_case, value = threshold overrides merged with defaults.
+
+```python
+class StrategyHealthMonitor:
+    def __init__(self, config_path: Path | None = None): ...
+    def thresholds_for(self, strategy_type: StrategyType) -> HealthThresholds: ...
+    def check(self, strategy: Strategy) -> list[HealthAlert]: ...
+    def check_all(self, strategies: list[Strategy]) -> list[HealthAlert]: ...
+```
+
+### Future features — Jira ticket creation required (AC)
+
+The following are out of scope for this ticket. **Acceptance criteria: create a Jira ticket for each** before closing this work.
+
+- **Profit target tracking** — Track strategy P&L against a configurable profit target (e.g., close at 50% max profit)
+- **Per-position adjustable thresholds** — Override health thresholds at the individual position/strategy level, not just by type
+- **Position annotations** — User-defined notes/tags on positions (e.g., "rolling candidate", "earnings play")
+- **InfluxDB persistence** — Store position/strategy snapshots as time-series data in InfluxDB for historical analysis
+
+---
+
+## Step 7: Integration
+
+### PositionMetricsReader
+
+**File:** `src/tastytrade/analytics/positions.py`
+
+`read()` changes:
+- Also load instruments from `tastytrade:instruments` Redis HSET
+- Store `self.tracker` reference (currently only DataFrame is saved)
+- Store `self.instruments: dict[str, EquityOptionInstrument]`
+
+New properties:
+- `strategies -> list[Strategy]` — calls `StrategyClassifier.classify()`
+- `strategy_summary -> pd.DataFrame` — columns: underlying, strategy, legs, net_delta, net_theta, net_vega, dte, max_profit, max_loss, health, alerts
+
+### CLI
+
+**File:** `src/tastytrade/subscription/cli.py`
+
+New `strategies` subcommand:
+```
+tasty-subscription strategies
+tasty-subscription strategies --json
+```
+
+### Justfile
+
+```just
+strategies:
+    uv run tasty-subscription strategies
+```
+
+---
+
+## Module Structure
+
+```
+src/tastytrade/
+    market/
+        models.py              # NEW: OptionType, EquityOptionInstrument, FutureOptionInstrument,
+                               #       EquityInstrument, FutureInstrument, CryptocurrencyInstrument
+        instruments.py         # EXTEND: add InstrumentsClient (one method per type)
+    accounts/
+        publisher.py           # EXTEND: add INSTRUMENTS_KEY, publish_instruments()
+        orchestrator.py        # EXTEND: instrument enrichment on startup + live updates
+    analytics/
+        positions.py           # EXTEND: strategies, strategy_summary properties
+        strategies/
+            __init__.py        # Public API exports
+            models.py          # StrategyType, ParsedLeg, Strategy (~200 lines)
+            patterns.py        # 25+ pattern matchers (~500 lines)
+            classifier.py      # Greedy classification engine (~100 lines)
+            health.py          # Health monitoring (~100 lines)
+
+config/
+    strategy_health.toml   # Per-strategy-type health thresholds
+
+unit_tests/
+    market/
+        test_instruments_client.py   # InstrumentsClient tests
+    analytics/
+        strategies/
+            test_patterns.py         # Per-pattern unit tests
+            test_classifier.py       # End-to-end greedy matching tests
+            test_health.py           # Health monitoring tests
+```
+
+---
+
+## Critical File References
+
+| File | Role |
+|------|------|
+| `src/tastytrade/accounts/orchestrator.py` | Integration point — instrument enrichment after startup |
+| `src/tastytrade/accounts/publisher.py` | Redis writer — add instruments HSET |
+| `src/tastytrade/market/instruments.py` | Existing instruments module — add InstrumentsClient |
+| `src/tastytrade/analytics/metrics.py` | SecurityMetrics + MetricsTracker — input data |
+| `src/tastytrade/analytics/positions.py` | PositionMetricsReader — new strategies properties |
+| `src/tastytrade/accounts/models.py` | Position model, InstrumentType, QuantityDirection |
+| `src/tastytrade/subscription/cli.py` | CLI commands — add `strategies` subcommand |
+| `unit_tests/analytics/test_metrics_tracker.py` | Factory helpers to reuse |
+
+---
+
+## Verification
+
+1. **Unit tests:** `uv run pytest unit_tests/analytics/strategies/ unit_tests/market/test_instruments_client.py -v`
+2. **Type checking:** `uv run mypy src/tastytrade/analytics/strategies/ src/tastytrade/market/models.py`
+3. **Linting:** `uv run ruff check src/tastytrade/analytics/strategies/`
+4. **Functional test with live data:**
+   - Start account-stream: `just account-stream` — verify instruments HSET populated in Redis
+   - Run strategies: `just strategies` — verify strategies identified with broker-provided metadata
+   - Cross-check against `just positions-strategies` (LLM-based) for accuracy

--- a/justfile
+++ b/justfile
@@ -48,7 +48,15 @@ positions:
 positions-summary:
     uv run tasty-subscription positions-summary
 
-# Position summary with LLM strategy identification
+# Deterministic strategy classification (no LLM)
+strategies:
+    uv run tasty-subscription strategies
+
+# Strategy classification in JSON format
+strategies-json:
+    uv run tasty-subscription strategies --json
+
+# Position summary with LLM strategy identification (legacy)
 positions-strategies:
     uv run tasty-subscription positions-summary | claude --print \
         "Identify the strategy for each underlying. Output ONLY a markdown table \

--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -126,6 +126,18 @@ async def run_account_stream_once(
                 for p in hydrated_positions
                 if p.instrument_type == InstrumentType.FUTURE
             ]
+            # Also fetch underlying futures for future option positions
+            # so we have their notional-multiplier for P&L calculations.
+            future_option_underlying_syms = list(
+                {
+                    p.underlying_symbol
+                    for p in hydrated_positions
+                    if p.instrument_type == InstrumentType.FUTURE_OPTION
+                    and p.underlying_symbol
+                    and p.underlying_symbol not in future_syms
+                }
+            )
+            future_syms = future_syms + future_option_underlying_syms
             crypto_syms = [
                 p.symbol
                 for p in hydrated_positions

--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -10,11 +10,13 @@ import asyncio
 import logging
 import time
 
-from tastytrade.accounts.publisher import AccountStreamPublisher
+from tastytrade.accounts.models import InstrumentType, Position
+from tastytrade.accounts.publisher import AccountStreamPublisher, Instrument
 from tastytrade.accounts.streamer import AccountStreamer
 from tastytrade.config import RedisConfigManager
 from tastytrade.config.enumerations import AccountEventType
 from tastytrade.connections import Credentials
+from tastytrade.market.instruments import InstrumentsClient
 
 logger = logging.getLogger(__name__)
 
@@ -93,8 +95,68 @@ async def run_account_stream_once(
         # === Create publisher ===
         publisher = AccountStreamPublisher()
 
-        # === Start consumer tasks for position + balance queues ===
+        # === Enrich positions with instrument details ===
         position_queue = streamer.queues[AccountEventType.CURRENT_POSITION]
+        hydrated_items = []
+        while not position_queue.empty():
+            hydrated_items.append(position_queue.get_nowait())
+
+        hydrated_positions = [p for p in hydrated_items if isinstance(p, Position)]
+
+        if streamer.session is not None and hydrated_positions:
+            instruments_client = InstrumentsClient(streamer.session)
+
+            equity_option_syms = [
+                p.symbol
+                for p in hydrated_positions
+                if p.instrument_type == InstrumentType.EQUITY_OPTION
+            ]
+            future_option_syms = [
+                p.symbol
+                for p in hydrated_positions
+                if p.instrument_type == InstrumentType.FUTURE_OPTION
+            ]
+            equity_syms = [
+                p.symbol
+                for p in hydrated_positions
+                if p.instrument_type == InstrumentType.EQUITY
+            ]
+            future_syms = [
+                p.symbol
+                for p in hydrated_positions
+                if p.instrument_type == InstrumentType.FUTURE
+            ]
+            crypto_syms = [
+                p.symbol
+                for p in hydrated_positions
+                if p.instrument_type == InstrumentType.CRYPTOCURRENCY
+            ]
+
+            all_instruments: list[Instrument] = []
+            if equity_option_syms:
+                all_instruments += await instruments_client.get_equity_options(
+                    equity_option_syms
+                )
+            if future_option_syms:
+                all_instruments += await instruments_client.get_future_options(
+                    future_option_syms
+                )
+            if equity_syms:
+                all_instruments += await instruments_client.get_equities(equity_syms)
+            if future_syms:
+                all_instruments += await instruments_client.get_futures(future_syms)
+            if crypto_syms:
+                all_instruments += await instruments_client.get_cryptocurrencies(
+                    crypto_syms
+                )
+
+            await publisher.publish_instruments(all_instruments)
+            logger.info("Enriched positions with %d instruments", len(all_instruments))
+
+        for item in hydrated_items:
+            position_queue.put_nowait(item)
+
+        # === Start consumer tasks for position + balance queues ===
         balance_queue = streamer.queues[AccountEventType.ACCOUNT_BALANCE]
 
         consumer_tasks.append(
@@ -116,9 +178,7 @@ async def run_account_stream_once(
         # === Monitor for reconnection signal ===
         while True:
             sleep_task = asyncio.create_task(asyncio.sleep(health_interval))
-            monitor_task = asyncio.create_task(
-                streamer.wait_for_reconnect_signal()
-            )
+            monitor_task = asyncio.create_task(streamer.wait_for_reconnect_signal())
 
             done, pending = await asyncio.wait(
                 [monitor_task, sleep_task],
@@ -135,9 +195,7 @@ async def run_account_stream_once(
             if monitor_task in done:
                 reason = monitor_task.result()
                 logger.warning("Reconnection triggered: %s", reason.value)
-                raise ConnectionError(
-                    f"Reconnection triggered: {reason.value}"
-                )
+                raise ConnectionError(f"Reconnection triggered: {reason.value}")
 
             # Health check on interval
             uptime = int(time.monotonic() - connection_established_at)

--- a/src/tastytrade/accounts/publisher.py
+++ b/src/tastytrade/accounts/publisher.py
@@ -11,7 +11,24 @@ from typing import Optional
 
 import redis.asyncio as aioredis  # type: ignore[import-untyped]
 
+from typing import Union
+
 from tastytrade.accounts.models import AccountBalance, Position
+from tastytrade.market.models import (
+    CryptocurrencyInstrument,
+    EquityInstrument,
+    EquityOptionInstrument,
+    FutureInstrument,
+    FutureOptionInstrument,
+)
+
+Instrument = Union[
+    EquityOptionInstrument,
+    FutureOptionInstrument,
+    EquityInstrument,
+    FutureInstrument,
+    CryptocurrencyInstrument,
+]
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +38,7 @@ class AccountStreamPublisher:
 
     POSITIONS_KEY = "tastytrade:positions"
     BALANCES_KEY = "tastytrade:balances"
+    INSTRUMENTS_KEY = "tastytrade:instruments"
 
     def __init__(
         self,
@@ -55,6 +73,18 @@ class AccountStreamPublisher:
             balance.model_dump_json(by_alias=True),
         )
         logger.debug("Published balance update")
+
+    async def publish_instruments(self, instruments: list[Instrument]) -> None:
+        """Write instrument details to Redis HSET. Key = symbol, value = JSON."""
+        if not instruments:
+            return
+        pipe = self.redis.pipeline()
+        for inst in instruments:
+            pipe.hset(
+                self.INSTRUMENTS_KEY, inst.symbol, inst.model_dump_json(by_alias=True)
+            )
+        await pipe.execute()
+        logger.info("Published %d instruments to Redis", len(instruments))
 
     async def close(self) -> None:
         """Close Redis connection."""

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -121,8 +121,12 @@ class PositionMetricsReader:
                     "net_theta": strat.net_theta,
                     "net_vega": strat.net_vega,
                     "dte": strat.days_to_expiration,
-                    "max_profit": strat.max_profit,
-                    "max_loss": strat.max_loss,
+                    "max_profit": f"{strat.max_profit:,}"
+                    if strat.max_profit is not None
+                    else None,
+                    "max_loss": f"{strat.max_loss:,}"
+                    if strat.max_loss is not None
+                    else None,
                     "health": health_level,
                     "alerts": alert_str,
                 }

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -90,6 +90,7 @@ class PositionMetricsReader:
                 columns=[
                     "underlying",
                     "strategy",
+                    "qty",
                     "legs",
                     "net_delta",
                     "net_theta",
@@ -107,8 +108,18 @@ class PositionMetricsReader:
             alerts = monitor.check(strat)
             alert_str = "; ".join(a.message for a in alerts) if alerts else "OK"
             health_level = max(a.level.value for a in alerts) if alerts else "OK"
+
+            # Extract common contract quantity from option legs
+            option_legs = [leg for leg in strat.legs if leg.is_option]
+            if option_legs:
+                qty = int(option_legs[0].abs_quantity)
+            else:
+                qty = int(strat.legs[0].abs_quantity) if strat.legs else 0
+
+            # Direction sign only — no repeated quantity
             leg_desc = ", ".join(
-                f"{leg.signed_quantity:+g} {leg.option_type or leg.instrument_type.value}"
+                f"{'+' if leg.is_long else '-'}"
+                f"{leg.option_type or leg.instrument_type.value}"
                 f"{'@' + str(leg.strike.normalize()) if leg.strike else ''}"
                 for leg in strat.legs
             )
@@ -116,6 +127,7 @@ class PositionMetricsReader:
                 {
                     "underlying": strat.underlying,
                     "strategy": strat.strategy_type.value,
+                    "qty": qty,
                     "legs": leg_desc,
                     "net_delta": strat.net_delta,
                     "net_theta": strat.net_theta,

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -108,8 +108,8 @@ class PositionMetricsReader:
             alert_str = "; ".join(a.message for a in alerts) if alerts else "OK"
             health_level = max(a.level.value for a in alerts) if alerts else "OK"
             leg_desc = ", ".join(
-                f"{leg.signed_quantity:+g}x {leg.option_type or leg.instrument_type.value}"
-                f"{'@' + str(leg.strike) if leg.strike else ''}"
+                f"{leg.signed_quantity:+g} {leg.option_type or leg.instrument_type.value}"
+                f"{'@' + str(leg.strike.normalize()) if leg.strike else ''}"
                 for leg in strat.legs
             )
             rows.append(

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -127,7 +127,10 @@ class PositionMetricsReader:
                     "alerts": alert_str,
                 }
             )
-        return pd.DataFrame(rows)
+        df = pd.DataFrame(rows)
+        if not df.empty and "dte" in df.columns:
+            df["dte"] = df["dte"].astype("Int64")  # nullable integer dtype
+        return df
 
     async def read(self) -> pd.DataFrame:
         """Read positions + market data + instruments from Redis, return joined DataFrame."""

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -1,14 +1,15 @@
 """Position metrics reader -- pure Redis consumer.
 
-Reads positions, latest quotes, and latest Greeks from Redis HSET.
-Joins them via MetricsTracker into a DataFrame.
+Reads positions, latest quotes, latest Greeks, and instrument details
+from Redis HSET. Joins them via MetricsTracker into a DataFrame.
+Provides strategy classification via StrategyClassifier.
 No API calls, no socket connections.
 """
 
 import json
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 import pandas as pd
 import redis.asyncio as aioredis  # type: ignore[import-untyped]
@@ -16,6 +17,9 @@ import redis.asyncio as aioredis  # type: ignore[import-untyped]
 from tastytrade.accounts.models import Position
 from tastytrade.accounts.publisher import AccountStreamPublisher
 from tastytrade.analytics.metrics import MetricsTracker
+from tastytrade.analytics.strategies.classifier import StrategyClassifier
+from tastytrade.analytics.strategies.health import StrategyHealthMonitor
+from tastytrade.analytics.strategies.models import Strategy
 from tastytrade.messaging.models.events import GreeksEvent, QuoteEvent
 
 logger = logging.getLogger(__name__)
@@ -36,6 +40,8 @@ class PositionMetricsReader:
         port = redis_port or int(os.environ.get("REDIS_PORT", "6379"))
         self.redis = aioredis.Redis(host=host, port=port)  # type: ignore[arg-type]
         self.position_metrics_df: pd.DataFrame = pd.DataFrame()
+        self.tracker: Optional[MetricsTracker] = None
+        self.instruments: dict[str, Any] = {}
 
     @property
     def summary(self) -> pd.DataFrame:
@@ -67,8 +73,64 @@ class PositionMetricsReader:
             )
         return pd.DataFrame(rows)
 
+    @property
+    def strategies(self) -> list[Strategy]:
+        """Classify positions into named option strategies."""
+        if self.tracker is None:
+            return []
+        classifier = StrategyClassifier()
+        return classifier.classify(self.tracker.securities, self.instruments)
+
+    @property
+    def strategy_summary(self) -> pd.DataFrame:
+        """Strategy summary DataFrame with Greeks, DTE, P&L, and health alerts."""
+        classified = self.strategies
+        if not classified:
+            return pd.DataFrame(
+                columns=[
+                    "underlying",
+                    "strategy",
+                    "legs",
+                    "net_delta",
+                    "net_theta",
+                    "net_vega",
+                    "dte",
+                    "max_profit",
+                    "max_loss",
+                    "health",
+                ]
+            )
+
+        monitor = StrategyHealthMonitor()
+        rows = []
+        for strat in classified:
+            alerts = monitor.check(strat)
+            alert_str = "; ".join(a.message for a in alerts) if alerts else "OK"
+            health_level = max(a.level.value for a in alerts) if alerts else "OK"
+            leg_desc = ", ".join(
+                f"{leg.signed_quantity:+g}x {leg.option_type or leg.instrument_type.value}"
+                f"{'@' + str(leg.strike) if leg.strike else ''}"
+                for leg in strat.legs
+            )
+            rows.append(
+                {
+                    "underlying": strat.underlying,
+                    "strategy": strat.strategy_type.value,
+                    "legs": leg_desc,
+                    "net_delta": strat.net_delta,
+                    "net_theta": strat.net_theta,
+                    "net_vega": strat.net_vega,
+                    "dte": strat.days_to_expiration,
+                    "max_profit": strat.max_profit,
+                    "max_loss": strat.max_loss,
+                    "health": health_level,
+                    "alerts": alert_str,
+                }
+            )
+        return pd.DataFrame(rows)
+
     async def read(self) -> pd.DataFrame:
-        """Read positions + market data from Redis, return joined DataFrame."""
+        """Read positions + market data + instruments from Redis, return joined DataFrame."""
         # 1. Read positions
         raw_positions = await self.redis.hgetall(AccountStreamPublisher.POSITIONS_KEY)
         if not raw_positions:
@@ -84,6 +146,7 @@ class PositionMetricsReader:
         # 2. Load into tracker
         tracker = MetricsTracker()
         tracker.load_positions(positions)
+        self.tracker = tracker
 
         # 3. Read latest quotes
         raw_quotes = await self.redis.hgetall(self.QUOTES_KEY)
@@ -102,6 +165,21 @@ class PositionMetricsReader:
                 tracker.on_greeks_event(greeks)
             except Exception as e:
                 logger.debug("Skipped greeks: %s", e)
+
+        # 5. Read instrument details
+        raw_instruments = await self.redis.hgetall(
+            AccountStreamPublisher.INSTRUMENTS_KEY
+        )
+        self.instruments = {}
+        for key, value in raw_instruments.items():
+            try:
+                symbol = key.decode() if isinstance(key, bytes) else key
+                self.instruments[symbol] = json.loads(value)
+            except Exception as e:
+                logger.debug("Skipped instrument: %s", e)
+
+        if self.instruments:
+            logger.info("Loaded %d instruments from Redis", len(self.instruments))
 
         self.position_metrics_df = tracker.df
         return self.position_metrics_df

--- a/src/tastytrade/analytics/strategies/__init__.py
+++ b/src/tastytrade/analytics/strategies/__init__.py
@@ -1,0 +1,13 @@
+"""Option strategy classification engine."""
+
+from tastytrade.analytics.strategies.classifier import StrategyClassifier
+from tastytrade.analytics.strategies.health import StrategyHealthMonitor
+from tastytrade.analytics.strategies.models import ParsedLeg, Strategy, StrategyType
+
+__all__ = [
+    "ParsedLeg",
+    "Strategy",
+    "StrategyClassifier",
+    "StrategyHealthMonitor",
+    "StrategyType",
+]

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import Any, Optional
 
+from tastytrade.accounts.models import InstrumentType
 from tastytrade.analytics.metrics import SecurityMetrics
 from tastytrade.analytics.strategies.models import ParsedLeg, Strategy
 from tastytrade.analytics.strategies.patterns import (
@@ -59,6 +60,23 @@ class StrategyClassifier:
                 )
             dte = instrument_data.get("days-to-expiration")
 
+        # Determine contract multiplier for dollar P&L
+        multiplier = Decimal("1")
+        if security.instrument_type == InstrumentType.EQUITY_OPTION:
+            if instrument_data and instrument_data.get("shares-per-contract"):
+                multiplier = Decimal(str(instrument_data["shares-per-contract"]))
+        elif security.instrument_type == InstrumentType.FUTURE_OPTION:
+            # Look up the underlying future's notional-multiplier
+            underlying_sym = security.underlying_symbol
+            if underlying_sym:
+                underlying_data = instruments.get(underlying_sym)
+                if underlying_data is not None:
+                    if isinstance(underlying_data, str):
+                        underlying_data = json.loads(underlying_data)
+                    nm = underlying_data.get("notional-multiplier")
+                    if nm is not None:
+                        multiplier = Decimal(str(nm))
+
         return ParsedLeg(
             streamer_symbol=security.streamer_symbol,
             symbol=security.symbol,
@@ -69,6 +87,7 @@ class StrategyClassifier:
             strike=strike,
             expiration=expiration,
             days_to_expiration=dte,
+            multiplier=multiplier,
             delta=security.delta,
             gamma=security.gamma,
             theta=security.theta,

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -8,7 +8,7 @@ legs become single-leg strategies.
 import json
 import logging
 from collections import defaultdict
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Optional
 
 from tastytrade.accounts.models import InstrumentType
@@ -20,6 +20,51 @@ from tastytrade.analytics.strategies.patterns import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def snap_to_option_tick(
+    price: float,
+    tick_sizes: list[dict[str, str]],
+) -> float:
+    """Snap a truncated future-option price to the nearest valid tick.
+
+    The TastyTrade Position API truncates average-open-price to ~2 decimal
+    places for future options. The underlying future's ``option-tick-sizes``
+    tells us the minimum price increment, so we can recover the true fill.
+
+    Args:
+        price: The truncated average-open-price from the Position API.
+        tick_sizes: The ``option-tick-sizes`` list from the underlying future
+            instrument (e.g. ``[{"threshold": "5.0", "value": "0.05"}, {"value": "0.5"}]``).
+
+    Returns:
+        The price snapped to the nearest valid tick.
+    """
+    if not tick_sizes or price <= 0:
+        return price
+
+    price_dec = Decimal(str(price))
+
+    # Find the correct tick size for this price level.
+    # Entries with a threshold apply when price < threshold (ascending order).
+    # The entry without a threshold is the catch-all for the highest tier.
+    tick = None
+    for entry in tick_sizes:
+        threshold = entry.get("threshold")
+        if threshold is not None and price_dec < Decimal(str(threshold)):
+            tick = Decimal(str(entry["value"]))
+            break
+    if tick is None:
+        # Use the catch-all (entry without threshold)
+        for entry in tick_sizes:
+            if "threshold" not in entry:
+                tick = Decimal(str(entry["value"]))
+                break
+    if tick is None or tick == 0:
+        return price
+
+    snapped = (price_dec / tick).quantize(Decimal("1"), rounding=ROUND_HALF_UP) * tick
+    return float(snapped)
 
 
 class StrategyClassifier:
@@ -63,6 +108,7 @@ class StrategyClassifier:
 
         # Determine contract multiplier for dollar P&L
         multiplier = Decimal("1")
+        underlying_data: Any = None
         if security.instrument_type == InstrumentType.EQUITY_OPTION:
             if instrument_data and instrument_data.get("shares-per-contract"):
                 multiplier = Decimal(str(instrument_data["shares-per-contract"]))
@@ -78,6 +124,21 @@ class StrategyClassifier:
                     if nm is not None:
                         multiplier = Decimal(str(nm))
 
+        # Recover average_open_price precision for future options.
+        # The Position API truncates prices to ~2 decimals; the underlying
+        # future's option-tick-sizes lets us snap back to the true fill.
+        avg_open = security.average_open_price
+        if avg_open is not None and avg_open == 0.0:
+            avg_open = None  # API returns 0.0 for some futures (e.g. /6E)
+        if (
+            avg_open is not None
+            and security.instrument_type == InstrumentType.FUTURE_OPTION
+            and underlying_data is not None
+        ):
+            tick_sizes = underlying_data.get("option-tick-sizes", [])
+            if tick_sizes:
+                avg_open = snap_to_option_tick(avg_open, tick_sizes)
+
         return ParsedLeg(
             streamer_symbol=security.streamer_symbol,
             symbol=security.symbol,
@@ -89,7 +150,7 @@ class StrategyClassifier:
             expiration=expiration,
             days_to_expiration=dte,
             multiplier=multiplier,
-            average_open_price=security.average_open_price,
+            average_open_price=avg_open,
             delta=security.delta,
             gamma=security.gamma,
             theta=security.theta,

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -8,7 +8,7 @@ legs become single-leg strategies.
 import json
 import logging
 from collections import defaultdict
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from typing import Any, Optional
 
 from tastytrade.accounts.models import InstrumentType
@@ -20,51 +20,6 @@ from tastytrade.analytics.strategies.patterns import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def snap_to_option_tick(
-    price: float,
-    tick_sizes: list[dict[str, str]],
-) -> float:
-    """Snap a truncated future-option price to the nearest valid tick.
-
-    The TastyTrade Position API truncates average-open-price to ~2 decimal
-    places for future options. The underlying future's ``option-tick-sizes``
-    tells us the minimum price increment, so we can recover the true fill.
-
-    Args:
-        price: The truncated average-open-price from the Position API.
-        tick_sizes: The ``option-tick-sizes`` list from the underlying future
-            instrument (e.g. ``[{"threshold": "5.0", "value": "0.05"}, {"value": "0.5"}]``).
-
-    Returns:
-        The price snapped to the nearest valid tick.
-    """
-    if not tick_sizes or price <= 0:
-        return price
-
-    price_dec = Decimal(str(price))
-
-    # Find the correct tick size for this price level.
-    # Entries with a threshold apply when price < threshold (ascending order).
-    # The entry without a threshold is the catch-all for the highest tier.
-    tick = None
-    for entry in tick_sizes:
-        threshold = entry.get("threshold")
-        if threshold is not None and price_dec < Decimal(str(threshold)):
-            tick = Decimal(str(entry["value"]))
-            break
-    if tick is None:
-        # Use the catch-all (entry without threshold)
-        for entry in tick_sizes:
-            if "threshold" not in entry:
-                tick = Decimal(str(entry["value"]))
-                break
-    if tick is None or tick == 0:
-        return price
-
-    snapped = (price_dec / tick).quantize(Decimal("1"), rounding=ROUND_HALF_UP) * tick
-    return float(snapped)
 
 
 class StrategyClassifier:
@@ -108,7 +63,6 @@ class StrategyClassifier:
 
         # Determine contract multiplier for dollar P&L
         multiplier = Decimal("1")
-        underlying_data: Any = None
         if security.instrument_type == InstrumentType.EQUITY_OPTION:
             if instrument_data and instrument_data.get("shares-per-contract"):
                 multiplier = Decimal(str(instrument_data["shares-per-contract"]))
@@ -124,20 +78,13 @@ class StrategyClassifier:
                     if nm is not None:
                         multiplier = Decimal(str(nm))
 
-        # Recover average_open_price precision for future options.
-        # The Position API truncates prices to ~2 decimals; the underlying
-        # future's option-tick-sizes lets us snap back to the true fill.
+        # The Position API returns 0.0 for average-open-price on some
+        # future options (e.g. /6E) where the premium is too small to
+        # represent. Treat as missing data — the transactions API can
+        # provide precise entry prices (see future ticket).
         avg_open = security.average_open_price
         if avg_open is not None and avg_open == 0.0:
-            avg_open = None  # API returns 0.0 for some futures (e.g. /6E)
-        if (
-            avg_open is not None
-            and security.instrument_type == InstrumentType.FUTURE_OPTION
-            and underlying_data is not None
-        ):
-            tick_sizes = underlying_data.get("option-tick-sizes", [])
-            if tick_sizes:
-                avg_open = snap_to_option_tick(avg_open, tick_sizes)
+            avg_open = None
 
         return ParsedLeg(
             streamer_symbol=security.streamer_symbol,

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -58,7 +58,8 @@ class StrategyClassifier:
                 expiration = (
                     date.fromisoformat(exp_raw) if isinstance(exp_raw, str) else exp_raw
                 )
-            dte = instrument_data.get("days-to-expiration")
+            dte_raw = instrument_data.get("days-to-expiration")
+            dte = int(dte_raw) if dte_raw is not None else None
 
         # Determine contract multiplier for dollar P&L
         multiplier = Decimal("1")
@@ -88,6 +89,7 @@ class StrategyClassifier:
             expiration=expiration,
             days_to_expiration=dte,
             multiplier=multiplier,
+            average_open_price=security.average_open_price,
             delta=security.delta,
             gamma=security.gamma,
             theta=security.theta,

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -1,0 +1,137 @@
+"""Greedy strategy classification engine.
+
+Groups positions by underlying, then applies pattern matchers
+from most-complex to simplest. Matched legs are consumed; remaining
+legs become single-leg strategies.
+"""
+
+import json
+import logging
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any, Optional
+
+from tastytrade.analytics.metrics import SecurityMetrics
+from tastytrade.analytics.strategies.models import ParsedLeg, Strategy
+from tastytrade.analytics.strategies.patterns import (
+    MULTI_LEG_MATCHERS,
+    match_single_leg,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StrategyClassifier:
+    """Classifies positions into named option strategies via greedy pattern matching."""
+
+    @staticmethod
+    def build_parsed_leg(
+        security: SecurityMetrics,
+        instruments: dict[str, Any],
+    ) -> ParsedLeg:
+        """Build a ParsedLeg by joining SecurityMetrics + instrument data."""
+        signed_qty = security.quantity
+        if security.quantity_direction.value == "Short":
+            signed_qty = -abs(signed_qty)
+        elif security.quantity_direction.value == "Long":
+            signed_qty = abs(signed_qty)
+
+        # Look up instrument metadata
+        instrument_data = instruments.get(security.symbol)
+        option_type: Optional[str] = None
+        strike: Optional[Decimal] = None
+        expiration = None
+        dte: Optional[int] = None
+
+        if instrument_data is not None:
+            if isinstance(instrument_data, str):
+                instrument_data = json.loads(instrument_data)
+            option_type = instrument_data.get("option-type")
+            strike_raw = instrument_data.get("strike-price")
+            if strike_raw is not None:
+                strike = Decimal(str(strike_raw))
+            exp_raw = instrument_data.get("expiration-date")
+            if exp_raw is not None:
+                from datetime import date
+
+                expiration = (
+                    date.fromisoformat(exp_raw) if isinstance(exp_raw, str) else exp_raw
+                )
+            dte = instrument_data.get("days-to-expiration")
+
+        return ParsedLeg(
+            streamer_symbol=security.streamer_symbol,
+            symbol=security.symbol,
+            underlying=security.underlying_symbol or security.symbol,
+            instrument_type=security.instrument_type,
+            signed_quantity=signed_qty,
+            option_type=option_type,
+            strike=strike,
+            expiration=expiration,
+            days_to_expiration=dte,
+            delta=security.delta,
+            gamma=security.gamma,
+            theta=security.theta,
+            vega=security.vega,
+            mid_price=security.mid_price,
+        )
+
+    def classify(
+        self,
+        securities: dict[str, SecurityMetrics],
+        instruments: dict[str, Any],
+    ) -> list[Strategy]:
+        """Classify all positions into strategies.
+
+        1. Build ParsedLeg for each security
+        2. Group by underlying
+        3. For each group: greedy match from most-complex to simplest
+        4. Remaining unmatched legs -> single-leg strategies
+        """
+        # Build parsed legs
+        all_legs: list[ParsedLeg] = []
+        for security in securities.values():
+            leg = self.build_parsed_leg(security, instruments)
+            all_legs.append(leg)
+
+        # Group by underlying
+        by_underlying: dict[str, list[ParsedLeg]] = defaultdict(list)
+        for leg in all_legs:
+            by_underlying[leg.underlying].append(leg)
+
+        strategies: list[Strategy] = []
+
+        for underlying, underlying_legs in by_underlying.items():
+            remaining = list(underlying_legs)
+
+            # Greedy matching: most complex patterns first
+            for matcher in MULTI_LEG_MATCHERS:
+                while remaining:
+                    result = matcher(remaining)
+                    if result is None:
+                        break
+                    strategies.append(
+                        Strategy(
+                            strategy_type=result.strategy_type,
+                            underlying=underlying,
+                            legs=result.matched_legs,
+                        )
+                    )
+                    # Remove matched legs from remaining
+                    matched_ids = {
+                        id(matched_leg) for matched_leg in result.matched_legs
+                    }
+                    remaining = [leg for leg in remaining if id(leg) not in matched_ids]
+
+            # Remaining legs -> single-leg strategies
+            for leg in remaining:
+                strategy_type = match_single_leg(leg)
+                strategies.append(
+                    Strategy(
+                        strategy_type=strategy_type,
+                        underlying=underlying,
+                        legs=(leg,),
+                    )
+                )
+
+        return strategies

--- a/src/tastytrade/analytics/strategies/health.py
+++ b/src/tastytrade/analytics/strategies/health.py
@@ -133,20 +133,34 @@ class StrategyHealthMonitor:
                     )
                 )
 
-        # Delta drift check
+        # Delta drift check — skip for delta-1 and covered strategies
+        # where high absolute delta is inherent, not a risk signal.
+        delta_exempt = {
+            StrategyType.LONG_STOCK,
+            StrategyType.SHORT_STOCK,
+            StrategyType.LONG_CRYPTO,
+            StrategyType.SHORT_CRYPTO,
+            StrategyType.LONG_FUTURE,
+            StrategyType.SHORT_FUTURE,
+            StrategyType.COVERED_CALL,
+            StrategyType.PROTECTIVE_PUT,
+        }
         net_delta = strategy.net_delta
-        if net_delta is not None:
-            if abs(net_delta) > thresholds.delta_drift_warning:
-                alerts.append(
-                    HealthAlert(
-                        strategy=strategy,
-                        level=AlertLevel.WARNING,
-                        message=(
-                            f"Net delta={net_delta:.2f} exceeds "
-                            f"+/-{thresholds.delta_drift_warning}"
-                        ),
-                    )
+        if (
+            net_delta is not None
+            and strategy.strategy_type not in delta_exempt
+            and abs(net_delta) > thresholds.delta_drift_warning
+        ):
+            alerts.append(
+                HealthAlert(
+                    strategy=strategy,
+                    level=AlertLevel.WARNING,
+                    message=(
+                        f"Net delta={net_delta:.2f} exceeds "
+                        f"+/-{thresholds.delta_drift_warning}"
+                    ),
                 )
+            )
 
         # Max loss proximity check
         max_loss = strategy.max_loss

--- a/src/tastytrade/analytics/strategies/health.py
+++ b/src/tastytrade/analytics/strategies/health.py
@@ -29,7 +29,7 @@ class AlertLevel(str, Enum):
 class HealthThresholds:
     """Configurable thresholds for strategy health checks."""
 
-    dte_warning: int = 21
+    dte_warning: int = 14
     dte_critical: int = 7
     max_loss_warning: float = 0.75
     max_loss_critical: float = 0.90
@@ -68,7 +68,7 @@ class StrategyHealthMonitor:
         # Load default section
         default_section = config.get("default", {})
         self.default_thresholds = HealthThresholds(
-            dte_warning=default_section.get("dte_warning", 21),
+            dte_warning=default_section.get("dte_warning", 14),
             dte_critical=default_section.get("dte_critical", 7),
             max_loss_warning=default_section.get("max_loss_warning", 0.75),
             max_loss_critical=default_section.get("max_loss_critical", 0.90),

--- a/src/tastytrade/analytics/strategies/health.py
+++ b/src/tastytrade/analytics/strategies/health.py
@@ -1,0 +1,165 @@
+"""Strategy health monitoring with configurable TOML thresholds."""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from tastytrade.analytics.strategies.models import Strategy, StrategyType
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[4] / "config" / "strategy_health.toml"
+)
+
+
+class AlertLevel(str, Enum):
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@dataclass(frozen=True)
+class HealthThresholds:
+    """Configurable thresholds for strategy health checks."""
+
+    dte_warning: int = 21
+    dte_critical: int = 7
+    max_loss_warning: float = 0.75
+    max_loss_critical: float = 0.90
+    delta_drift_warning: float = 0.30
+
+
+@dataclass(frozen=True)
+class HealthAlert:
+    """A single health alert for a strategy."""
+
+    strategy: Strategy
+    level: AlertLevel
+    message: str
+
+
+class StrategyHealthMonitor:
+    """Monitors strategy health against configurable thresholds."""
+
+    def __init__(self, config_path: Optional[Path] = None) -> None:
+        self.config_path = config_path or DEFAULT_CONFIG_PATH
+        self.thresholds_map: dict[str, HealthThresholds] = {}
+        self.default_thresholds = HealthThresholds()
+        self.load_config()
+
+    def load_config(self) -> None:
+        """Load thresholds from TOML config file."""
+        if not self.config_path.exists():
+            logger.warning(
+                "Health config not found at %s, using defaults", self.config_path
+            )
+            return
+
+        with open(self.config_path, "rb") as f:
+            config = tomllib.load(f)
+
+        # Load default section
+        default_section = config.get("default", {})
+        self.default_thresholds = HealthThresholds(
+            dte_warning=default_section.get("dte_warning", 21),
+            dte_critical=default_section.get("dte_critical", 7),
+            max_loss_warning=default_section.get("max_loss_warning", 0.75),
+            max_loss_critical=default_section.get("max_loss_critical", 0.90),
+            delta_drift_warning=default_section.get("delta_drift_warning", 0.30),
+        )
+
+        # Load per-strategy-type overrides
+        for key, section in config.items():
+            if key == "default":
+                continue
+            self.thresholds_map[key] = HealthThresholds(
+                dte_warning=section.get(
+                    "dte_warning", self.default_thresholds.dte_warning
+                ),
+                dte_critical=section.get(
+                    "dte_critical", self.default_thresholds.dte_critical
+                ),
+                max_loss_warning=section.get(
+                    "max_loss_warning", self.default_thresholds.max_loss_warning
+                ),
+                max_loss_critical=section.get(
+                    "max_loss_critical", self.default_thresholds.max_loss_critical
+                ),
+                delta_drift_warning=section.get(
+                    "delta_drift_warning",
+                    self.default_thresholds.delta_drift_warning,
+                ),
+            )
+
+        logger.info(
+            "Loaded health config: %d strategy-specific overrides",
+            len(self.thresholds_map),
+        )
+
+    def thresholds_for(self, strategy_type: StrategyType) -> HealthThresholds:
+        """Get thresholds for a strategy type, falling back to defaults."""
+        key = strategy_type.name.lower()
+        return self.thresholds_map.get(key, self.default_thresholds)
+
+    def check(self, strategy: Strategy) -> list[HealthAlert]:
+        """Check a single strategy's health."""
+        alerts: list[HealthAlert] = []
+        thresholds = self.thresholds_for(strategy.strategy_type)
+
+        # DTE check
+        dte = strategy.days_to_expiration
+        if dte is not None:
+            if dte <= thresholds.dte_critical:
+                alerts.append(
+                    HealthAlert(
+                        strategy=strategy,
+                        level=AlertLevel.CRITICAL,
+                        message=f"DTE={dte} <= {thresholds.dte_critical} (critical)",
+                    )
+                )
+            elif dte <= thresholds.dte_warning:
+                alerts.append(
+                    HealthAlert(
+                        strategy=strategy,
+                        level=AlertLevel.WARNING,
+                        message=f"DTE={dte} <= {thresholds.dte_warning} (warning)",
+                    )
+                )
+
+        # Delta drift check
+        net_delta = strategy.net_delta
+        if net_delta is not None:
+            if abs(net_delta) > thresholds.delta_drift_warning:
+                alerts.append(
+                    HealthAlert(
+                        strategy=strategy,
+                        level=AlertLevel.WARNING,
+                        message=(
+                            f"Net delta={net_delta:.2f} exceeds "
+                            f"+/-{thresholds.delta_drift_warning}"
+                        ),
+                    )
+                )
+
+        # Max loss proximity check
+        max_loss = strategy.max_loss
+        max_profit = strategy.max_profit
+        if max_loss is not None and max_profit is not None and max_loss > 0:
+            # Simplified check -- full implementation requires current P&L tracking
+            pass
+
+        return alerts
+
+    def check_all(self, strategies: list[Strategy]) -> list[HealthAlert]:
+        """Check health of all strategies."""
+        alerts: list[HealthAlert] = []
+        for strategy in strategies:
+            alerts.extend(self.check(strategy))
+        return alerts

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -91,6 +91,11 @@ class ParsedLeg:
     expiration: Optional[date] = None
     days_to_expiration: Optional[int] = None
 
+    # Contract multiplier for dollar P&L.
+    # Equity options: shares-per-contract (100).
+    # Future options: underlying future's notional-multiplier.
+    multiplier: Decimal = Decimal("1")
+
     # Market data (from real-time feeds)
     delta: Optional[float] = None
     gamma: Optional[float] = None
@@ -232,11 +237,23 @@ class Strategy:
         return compute_max_loss(self)
 
 
-def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
-    """Compute max profit based on strategy type.
+def _strategy_multiplier(strategy: Strategy) -> Decimal:
+    """Get the contract multiplier for a strategy.
 
-    For credit spreads: net credit received.
-    For debit spreads: width - net debit.
+    All legs in a strategy share the same underlying, so the multiplier
+    is consistent. Uses the first option leg's multiplier.
+    """
+    for leg in strategy.legs:
+        if leg.is_option:
+            return leg.multiplier
+    return Decimal("1")
+
+
+def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
+    """Compute max profit in dollars based on strategy type.
+
+    For credit spreads: net credit × multiplier.
+    For debit spreads: (width - net debit) × multiplier.
     Returns None if insufficient data.
     """
     legs = strategy.legs
@@ -246,9 +263,9 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     st = strategy.strategy_type
+    mult = _strategy_multiplier(strategy)
 
     if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
-        # Credit spread: max profit = net credit
         net_credit = sum(
             (
                 Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
@@ -257,10 +274,9 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(net_credit, Decimal("0"))
+        return max(net_credit * mult, Decimal("0"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        # Debit spread: max profit = width - net debit
         w = strategy.width
         if w is None:
             return None
@@ -272,10 +288,9 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(w - net_debit, Decimal("0"))
+        return max((w - net_debit) * mult, Decimal("0"))
 
     if st == StrategyType.IRON_CONDOR:
-        # Iron condor: net credit
         net_credit = sum(
             (
                 Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
@@ -284,34 +299,39 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(net_credit, Decimal("0"))
+        return max(net_credit * mult, Decimal("0"))
 
     if st in (StrategyType.SHORT_STRANGLE, StrategyType.SHORT_STRADDLE):
-        # Short strangle/straddle: total premium collected
-        return sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
+        return (
+            sum(
+                (
+                    Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
+                    for leg in option_legs
+                    if leg.mid_price is not None
+                ),
+                Decimal("0"),
+            )
+            * mult
         )
 
     if st in (StrategyType.NAKED_CALL, StrategyType.NAKED_PUT):
-        return sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
+        return (
+            sum(
+                (
+                    Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
+                    for leg in option_legs
+                    if leg.mid_price is not None
+                ),
+                Decimal("0"),
+            )
+            * mult
         )
 
     return None
 
 
 def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
-    """Compute max loss based on strategy type.
+    """Compute max loss in dollars based on strategy type.
 
     Returns None for unlimited-risk strategies or insufficient data.
     """
@@ -322,9 +342,9 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     st = strategy.strategy_type
+    mult = _strategy_multiplier(strategy)
 
     if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
-        # Credit spread: max loss = width - net credit
         w = strategy.width
         if w is None:
             return None
@@ -336,10 +356,9 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(w - net_credit, Decimal("0"))
+        return max((w - net_credit) * mult, Decimal("0"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        # Debit spread: max loss = net debit
         net_debit = sum(
             (
                 Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity))
@@ -348,10 +367,9 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(net_debit, Decimal("0"))
+        return max(net_debit * mult, Decimal("0"))
 
     if st == StrategyType.IRON_CONDOR:
-        # Iron condor: widest wing width - net credit
         put_strikes = sorted(
             leg.strike for leg in option_legs if leg.is_put and leg.strike
         )
@@ -379,7 +397,7 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             ),
             Decimal("0"),
         )
-        return max(wing_width - net_credit, Decimal("0"))
+        return max((wing_width - net_credit) * mult, Decimal("0"))
 
     # Unlimited risk strategies return None
     if st in (

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -96,6 +96,9 @@ class ParsedLeg:
     # Future options: underlying future's notional-multiplier.
     multiplier: Decimal = Decimal("1")
 
+    # Entry price (from position's average-open-price)
+    average_open_price: Optional[float] = None
+
     # Market data (from real-time feeds)
     delta: Optional[float] = None
     gamma: Optional[float] = None
@@ -178,16 +181,17 @@ class Strategy:
 
     @property
     def net_theta(self) -> Optional[float]:
+        """Dollar-denominated net theta (scaled by contract multiplier)."""
         vals = [leg.theta for leg in self.legs if leg.theta is not None]
         if not vals:
             return None
         return round(
             sum(
-                (leg.theta or 0.0) * leg.signed_quantity
+                (leg.theta or 0.0) * leg.signed_quantity * float(leg.multiplier)
                 for leg in self.legs
                 if leg.theta is not None
             ),
-            4,
+            2,
         )
 
     @property
@@ -249,125 +253,104 @@ def _strategy_multiplier(strategy: Strategy) -> Decimal:
     return Decimal("1")
 
 
-def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
-    """Compute max profit in dollars based on strategy type.
+def _net_entry_credit(option_legs: list[ParsedLeg]) -> Optional[Decimal]:
+    """Compute the net credit received at entry from average_open_price.
 
-    For credit spreads: net credit × multiplier.
-    For debit spreads: (width - net debit) × multiplier.
+    Positive = net credit (sold premium > bought premium).
+    Returns None if any leg is missing open price data.
+    """
+    if any(leg.average_open_price is None for leg in option_legs):
+        return None
+    # Short legs contribute credit (+), long legs contribute debit (-)
+    return sum(
+        (
+            Decimal(str(leg.average_open_price))
+            * Decimal(str(leg.signed_quantity * -1))
+            for leg in option_legs
+            if leg.average_open_price is not None
+        ),
+        Decimal("0"),
+    )
+
+
+def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
+    """Compute max profit in dollars based on strategy type and entry prices.
+
+    Uses average_open_price (the actual fill) — not the current mark.
+    Max profit is fixed at entry and does not change with market moves.
     Returns None if insufficient data.
     """
-    legs = strategy.legs
-    option_legs = [leg for leg in legs if leg.is_option]
-
-    if not option_legs or any(leg.mid_price is None for leg in option_legs):
+    option_legs = [leg for leg in strategy.legs if leg.is_option]
+    if not option_legs:
         return None
 
     st = strategy.strategy_type
     mult = _strategy_multiplier(strategy)
+    net_credit = _net_entry_credit(option_legs)
 
-    if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
-        net_credit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
-        )
-        return max(net_credit * mult, Decimal("0"))
+    if net_credit is None:
+        return None
+
+    if st in (
+        StrategyType.BEAR_CALL_SPREAD,
+        StrategyType.BULL_PUT_SPREAD,
+        StrategyType.IRON_CONDOR,
+        StrategyType.SHORT_STRANGLE,
+        StrategyType.SHORT_STRADDLE,
+        StrategyType.NAKED_CALL,
+        StrategyType.NAKED_PUT,
+        StrategyType.JADE_LIZARD,
+    ):
+        # Credit strategies: max profit = net credit received × multiplier
+        return (max(net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
+        # Debit spread: max profit = width - net debit paid
         w = strategy.width
         if w is None:
             return None
-        net_debit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
-        )
-        return max((w - net_debit) * mult, Decimal("0"))
-
-    if st == StrategyType.IRON_CONDOR:
-        net_credit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
-        )
-        return max(net_credit * mult, Decimal("0"))
-
-    if st in (StrategyType.SHORT_STRANGLE, StrategyType.SHORT_STRADDLE):
-        return (
-            sum(
-                (
-                    Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
-                    for leg in option_legs
-                    if leg.mid_price is not None
-                ),
-                Decimal("0"),
-            )
-            * mult
-        )
-
-    if st in (StrategyType.NAKED_CALL, StrategyType.NAKED_PUT):
-        return (
-            sum(
-                (
-                    Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
-                    for leg in option_legs
-                    if leg.mid_price is not None
-                ),
-                Decimal("0"),
-            )
-            * mult
-        )
+        # net_credit is negative for debit spreads (we paid more than we received)
+        return (max(w + net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
 
     return None
 
 
 def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
-    """Compute max loss in dollars based on strategy type.
+    """Compute max loss in dollars based on strategy type and entry prices.
 
+    Uses average_open_price (the actual fill) — not the current mark.
     Returns None for unlimited-risk strategies or insufficient data.
     """
-    legs = strategy.legs
-    option_legs = [leg for leg in legs if leg.is_option]
-
-    if not option_legs or any(leg.mid_price is None for leg in option_legs):
+    option_legs = [leg for leg in strategy.legs if leg.is_option]
+    if not option_legs:
         return None
 
     st = strategy.strategy_type
     mult = _strategy_multiplier(strategy)
+    net_credit = _net_entry_credit(option_legs)
+
+    if net_credit is None:
+        return None
+
+    # Unlimited risk strategies
+    if st in (
+        StrategyType.NAKED_CALL,
+        StrategyType.SHORT_STRANGLE,
+        StrategyType.SHORT_STRADDLE,
+    ):
+        return None
 
     if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
+        # Credit spread: max loss = width - net credit
         w = strategy.width
         if w is None:
             return None
-        net_credit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
-        )
-        return max((w - net_credit) * mult, Decimal("0"))
+        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        net_debit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
-        )
-        return max(net_debit * mult, Decimal("0"))
+        # Debit spread: max loss = net debit paid
+        net_debit = -net_credit  # flip sign: positive = what we paid
+        return (max(net_debit, Decimal("0")) * mult).quantize(Decimal("0.01"))
 
     if st == StrategyType.IRON_CONDOR:
         put_strikes = sorted(
@@ -388,23 +371,15 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             else Decimal("0")
         )
         wing_width = max(put_width, call_width)
-
-        net_credit = sum(
-            (
-                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
-                for leg in option_legs
-                if leg.mid_price is not None
-            ),
-            Decimal("0"),
+        return (max(wing_width - net_credit, Decimal("0")) * mult).quantize(
+            Decimal("0.01")
         )
-        return max((wing_width - net_credit) * mult, Decimal("0"))
 
-    # Unlimited risk strategies return None
-    if st in (
-        StrategyType.NAKED_CALL,
-        StrategyType.SHORT_STRANGLE,
-        StrategyType.SHORT_STRADDLE,
-    ):
-        return None  # Unlimited risk
+    if st == StrategyType.JADE_LIZARD:
+        # Jade lizard has a defined-risk side (the vertical spread)
+        w = strategy.width
+        if w is None:
+            return None
+        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
 
     return None

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -1,0 +1,392 @@
+"""Strategy identification models.
+
+StrategyType enum, ParsedLeg (frozen dataclass), and Strategy (dataclass).
+"""
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from tastytrade.accounts.models import InstrumentType
+
+
+class StrategyType(str, Enum):
+    """All recognized option strategy types."""
+
+    # Delta-1
+    LONG_STOCK = "Long Stock"
+    SHORT_STOCK = "Short Stock"
+    LONG_CRYPTO = "Long Crypto"
+    SHORT_CRYPTO = "Short Crypto"
+    LONG_FUTURE = "Long Future"
+    SHORT_FUTURE = "Short Future"
+
+    # Single-leg options
+    LONG_CALL = "Long Call"
+    LONG_PUT = "Long Put"
+    NAKED_CALL = "Naked Call"
+    NAKED_PUT = "Naked Put"
+
+    # Covered
+    COVERED_CALL = "Covered Call"
+    PROTECTIVE_PUT = "Protective Put"
+    COLLAR = "Collar"
+
+    # Verticals
+    BULL_CALL_SPREAD = "Bull Call Spread"
+    BEAR_CALL_SPREAD = "Bear Call Spread"
+    BULL_PUT_SPREAD = "Bull Put Spread"
+    BEAR_PUT_SPREAD = "Bear Put Spread"
+
+    # Straddle/Strangle
+    LONG_STRADDLE = "Long Straddle"
+    SHORT_STRADDLE = "Short Straddle"
+    LONG_STRANGLE = "Long Strangle"
+    SHORT_STRANGLE = "Short Strangle"
+
+    # Tastytrade
+    JADE_LIZARD = "Jade Lizard"
+    COVERED_JADE_LIZARD = "Covered Jade Lizard"
+    BIG_LIZARD = "Big Lizard"
+
+    # Iron
+    IRON_CONDOR = "Iron Condor"
+    IRON_BUTTERFLY = "Iron Butterfly"
+
+    # Butterfly/Condor
+    CALL_BUTTERFLY = "Call Butterfly"
+    PUT_BUTTERFLY = "Put Butterfly"
+    CONDOR = "Condor"
+
+    # Calendar/Diagonal
+    CALENDAR_SPREAD = "Calendar Spread"
+    DIAGONAL_SPREAD = "Diagonal Spread"
+
+    # Other
+    RATIO_SPREAD = "Ratio Spread"
+    SYNTHETIC_LONG = "Synthetic Long"
+    SYNTHETIC_SHORT = "Synthetic Short"
+    CUSTOM = "Custom"
+
+
+@dataclass(frozen=True)
+class ParsedLeg:
+    """A single position leg enriched with instrument metadata.
+
+    Built by joining SecurityMetrics + instrument data from Redis.
+    """
+
+    # Position identity
+    streamer_symbol: str
+    symbol: str
+    underlying: str
+    instrument_type: InstrumentType
+    signed_quantity: float  # positive=long, negative=short
+
+    # Instrument fields (from broker API) — None for non-options
+    option_type: Optional[str] = None  # "C" or "P"
+    strike: Optional[Decimal] = None
+    expiration: Optional[date] = None
+    days_to_expiration: Optional[int] = None
+
+    # Market data (from real-time feeds)
+    delta: Optional[float] = None
+    gamma: Optional[float] = None
+    theta: Optional[float] = None
+    vega: Optional[float] = None
+    mid_price: Optional[float] = None
+
+    @property
+    def is_long(self) -> bool:
+        return self.signed_quantity > 0
+
+    @property
+    def is_short(self) -> bool:
+        return self.signed_quantity < 0
+
+    @property
+    def is_call(self) -> bool:
+        return self.option_type == "C"
+
+    @property
+    def is_put(self) -> bool:
+        return self.option_type == "P"
+
+    @property
+    def is_option(self) -> bool:
+        return self.instrument_type in (
+            InstrumentType.EQUITY_OPTION,
+            InstrumentType.FUTURE_OPTION,
+        )
+
+    @property
+    def is_stock(self) -> bool:
+        return self.instrument_type in (
+            InstrumentType.EQUITY,
+            InstrumentType.FUTURE,
+            InstrumentType.CRYPTOCURRENCY,
+        )
+
+    @property
+    def abs_quantity(self) -> float:
+        return abs(self.signed_quantity)
+
+
+@dataclass
+class Strategy:
+    """A classified option strategy with its component legs."""
+
+    strategy_type: StrategyType
+    underlying: str
+    legs: tuple[ParsedLeg, ...]
+
+    # Computed properties
+    @property
+    def net_delta(self) -> Optional[float]:
+        deltas = [leg.delta for leg in self.legs if leg.delta is not None]
+        if not deltas:
+            return None
+        return round(
+            sum(
+                (leg.delta or 0.0) * leg.signed_quantity
+                for leg in self.legs
+                if leg.delta is not None
+            ),
+            4,
+        )
+
+    @property
+    def net_gamma(self) -> Optional[float]:
+        vals = [leg.gamma for leg in self.legs if leg.gamma is not None]
+        if not vals:
+            return None
+        return round(
+            sum(
+                (leg.gamma or 0.0) * leg.signed_quantity
+                for leg in self.legs
+                if leg.gamma is not None
+            ),
+            4,
+        )
+
+    @property
+    def net_theta(self) -> Optional[float]:
+        vals = [leg.theta for leg in self.legs if leg.theta is not None]
+        if not vals:
+            return None
+        return round(
+            sum(
+                (leg.theta or 0.0) * leg.signed_quantity
+                for leg in self.legs
+                if leg.theta is not None
+            ),
+            4,
+        )
+
+    @property
+    def net_vega(self) -> Optional[float]:
+        vals = [leg.vega for leg in self.legs if leg.vega is not None]
+        if not vals:
+            return None
+        return round(
+            sum(
+                (leg.vega or 0.0) * leg.signed_quantity
+                for leg in self.legs
+                if leg.vega is not None
+            ),
+            4,
+        )
+
+    @property
+    def days_to_expiration(self) -> Optional[int]:
+        dtes = [
+            leg.days_to_expiration
+            for leg in self.legs
+            if leg.days_to_expiration is not None
+        ]
+        return min(dtes) if dtes else None
+
+    @property
+    def nearest_expiration(self) -> Optional[date]:
+        exps = [leg.expiration for leg in self.legs if leg.expiration is not None]
+        return min(exps) if exps else None
+
+    @property
+    def width(self) -> Optional[Decimal]:
+        """Strike width for spreads (difference between strikes)."""
+        strikes = sorted({leg.strike for leg in self.legs if leg.strike is not None})
+        if len(strikes) >= 2:
+            return strikes[-1] - strikes[0]
+        return None
+
+    @property
+    def max_profit(self) -> Optional[Decimal]:
+        """Strategy-type-specific max profit calculation."""
+        return compute_max_profit(self)
+
+    @property
+    def max_loss(self) -> Optional[Decimal]:
+        """Strategy-type-specific max loss calculation."""
+        return compute_max_loss(self)
+
+
+def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
+    """Compute max profit based on strategy type.
+
+    For credit spreads: net credit received.
+    For debit spreads: width - net debit.
+    Returns None if insufficient data.
+    """
+    legs = strategy.legs
+    option_legs = [leg for leg in legs if leg.is_option]
+
+    if not option_legs or any(leg.mid_price is None for leg in option_legs):
+        return None
+
+    st = strategy.strategy_type
+
+    if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
+        # Credit spread: max profit = net credit
+        net_credit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(net_credit, Decimal("0"))
+
+    if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
+        # Debit spread: max profit = width - net debit
+        w = strategy.width
+        if w is None:
+            return None
+        net_debit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(w - net_debit, Decimal("0"))
+
+    if st == StrategyType.IRON_CONDOR:
+        # Iron condor: net credit
+        net_credit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(net_credit, Decimal("0"))
+
+    if st in (StrategyType.SHORT_STRANGLE, StrategyType.SHORT_STRADDLE):
+        # Short strangle/straddle: total premium collected
+        return sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+
+    if st in (StrategyType.NAKED_CALL, StrategyType.NAKED_PUT):
+        return sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(abs(leg.signed_quantity)))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+
+    return None
+
+
+def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
+    """Compute max loss based on strategy type.
+
+    Returns None for unlimited-risk strategies or insufficient data.
+    """
+    legs = strategy.legs
+    option_legs = [leg for leg in legs if leg.is_option]
+
+    if not option_legs or any(leg.mid_price is None for leg in option_legs):
+        return None
+
+    st = strategy.strategy_type
+
+    if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
+        # Credit spread: max loss = width - net credit
+        w = strategy.width
+        if w is None:
+            return None
+        net_credit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(w - net_credit, Decimal("0"))
+
+    if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
+        # Debit spread: max loss = net debit
+        net_debit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(net_debit, Decimal("0"))
+
+    if st == StrategyType.IRON_CONDOR:
+        # Iron condor: widest wing width - net credit
+        put_strikes = sorted(
+            leg.strike for leg in option_legs if leg.is_put and leg.strike
+        )
+        call_strikes = sorted(
+            leg.strike for leg in option_legs if leg.is_call and leg.strike
+        )
+
+        put_width = (
+            (put_strikes[-1] - put_strikes[0])
+            if len(put_strikes) >= 2
+            else Decimal("0")
+        )
+        call_width = (
+            (call_strikes[-1] - call_strikes[0])
+            if len(call_strikes) >= 2
+            else Decimal("0")
+        )
+        wing_width = max(put_width, call_width)
+
+        net_credit = sum(
+            (
+                Decimal(str(leg.mid_price)) * Decimal(str(leg.signed_quantity * -1))
+                for leg in option_legs
+                if leg.mid_price is not None
+            ),
+            Decimal("0"),
+        )
+        return max(wing_width - net_credit, Decimal("0"))
+
+    # Unlimited risk strategies return None
+    if st in (
+        StrategyType.NAKED_CALL,
+        StrategyType.SHORT_STRANGLE,
+        StrategyType.SHORT_STRADDLE,
+    ):
+        return None  # Unlimited risk
+
+    return None

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -372,7 +372,7 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         )
         wing_width = max(put_width, call_width)
         return (max(wing_width - net_credit, Decimal("0")) * mult).quantize(
-            Decimal("0.01")
+            Decimal("1")
         )
 
     if st == StrategyType.JADE_LIZARD:

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -302,7 +302,7 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         StrategyType.JADE_LIZARD,
     ):
         # Credit strategies: max profit = net credit received × multiplier
-        return (max(net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
+        return (max(net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
         # Debit spread: max profit = width - net debit paid
@@ -310,7 +310,7 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         if w is None:
             return None
         # net_credit is negative for debit spreads (we paid more than we received)
-        return (max(w + net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
+        return (max(w + net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
 
     return None
 
@@ -345,12 +345,12 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         w = strategy.width
         if w is None:
             return None
-        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
+        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
         # Debit spread: max loss = net debit paid
         net_debit = -net_credit  # flip sign: positive = what we paid
-        return (max(net_debit, Decimal("0")) * mult).quantize(Decimal("0.01"))
+        return (max(net_debit, Decimal("0")) * mult).quantize(Decimal("1"))
 
     if st == StrategyType.IRON_CONDOR:
         put_strikes = sorted(
@@ -380,6 +380,6 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         w = strategy.width
         if w is None:
             return None
-        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("0.01"))
+        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
 
     return None

--- a/src/tastytrade/analytics/strategies/patterns.py
+++ b/src/tastytrade/analytics/strategies/patterns.py
@@ -263,8 +263,11 @@ def match_big_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
 
 
 def match_jade_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
-    """Jade Lizard: short OTM put + bear call spread (short call + long higher call).
-    3 options, same exp.
+    """Jade Lizard: short put + short call vertical OR short call + short put vertical.
+
+    Variant A: short put + bear call spread (short call + long higher call).
+    Variant B: short call + bull put spread (short put + long lower put).
+    3 options, same exp, same abs quantity.
     """
     options = [leg for leg in legs if leg.is_option]
     if len(options) < 3:
@@ -275,23 +278,31 @@ def match_jade_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
         if not same_expiration(combo_list):
             continue
 
-        short_puts = [leg for leg in combo_list if leg.is_put and leg.is_short]
-        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
-        long_calls = [leg for leg in combo_list if leg.is_call and leg.is_long]
-
-        if len(short_puts) != 1 or len(short_calls) != 1 or len(long_calls) != 1:
-            continue
-
         if not same_abs_quantity(combo_list):
             continue
 
-        # Bear call spread: short lower, long higher
-        if (
-            short_calls[0].strike is not None
-            and long_calls[0].strike is not None
-            and short_calls[0].strike < long_calls[0].strike
-        ):
-            return MatchResult(StrategyType.JADE_LIZARD, tuple(combo_list))
+        short_puts = [leg for leg in combo_list if leg.is_put and leg.is_short]
+        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
+        long_calls = [leg for leg in combo_list if leg.is_call and leg.is_long]
+        long_puts = [leg for leg in combo_list if leg.is_put and leg.is_long]
+
+        # Variant A: short put + bear call spread (1 short put, 1 short call, 1 long call)
+        if len(short_puts) == 1 and len(short_calls) == 1 and len(long_calls) == 1:
+            if (
+                short_calls[0].strike is not None
+                and long_calls[0].strike is not None
+                and short_calls[0].strike < long_calls[0].strike
+            ):
+                return MatchResult(StrategyType.JADE_LIZARD, tuple(combo_list))
+
+        # Variant B: short call + bull put spread (1 short call, 1 short put, 1 long put)
+        if len(short_calls) == 1 and len(short_puts) == 1 and len(long_puts) == 1:
+            if (
+                long_puts[0].strike is not None
+                and short_puts[0].strike is not None
+                and long_puts[0].strike < short_puts[0].strike
+            ):
+                return MatchResult(StrategyType.JADE_LIZARD, tuple(combo_list))
 
     return None
 

--- a/src/tastytrade/analytics/strategies/patterns.py
+++ b/src/tastytrade/analytics/strategies/patterns.py
@@ -1,0 +1,601 @@
+"""Pattern matchers for option strategy identification.
+
+Each matcher: match_X(legs: list[ParsedLeg]) -> MatchResult | None
+
+Priority order (greedy -- most legs first):
+1. 4+ legs: Iron Condor, Iron Butterfly, Covered Jade Lizard, Big Lizard, Butterfly
+2. 3 legs: Jade Lizard, Collar
+3. 2 legs (with stock): Covered Call, Protective Put
+4. 2 legs (same exp, same type): Vertical spreads, Ratio Spread
+5. 2 legs (same exp, diff type): Straddle, Strangle, Synthetic
+6. 2 legs (diff exp): Calendar, Diagonal
+7. 1 leg: single positions
+"""
+
+import logging
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Callable
+
+from tastytrade.analytics.strategies.models import ParsedLeg, StrategyType
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """Result of a successful pattern match."""
+
+    strategy_type: StrategyType
+    matched_legs: tuple[ParsedLeg, ...]
+
+
+def same_expiration(legs: list[ParsedLeg]) -> bool:
+    """Check if all option legs share the same expiration."""
+    exps = {leg.expiration for leg in legs if leg.expiration is not None}
+    return len(exps) == 1
+
+
+def same_abs_quantity(legs: list[ParsedLeg]) -> bool:
+    """Check if all legs have the same absolute quantity."""
+    qtys = {leg.abs_quantity for leg in legs}
+    return len(qtys) == 1
+
+
+# ===== 4-leg patterns =====
+
+
+def match_iron_condor(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Iron Condor: 4 options, same exp, same qty.
+    Short put + long put (lower) + short call + long call (higher).
+    Put strikes < Call strikes.
+    """
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 4:
+        return None
+
+    for combo in combinations(options, 4):
+        combo_list = list(combo)
+        if not same_expiration(combo_list) or not same_abs_quantity(combo_list):
+            continue
+
+        puts = sorted(
+            [leg for leg in combo_list if leg.is_put],
+            key=lambda x: x.strike or 0,
+        )
+        calls = sorted(
+            [leg for leg in combo_list if leg.is_call],
+            key=lambda x: x.strike or 0,
+        )
+
+        if len(puts) != 2 or len(calls) != 2:
+            continue
+
+        # Long lower put, short higher put, short lower call, long higher call
+        if (
+            puts[0].is_long
+            and puts[1].is_short
+            and calls[0].is_short
+            and calls[1].is_long
+        ):
+            # Put strikes must be below call strikes
+            if puts[1].strike is not None and calls[0].strike is not None:
+                if puts[1].strike < calls[0].strike:
+                    return MatchResult(StrategyType.IRON_CONDOR, tuple(combo_list))
+
+    return None
+
+
+def match_iron_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Iron Butterfly: 4 options, same exp, same qty.
+    Like iron condor but short put strike == short call strike.
+    """
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 4:
+        return None
+
+    for combo in combinations(options, 4):
+        combo_list = list(combo)
+        if not same_expiration(combo_list) or not same_abs_quantity(combo_list):
+            continue
+
+        puts = sorted(
+            [leg for leg in combo_list if leg.is_put],
+            key=lambda x: x.strike or 0,
+        )
+        calls = sorted(
+            [leg for leg in combo_list if leg.is_call],
+            key=lambda x: x.strike or 0,
+        )
+
+        if len(puts) != 2 or len(calls) != 2:
+            continue
+
+        if (
+            puts[0].is_long
+            and puts[1].is_short
+            and calls[0].is_short
+            and calls[1].is_long
+        ):
+            if puts[1].strike is not None and calls[0].strike is not None:
+                if puts[1].strike == calls[0].strike:
+                    return MatchResult(StrategyType.IRON_BUTTERFLY, tuple(combo_list))
+
+    return None
+
+
+def match_call_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Call Butterfly: 3 calls, same exp. Buy 1 low, sell 2 middle, buy 1 high.
+    Middle strike = (low + high) / 2. Qty ratio 1:2:1.
+    """
+    options = [leg for leg in legs if leg.is_option and leg.is_call]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = sorted(combo, key=lambda x: x.strike or 0)
+        if not same_expiration(list(combo_list)):
+            continue
+
+        low, mid, high = combo_list
+        if low.strike is None or mid.strike is None or high.strike is None:
+            continue
+
+        # Check equal spacing
+        if mid.strike - low.strike != high.strike - mid.strike:
+            continue
+
+        # Buy 1 low, sell 2 middle, buy 1 high
+        if (
+            low.is_long
+            and mid.is_short
+            and high.is_long
+            and low.abs_quantity == high.abs_quantity
+            and mid.abs_quantity == 2 * low.abs_quantity
+        ):
+            return MatchResult(StrategyType.CALL_BUTTERFLY, tuple(combo_list))
+
+    return None
+
+
+def match_put_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Put Butterfly: 3 puts, same exp. Buy 1 low, sell 2 middle, buy 1 high."""
+    options = [leg for leg in legs if leg.is_option and leg.is_put]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = sorted(combo, key=lambda x: x.strike or 0)
+        if not same_expiration(list(combo_list)):
+            continue
+
+        low, mid, high = combo_list
+        if low.strike is None or mid.strike is None or high.strike is None:
+            continue
+
+        if mid.strike - low.strike != high.strike - mid.strike:
+            continue
+
+        if (
+            low.is_long
+            and mid.is_short
+            and high.is_long
+            and low.abs_quantity == high.abs_quantity
+            and mid.abs_quantity == 2 * low.abs_quantity
+        ):
+            return MatchResult(StrategyType.PUT_BUTTERFLY, tuple(combo_list))
+
+    return None
+
+
+def match_covered_jade_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Covered Jade Lizard: long stock + short put + bear call spread.
+    4 legs total: 1 stock + 3 options.
+    """
+    stocks = [leg for leg in legs if leg.is_stock and leg.is_long]
+    options = [leg for leg in legs if leg.is_option]
+
+    if not stocks or len(options) < 3:
+        return None
+
+    stock = stocks[0]
+
+    for combo in combinations(options, 3):
+        combo_list = list(combo)
+        if not same_expiration(combo_list):
+            continue
+
+        short_puts = [leg for leg in combo_list if leg.is_put and leg.is_short]
+        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
+        long_calls = [leg for leg in combo_list if leg.is_call and leg.is_long]
+
+        if len(short_puts) != 1 or len(short_calls) != 1 or len(long_calls) != 1:
+            continue
+
+        # Bear call spread: short call at lower strike, long call at higher
+        if (
+            short_calls[0].strike is not None
+            and long_calls[0].strike is not None
+            and short_calls[0].strike < long_calls[0].strike
+        ):
+            matched = (stock,) + tuple(combo_list)
+            return MatchResult(StrategyType.COVERED_JADE_LIZARD, matched)
+
+    return None
+
+
+def match_big_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Big Lizard: short straddle + long OTM call.
+    3 options: short call + short put at same strike + long call at higher strike.
+    """
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = list(combo)
+        if not same_expiration(combo_list):
+            continue
+
+        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
+        short_puts = [leg for leg in combo_list if leg.is_put and leg.is_short]
+        long_calls = [leg for leg in combo_list if leg.is_call and leg.is_long]
+
+        if len(short_calls) != 1 or len(short_puts) != 1 or len(long_calls) != 1:
+            continue
+
+        # Short straddle: same strike
+        if short_calls[0].strike != short_puts[0].strike:
+            continue
+
+        # Long call at higher strike
+        if (
+            long_calls[0].strike is not None
+            and short_calls[0].strike is not None
+            and long_calls[0].strike > short_calls[0].strike
+        ):
+            return MatchResult(StrategyType.BIG_LIZARD, tuple(combo_list))
+
+    return None
+
+
+# ===== 3-leg patterns =====
+
+
+def match_jade_lizard(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Jade Lizard: short OTM put + bear call spread (short call + long higher call).
+    3 options, same exp.
+    """
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = list(combo)
+        if not same_expiration(combo_list):
+            continue
+
+        short_puts = [leg for leg in combo_list if leg.is_put and leg.is_short]
+        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
+        long_calls = [leg for leg in combo_list if leg.is_call and leg.is_long]
+
+        if len(short_puts) != 1 or len(short_calls) != 1 or len(long_calls) != 1:
+            continue
+
+        if not same_abs_quantity(combo_list):
+            continue
+
+        # Bear call spread: short lower, long higher
+        if (
+            short_calls[0].strike is not None
+            and long_calls[0].strike is not None
+            and short_calls[0].strike < long_calls[0].strike
+        ):
+            return MatchResult(StrategyType.JADE_LIZARD, tuple(combo_list))
+
+    return None
+
+
+def match_collar(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Collar: long stock + long put + short call, same exp."""
+    stocks = [leg for leg in legs if leg.is_stock and leg.is_long]
+    options = [leg for leg in legs if leg.is_option]
+
+    if not stocks or len(options) < 2:
+        return None
+
+    stock = stocks[0]
+
+    for combo in combinations(options, 2):
+        combo_list = list(combo)
+        if not same_expiration(combo_list):
+            continue
+
+        long_puts = [leg for leg in combo_list if leg.is_put and leg.is_long]
+        short_calls = [leg for leg in combo_list if leg.is_call and leg.is_short]
+
+        if len(long_puts) != 1 or len(short_calls) != 1:
+            continue
+
+        matched = (stock,) + tuple(combo_list)
+        return MatchResult(StrategyType.COLLAR, matched)
+
+    return None
+
+
+# ===== 2-leg patterns (with stock) =====
+
+
+def match_covered_call(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Covered Call: long stock + short call."""
+    stocks = [leg for leg in legs if leg.is_stock and leg.is_long]
+    short_calls = [
+        leg for leg in legs if leg.is_option and leg.is_call and leg.is_short
+    ]
+
+    if not stocks or not short_calls:
+        return None
+
+    return MatchResult(StrategyType.COVERED_CALL, (stocks[0], short_calls[0]))
+
+
+def match_protective_put(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Protective Put: long stock + long put."""
+    stocks = [leg for leg in legs if leg.is_stock and leg.is_long]
+    long_puts = [leg for leg in legs if leg.is_option and leg.is_put and leg.is_long]
+
+    if not stocks or not long_puts:
+        return None
+
+    return MatchResult(StrategyType.PROTECTIVE_PUT, (stocks[0], long_puts[0]))
+
+
+# ===== 2-leg patterns (same exp, same type) =====
+
+
+def match_vertical_spread(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Match vertical spreads: 2 options, same type, same exp, diff strikes, same qty."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type != b.option_type:
+            continue
+        if a.expiration != b.expiration or a.expiration is None:
+            continue
+        if a.strike == b.strike or a.strike is None or b.strike is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+
+        low, high = (a, b) if a.strike < b.strike else (b, a)
+
+        if a.is_call:
+            if low.is_long and high.is_short:
+                return MatchResult(StrategyType.BULL_CALL_SPREAD, (low, high))
+            if low.is_short and high.is_long:
+                return MatchResult(StrategyType.BEAR_CALL_SPREAD, (low, high))
+        else:  # puts
+            if low.is_long and high.is_short:
+                return MatchResult(StrategyType.BEAR_PUT_SPREAD, (low, high))
+            if low.is_short and high.is_long:
+                return MatchResult(StrategyType.BULL_PUT_SPREAD, (low, high))
+
+    return None
+
+
+def match_ratio_spread(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Ratio Spread: 2 options, same type, same exp, different quantities."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type != b.option_type:
+            continue
+        if a.expiration != b.expiration or a.expiration is None:
+            continue
+        if a.strike == b.strike or a.strike is None or b.strike is None:
+            continue
+        # Must have different quantities (distinguishes from vertical)
+        if a.abs_quantity == b.abs_quantity:
+            continue
+        # One long, one short
+        if (a.is_long and b.is_short) or (a.is_short and b.is_long):
+            return MatchResult(StrategyType.RATIO_SPREAD, tuple(combo))
+
+    return None
+
+
+# ===== 2-leg patterns (same exp, different type) =====
+
+
+def match_straddle(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Straddle: call + put, same exp, same strike, same qty, same direction."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type == b.option_type:
+            continue
+        if a.expiration != b.expiration or a.expiration is None:
+            continue
+        if a.strike != b.strike or a.strike is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+        if a.is_long != b.is_long:
+            continue
+
+        if a.is_long:
+            return MatchResult(StrategyType.LONG_STRADDLE, tuple(combo))
+        else:
+            return MatchResult(StrategyType.SHORT_STRADDLE, tuple(combo))
+
+    return None
+
+
+def match_strangle(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Strangle: call + put, same exp, different strikes, same qty, same direction."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type == b.option_type:
+            continue
+        if a.expiration != b.expiration or a.expiration is None:
+            continue
+        if a.strike == b.strike:
+            continue
+        if a.strike is None or b.strike is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+        if a.is_long != b.is_long:
+            continue
+
+        if a.is_long:
+            return MatchResult(StrategyType.LONG_STRANGLE, tuple(combo))
+        else:
+            return MatchResult(StrategyType.SHORT_STRANGLE, tuple(combo))
+
+    return None
+
+
+def match_synthetic(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Synthetic Long/Short: call + put, same exp, same strike, opposite directions."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type == b.option_type:
+            continue
+        if a.expiration != b.expiration or a.expiration is None:
+            continue
+        if a.strike != b.strike or a.strike is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+        if a.is_long == b.is_long:
+            continue
+
+        call = a if a.is_call else b
+        put = b if a.is_call else a
+
+        if call.is_long and put.is_short:
+            return MatchResult(StrategyType.SYNTHETIC_LONG, tuple(combo))
+        else:
+            return MatchResult(StrategyType.SYNTHETIC_SHORT, tuple(combo))
+
+    return None
+
+
+# ===== 2-leg patterns (different exp) =====
+
+
+def match_calendar_spread(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Calendar Spread: 2 options, same type, same strike, different exp."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type != b.option_type:
+            continue
+        if a.strike != b.strike or a.strike is None:
+            continue
+        if a.expiration == b.expiration:
+            continue
+        if a.expiration is None or b.expiration is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+
+        return MatchResult(StrategyType.CALENDAR_SPREAD, tuple(combo))
+
+    return None
+
+
+def match_diagonal_spread(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Diagonal Spread: 2 options, same type, different strike, different exp."""
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 2:
+        return None
+
+    for combo in combinations(options, 2):
+        a, b = combo
+        if a.option_type != b.option_type:
+            continue
+        if a.strike == b.strike:
+            continue
+        if a.strike is None or b.strike is None:
+            continue
+        if a.expiration == b.expiration:
+            continue
+        if a.expiration is None or b.expiration is None:
+            continue
+        if a.abs_quantity != b.abs_quantity:
+            continue
+
+        return MatchResult(StrategyType.DIAGONAL_SPREAD, tuple(combo))
+
+    return None
+
+
+# ===== 1-leg patterns =====
+
+
+def match_single_leg(leg: ParsedLeg) -> StrategyType:
+    """Classify a single unmatched leg."""
+    from tastytrade.accounts.models import InstrumentType
+
+    if leg.instrument_type == InstrumentType.EQUITY:
+        return StrategyType.LONG_STOCK if leg.is_long else StrategyType.SHORT_STOCK
+    if leg.instrument_type == InstrumentType.FUTURE:
+        return StrategyType.LONG_FUTURE if leg.is_long else StrategyType.SHORT_FUTURE
+    if leg.instrument_type == InstrumentType.CRYPTOCURRENCY:
+        return StrategyType.LONG_CRYPTO if leg.is_long else StrategyType.SHORT_CRYPTO
+    if leg.is_call:
+        return StrategyType.LONG_CALL if leg.is_long else StrategyType.NAKED_CALL
+    if leg.is_put:
+        return StrategyType.LONG_PUT if leg.is_long else StrategyType.NAKED_PUT
+    return StrategyType.CUSTOM
+
+
+# ===== Ordered matcher list =====
+
+MULTI_LEG_MATCHERS: list[Callable[[list[ParsedLeg]], MatchResult | None]] = [
+    # 4+ legs first
+    match_iron_condor,
+    match_iron_butterfly,
+    match_covered_jade_lizard,
+    match_big_lizard,
+    match_call_butterfly,
+    match_put_butterfly,
+    # 3 legs
+    match_jade_lizard,
+    match_collar,
+    # 2 legs with stock
+    match_covered_call,
+    match_protective_put,
+    # 2 legs same exp same type
+    match_vertical_spread,
+    match_ratio_spread,
+    # 2 legs same exp diff type
+    match_straddle,
+    match_strangle,
+    match_synthetic,
+    # 2 legs diff exp
+    match_calendar_spread,
+    match_diagonal_spread,
+]

--- a/src/tastytrade/connections/subscription.py
+++ b/src/tastytrade/connections/subscription.py
@@ -50,11 +50,12 @@ class RedisSubscriptionStore(SubscriptionStore):
         db: Optional[int] = 0,
     ):
         self.hash_key = hash_key
-        self.redis = redis.Redis(
-            host=host or os.environ.get("REDIS_HOST", "localhost"),
-            port=port or os.environ.get("REDIS_PORT", 6379),
-            db=db or os.environ.get("REDIS_DB", 0),
+        resolved_host: str = host or os.environ.get("REDIS_HOST") or "localhost"
+        resolved_port: int = port or int(os.environ.get("REDIS_PORT", "6379"))
+        resolved_db: int = (
+            db if db is not None else int(os.environ.get("REDIS_DB", "0"))
         )
+        self.redis = redis.Redis(host=resolved_host, port=resolved_port, db=resolved_db)
 
     async def add_subscription(
         self, symbol: str, metadata: Optional[dict[Any, Any]] = None

--- a/src/tastytrade/market/instruments.py
+++ b/src/tastytrade/market/instruments.py
@@ -1,12 +1,25 @@
 import logging
-from typing import Union
+from typing import TypeVar, Union
 
 import polars as pl
+from pydantic import BaseModel
 from requests import Response
 
 from tastytrade.connections.requests import AsyncSessionHandler, SessionHandler
+from tastytrade.market.models import (
+    CryptocurrencyInstrument,
+    EquityInstrument,
+    EquityOptionInstrument,
+    FutureInstrument,
+    FutureOptionInstrument,
+)
+from tastytrade.utils.validators import validate_async_response
+
+T = TypeVar("T", bound=BaseModel)
 
 logger = logging.getLogger(__name__)
+
+INSTRUMENT_BATCH_SIZE = 50
 
 
 async def get_option_chains(
@@ -41,3 +54,65 @@ async def get_option_chains(
         data = sync_response.json()
 
     return pl.DataFrame(data["data"]["items"])
+
+
+class InstrumentsClient:
+    """Async client for TastyTrade instrument endpoints."""
+
+    def __init__(self, session: AsyncSessionHandler) -> None:
+        self.session = session
+
+    async def get_equity_options(
+        self, symbols: list[str]
+    ) -> list[EquityOptionInstrument]:
+        """GET /instruments/equity-options?symbol[]={sym1}&symbol[]={sym2}..."""
+        return await self.fetch_batch(
+            "/instruments/equity-options", symbols, EquityOptionInstrument
+        )
+
+    async def get_future_options(
+        self, symbols: list[str]
+    ) -> list[FutureOptionInstrument]:
+        """GET /instruments/future-options?symbol[]={sym1}&symbol[]={sym2}..."""
+        return await self.fetch_batch(
+            "/instruments/future-options", symbols, FutureOptionInstrument
+        )
+
+    async def get_equities(self, symbols: list[str]) -> list[EquityInstrument]:
+        """GET /instruments/equities?symbol[]={sym1}&symbol[]={sym2}..."""
+        return await self.fetch_batch(
+            "/instruments/equities", symbols, EquityInstrument
+        )
+
+    async def get_futures(self, symbols: list[str]) -> list[FutureInstrument]:
+        """GET /instruments/futures?symbol[]={sym1}&symbol[]={sym2}..."""
+        return await self.fetch_batch("/instruments/futures", symbols, FutureInstrument)
+
+    async def get_cryptocurrencies(
+        self, symbols: list[str]
+    ) -> list[CryptocurrencyInstrument]:
+        """GET /instruments/cryptocurrencies?symbol[]={sym1}&symbol[]={sym2}..."""
+        return await self.fetch_batch(
+            "/instruments/cryptocurrencies", symbols, CryptocurrencyInstrument
+        )
+
+    async def fetch_batch(
+        self, endpoint: str, symbols: list[str], model_cls: type[T]
+    ) -> list[T]:
+        """Batch-fetch instruments, ~50 symbols per request."""
+        results: list[T] = []
+        for i in range(0, len(symbols), INSTRUMENT_BATCH_SIZE):
+            batch = symbols[i : i + INSTRUMENT_BATCH_SIZE]
+            params = [("symbol[]", sym) for sym in batch]
+            url = f"{self.session.base_url}{endpoint}"
+            async with self.session.session.get(url, params=params) as response:
+                await validate_async_response(response)
+                data = await response.json()
+                items = data.get("data", {}).get("items", [])
+                for item in items:
+                    try:
+                        results.append(model_cls.model_validate(item))
+                    except Exception as e:
+                        logger.warning("Failed to parse %s instrument: %s", endpoint, e)
+        logger.info("Fetched %d instruments from %s", len(results), endpoint)
+        return results

--- a/src/tastytrade/market/models.py
+++ b/src/tastytrade/market/models.py
@@ -1,14 +1,16 @@
 """Instrument models for TastyTrade API instrument endpoints.
 
 Each model maps 1:1 to its TT API ``/instruments/*`` endpoint.
-All extend TastyTradeApiModel (frozen Pydantic).
+All extend InstrumentModel (frozen Pydantic with extra="allow").
+
+Field inventory sourced from live TT API responses (2026-02-28).
 """
 
 import logging
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -24,8 +26,8 @@ class InstrumentModel(BaseModel):
     """Base model for instrument API responses.
 
     Separate from TastyTradeApiModel to avoid circular imports
-    (market.models <-> accounts.publisher). Uses extra="ignore"
-    since the TT API returns many fields we don't need.
+    (market.models <-> accounts.publisher). Uses extra="allow"
+    to preserve any new fields the TT API adds in the future.
     """
 
     model_config = ConfigDict(
@@ -38,6 +40,11 @@ class InstrumentModel(BaseModel):
 
 
 class EquityOptionInstrument(InstrumentModel):
+    """Equity option instrument from GET /instruments/equity-options.
+
+    All 19 fields observed in live API responses (2026-02-28).
+    """
+
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     strike_price: Decimal = Field(alias="strike-price")
@@ -53,9 +60,21 @@ class EquityOptionInstrument(InstrumentModel):
     streamer_symbol: str = Field(alias="streamer-symbol")
     active: bool = Field(alias="active")
     is_closing_only: bool = Field(alias="is-closing-only")
+    # Fields discovered in live API (not in original plan)
+    expiration_type: Optional[str] = Field(default=None, alias="expiration-type")
+    market_time_instrument_collection: Optional[str] = Field(
+        default=None, alias="market-time-instrument-collection"
+    )
+    option_chain_type: Optional[str] = Field(default=None, alias="option-chain-type")
+    stops_trading_at: Optional[str] = Field(default=None, alias="stops-trading-at")
 
 
 class FutureOptionInstrument(InstrumentModel):
+    """Future option instrument from GET /instruments/future-options.
+
+    All 34 fields observed in live API responses (2026-02-28).
+    """
+
     symbol: str = Field(alias="symbol")
     underlying_symbol: str = Field(alias="underlying-symbol")
     product_code: str = Field(alias="product-code")
@@ -64,17 +83,99 @@ class FutureOptionInstrument(InstrumentModel):
     option_type: OptionType = Field(alias="option-type")
     exchange: str = Field(alias="exchange")
     streamer_symbol: str = Field(alias="streamer-symbol")
+    # Fields discovered in live API (not in original plan)
+    active: bool = Field(default=True, alias="active")
+    days_to_expiration: int = Field(default=0, alias="days-to-expiration")
+    display_factor: Optional[str] = Field(default=None, alias="display-factor")
+    exchange_symbol: Optional[str] = Field(default=None, alias="exchange-symbol")
+    exercise_style: Optional[str] = Field(default=None, alias="exercise-style")
+    expires_at: Optional[str] = Field(default=None, alias="expires-at")
+    future_option_product: Optional[dict[str, Any]] = Field(
+        default=None, alias="future-option-product"
+    )
+    future_price_ratio: Optional[str] = Field(default=None, alias="future-price-ratio")
+    is_closing_only: bool = Field(default=False, alias="is-closing-only")
+    is_confirmed: Optional[bool] = Field(default=None, alias="is-confirmed")
+    is_exercisable_weekly: Optional[bool] = Field(
+        default=None, alias="is-exercisable-weekly"
+    )
+    is_primary_deliverable: Optional[bool] = Field(
+        default=None, alias="is-primary-deliverable"
+    )
+    is_vanilla: Optional[bool] = Field(default=None, alias="is-vanilla")
+    last_trade_time: Optional[str] = Field(default=None, alias="last-trade-time")
+    maturity_date: Optional[date] = Field(default=None, alias="maturity-date")
+    multiplier: Optional[str] = Field(default=None, alias="multiplier")
+    notional_value: Optional[str] = Field(default=None, alias="notional-value")
+    option_root_symbol: Optional[str] = Field(default=None, alias="option-root-symbol")
+    root_symbol: Optional[str] = Field(default=None, alias="root-symbol")
+    security_exchange: Optional[str] = Field(default=None, alias="security-exchange")
+    security_id: Optional[str] = Field(default=None, alias="security-id")
+    settlement_type: Optional[str] = Field(default=None, alias="settlement-type")
+    stops_trading_at: Optional[str] = Field(default=None, alias="stops-trading-at")
+    strike_factor: Optional[str] = Field(default=None, alias="strike-factor")
+    sx_id: Optional[str] = Field(default=None, alias="sx-id")
+    underlying_count: Optional[str] = Field(default=None, alias="underlying-count")
 
 
 class EquityInstrument(InstrumentModel):
+    """Equity instrument from GET /instruments/equities.
+
+    All 27 fields observed in live API responses (2026-02-28).
+    """
+
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")
     is_etf: bool = Field(alias="is-etf")
     active: bool = Field(alias="active")
+    # Fields discovered in live API (not in original plan)
+    id: Optional[int] = Field(default=None, alias="id")
+    cusip: Optional[str] = Field(default=None, alias="cusip")
+    short_description: Optional[str] = Field(default=None, alias="short-description")
+    streamer_symbol: Optional[str] = Field(default=None, alias="streamer-symbol")
+    is_closing_only: bool = Field(default=False, alias="is-closing-only")
+    is_index: bool = Field(default=False, alias="is-index")
+    is_illiquid: bool = Field(default=False, alias="is-illiquid")
+    is_fraud_risk: bool = Field(default=False, alias="is-fraud-risk")
+    is_options_closing_only: bool = Field(
+        default=False, alias="is-options-closing-only"
+    )
+    is_fractional_quantity_eligible: bool = Field(
+        default=False, alias="is-fractional-quantity-eligible"
+    )
+    bypass_manual_review: bool = Field(default=False, alias="bypass-manual-review")
+    overnight_trading_permitted: bool = Field(
+        default=False, alias="overnight-trading-permitted"
+    )
+    borrow_rate: Optional[str] = Field(default=None, alias="borrow-rate")
+    lendability: Optional[str] = Field(default=None, alias="lendability")
+    instrument_sub_type: Optional[str] = Field(
+        default=None, alias="instrument-sub-type"
+    )
+    listed_market: Optional[str] = Field(default=None, alias="listed-market")
+    market_time_instrument_collection: Optional[str] = Field(
+        default=None, alias="market-time-instrument-collection"
+    )
+    country_of_incorporation: Optional[str] = Field(
+        default=None, alias="country-of-incorporation"
+    )
+    country_of_taxation: Optional[str] = Field(
+        default=None, alias="country-of-taxation"
+    )
+    tick_sizes: Optional[list[dict[str, str]]] = Field(default=None, alias="tick-sizes")
+    option_tick_sizes: Optional[list[dict[str, str]]] = Field(
+        default=None, alias="option-tick-sizes"
+    )
 
 
 class FutureInstrument(InstrumentModel):
+    """Future instrument from GET /instruments/futures.
+
+    Core fields defined; no live data available for full inventory.
+    extra="allow" will capture any additional fields.
+    """
+
     symbol: str = Field(alias="symbol")
     product_code: str = Field(alias="product-code")
     contract_size: Decimal = Field(alias="contract-size")
@@ -84,6 +185,12 @@ class FutureInstrument(InstrumentModel):
 
 
 class CryptocurrencyInstrument(InstrumentModel):
+    """Cryptocurrency instrument from GET /instruments/cryptocurrencies.
+
+    Core fields defined; no live data available for full inventory.
+    extra="allow" will capture any additional fields.
+    """
+
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")

--- a/src/tastytrade/market/models.py
+++ b/src/tastytrade/market/models.py
@@ -10,9 +10,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from pydantic import Field
-
-from tastytrade.accounts.models import TastyTradeApiModel
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +20,24 @@ class OptionType(str, Enum):
     PUT = "P"
 
 
-class EquityOptionInstrument(TastyTradeApiModel):
+class InstrumentModel(BaseModel):
+    """Base model for instrument API responses.
+
+    Separate from TastyTradeApiModel to avoid circular imports
+    (market.models <-> accounts.publisher). Uses extra="ignore"
+    since the TT API returns many fields we don't need.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        validate_assignment=True,
+        extra="allow",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+
+class EquityOptionInstrument(InstrumentModel):
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     strike_price: Decimal = Field(alias="strike-price")
@@ -40,7 +55,7 @@ class EquityOptionInstrument(TastyTradeApiModel):
     is_closing_only: bool = Field(alias="is-closing-only")
 
 
-class FutureOptionInstrument(TastyTradeApiModel):
+class FutureOptionInstrument(InstrumentModel):
     symbol: str = Field(alias="symbol")
     underlying_symbol: str = Field(alias="underlying-symbol")
     product_code: str = Field(alias="product-code")
@@ -51,7 +66,7 @@ class FutureOptionInstrument(TastyTradeApiModel):
     streamer_symbol: str = Field(alias="streamer-symbol")
 
 
-class EquityInstrument(TastyTradeApiModel):
+class EquityInstrument(InstrumentModel):
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")
@@ -59,7 +74,7 @@ class EquityInstrument(TastyTradeApiModel):
     active: bool = Field(alias="active")
 
 
-class FutureInstrument(TastyTradeApiModel):
+class FutureInstrument(InstrumentModel):
     symbol: str = Field(alias="symbol")
     product_code: str = Field(alias="product-code")
     contract_size: Decimal = Field(alias="contract-size")
@@ -68,7 +83,7 @@ class FutureInstrument(TastyTradeApiModel):
     active: bool = Field(alias="active")
 
 
-class CryptocurrencyInstrument(TastyTradeApiModel):
+class CryptocurrencyInstrument(InstrumentModel):
     symbol: str = Field(alias="symbol")
     instrument_type: str = Field(alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")

--- a/src/tastytrade/market/models.py
+++ b/src/tastytrade/market/models.py
@@ -1,0 +1,75 @@
+"""Instrument models for TastyTrade API instrument endpoints.
+
+Each model maps 1:1 to its TT API ``/instruments/*`` endpoint.
+All extend TastyTradeApiModel (frozen Pydantic).
+"""
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field
+
+from tastytrade.accounts.models import TastyTradeApiModel
+
+logger = logging.getLogger(__name__)
+
+
+class OptionType(str, Enum):
+    CALL = "C"
+    PUT = "P"
+
+
+class EquityOptionInstrument(TastyTradeApiModel):
+    symbol: str = Field(alias="symbol")
+    instrument_type: str = Field(alias="instrument-type")
+    strike_price: Decimal = Field(alias="strike-price")
+    option_type: OptionType = Field(alias="option-type")
+    root_symbol: str = Field(alias="root-symbol")
+    underlying_symbol: str = Field(alias="underlying-symbol")
+    expiration_date: date = Field(alias="expiration-date")
+    days_to_expiration: int = Field(alias="days-to-expiration")
+    expires_at: datetime = Field(alias="expires-at")
+    exercise_style: str = Field(alias="exercise-style")
+    settlement_type: str = Field(alias="settlement-type")
+    shares_per_contract: int = Field(alias="shares-per-contract")
+    streamer_symbol: str = Field(alias="streamer-symbol")
+    active: bool = Field(alias="active")
+    is_closing_only: bool = Field(alias="is-closing-only")
+
+
+class FutureOptionInstrument(TastyTradeApiModel):
+    symbol: str = Field(alias="symbol")
+    underlying_symbol: str = Field(alias="underlying-symbol")
+    product_code: str = Field(alias="product-code")
+    expiration_date: date = Field(alias="expiration-date")
+    strike_price: Decimal = Field(alias="strike-price")
+    option_type: OptionType = Field(alias="option-type")
+    exchange: str = Field(alias="exchange")
+    streamer_symbol: str = Field(alias="streamer-symbol")
+
+
+class EquityInstrument(TastyTradeApiModel):
+    symbol: str = Field(alias="symbol")
+    instrument_type: str = Field(alias="instrument-type")
+    description: Optional[str] = Field(default=None, alias="description")
+    is_etf: bool = Field(alias="is-etf")
+    active: bool = Field(alias="active")
+
+
+class FutureInstrument(TastyTradeApiModel):
+    symbol: str = Field(alias="symbol")
+    product_code: str = Field(alias="product-code")
+    contract_size: Decimal = Field(alias="contract-size")
+    notional_multiplier: Decimal = Field(alias="notional-multiplier")
+    expiration_date: date = Field(alias="expiration-date")
+    active: bool = Field(alias="active")
+
+
+class CryptocurrencyInstrument(TastyTradeApiModel):
+    symbol: str = Field(alias="symbol")
+    instrument_type: str = Field(alias="instrument-type")
+    description: Optional[str] = Field(default=None, alias="description")
+    active: bool = Field(alias="active")

--- a/src/tastytrade/market/models.py
+++ b/src/tastytrade/market/models.py
@@ -4,6 +4,14 @@ Each model maps 1:1 to its TT API ``/instruments/*`` endpoint.
 All extend InstrumentModel (frozen Pydantic with extra="allow").
 
 Field inventory sourced from live TT API responses (2026-02-28).
+
+Resilience policy:
+- Fields our code consumes (strategy classifier, publisher, position
+  joining) are **required** — if the API stops sending them we fail
+  fast rather than silently ingesting bad data.
+- Informational fields (display, metadata) are Optional with defaults
+  so API schema additions/removals don't break parsing.
+- ``extra="allow"`` captures any future fields the API adds.
 """
 
 import logging
@@ -45,22 +53,26 @@ class EquityOptionInstrument(InstrumentModel):
     All 19 fields observed in live API responses (2026-02-28).
     """
 
+    # --- Required: consumed by our code ---
     symbol: str = Field(alias="symbol")
-    instrument_type: str = Field(alias="instrument-type")
     strike_price: Decimal = Field(alias="strike-price")
     option_type: OptionType = Field(alias="option-type")
-    root_symbol: str = Field(alias="root-symbol")
     underlying_symbol: str = Field(alias="underlying-symbol")
     expiration_date: date = Field(alias="expiration-date")
     days_to_expiration: int = Field(alias="days-to-expiration")
-    expires_at: datetime = Field(alias="expires-at")
-    exercise_style: str = Field(alias="exercise-style")
-    settlement_type: str = Field(alias="settlement-type")
-    shares_per_contract: int = Field(alias="shares-per-contract")
     streamer_symbol: str = Field(alias="streamer-symbol")
-    active: bool = Field(alias="active")
-    is_closing_only: bool = Field(alias="is-closing-only")
-    # Fields discovered in live API (not in original plan)
+
+    # --- Informational: Optional with defaults ---
+    instrument_type: Optional[str] = Field(default=None, alias="instrument-type")
+    root_symbol: Optional[str] = Field(default=None, alias="root-symbol")
+    expires_at: Optional[datetime] = Field(default=None, alias="expires-at")
+    exercise_style: Optional[str] = Field(default=None, alias="exercise-style")
+    settlement_type: Optional[str] = Field(default=None, alias="settlement-type")
+    shares_per_contract: Optional[int] = Field(
+        default=None, alias="shares-per-contract"
+    )
+    active: Optional[bool] = Field(default=None, alias="active")
+    is_closing_only: Optional[bool] = Field(default=None, alias="is-closing-only")
     expiration_type: Optional[str] = Field(default=None, alias="expiration-type")
     market_time_instrument_collection: Optional[str] = Field(
         default=None, alias="market-time-instrument-collection"
@@ -75,17 +87,19 @@ class FutureOptionInstrument(InstrumentModel):
     All 34 fields observed in live API responses (2026-02-28).
     """
 
+    # --- Required: consumed by our code ---
     symbol: str = Field(alias="symbol")
-    underlying_symbol: str = Field(alias="underlying-symbol")
-    product_code: str = Field(alias="product-code")
-    expiration_date: date = Field(alias="expiration-date")
     strike_price: Decimal = Field(alias="strike-price")
     option_type: OptionType = Field(alias="option-type")
-    exchange: str = Field(alias="exchange")
+    underlying_symbol: str = Field(alias="underlying-symbol")
+    expiration_date: date = Field(alias="expiration-date")
+    days_to_expiration: int = Field(alias="days-to-expiration")
     streamer_symbol: str = Field(alias="streamer-symbol")
-    # Fields discovered in live API (not in original plan)
-    active: bool = Field(default=True, alias="active")
-    days_to_expiration: int = Field(default=0, alias="days-to-expiration")
+
+    # --- Informational: Optional with defaults ---
+    product_code: Optional[str] = Field(default=None, alias="product-code")
+    exchange: Optional[str] = Field(default=None, alias="exchange")
+    active: Optional[bool] = Field(default=None, alias="active")
     display_factor: Optional[str] = Field(default=None, alias="display-factor")
     exchange_symbol: Optional[str] = Field(default=None, alias="exchange-symbol")
     exercise_style: Optional[str] = Field(default=None, alias="exercise-style")
@@ -94,7 +108,7 @@ class FutureOptionInstrument(InstrumentModel):
         default=None, alias="future-option-product"
     )
     future_price_ratio: Optional[str] = Field(default=None, alias="future-price-ratio")
-    is_closing_only: bool = Field(default=False, alias="is-closing-only")
+    is_closing_only: Optional[bool] = Field(default=None, alias="is-closing-only")
     is_confirmed: Optional[bool] = Field(default=None, alias="is-confirmed")
     is_exercisable_weekly: Optional[bool] = Field(
         default=None, alias="is-exercisable-weekly"
@@ -124,29 +138,33 @@ class EquityInstrument(InstrumentModel):
     All 27 fields observed in live API responses (2026-02-28).
     """
 
+    # --- Required: consumed by our code ---
     symbol: str = Field(alias="symbol")
-    instrument_type: str = Field(alias="instrument-type")
+
+    # --- Informational: Optional with defaults ---
+    instrument_type: Optional[str] = Field(default=None, alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")
-    is_etf: bool = Field(alias="is-etf")
-    active: bool = Field(alias="active")
-    # Fields discovered in live API (not in original plan)
+    is_etf: Optional[bool] = Field(default=None, alias="is-etf")
+    active: Optional[bool] = Field(default=None, alias="active")
     id: Optional[int] = Field(default=None, alias="id")
     cusip: Optional[str] = Field(default=None, alias="cusip")
     short_description: Optional[str] = Field(default=None, alias="short-description")
     streamer_symbol: Optional[str] = Field(default=None, alias="streamer-symbol")
-    is_closing_only: bool = Field(default=False, alias="is-closing-only")
-    is_index: bool = Field(default=False, alias="is-index")
-    is_illiquid: bool = Field(default=False, alias="is-illiquid")
-    is_fraud_risk: bool = Field(default=False, alias="is-fraud-risk")
-    is_options_closing_only: bool = Field(
-        default=False, alias="is-options-closing-only"
+    is_closing_only: Optional[bool] = Field(default=None, alias="is-closing-only")
+    is_index: Optional[bool] = Field(default=None, alias="is-index")
+    is_illiquid: Optional[bool] = Field(default=None, alias="is-illiquid")
+    is_fraud_risk: Optional[bool] = Field(default=None, alias="is-fraud-risk")
+    is_options_closing_only: Optional[bool] = Field(
+        default=None, alias="is-options-closing-only"
     )
-    is_fractional_quantity_eligible: bool = Field(
-        default=False, alias="is-fractional-quantity-eligible"
+    is_fractional_quantity_eligible: Optional[bool] = Field(
+        default=None, alias="is-fractional-quantity-eligible"
     )
-    bypass_manual_review: bool = Field(default=False, alias="bypass-manual-review")
-    overnight_trading_permitted: bool = Field(
-        default=False, alias="overnight-trading-permitted"
+    bypass_manual_review: Optional[bool] = Field(
+        default=None, alias="bypass-manual-review"
+    )
+    overnight_trading_permitted: Optional[bool] = Field(
+        default=None, alias="overnight-trading-permitted"
     )
     borrow_rate: Optional[str] = Field(default=None, alias="borrow-rate")
     lendability: Optional[str] = Field(default=None, alias="lendability")
@@ -173,25 +191,31 @@ class FutureInstrument(InstrumentModel):
     """Future instrument from GET /instruments/futures.
 
     Core fields defined; no live data available for full inventory.
-    extra="allow" will capture any additional fields.
     """
 
+    # --- Required: consumed by our code ---
     symbol: str = Field(alias="symbol")
-    product_code: str = Field(alias="product-code")
-    contract_size: Decimal = Field(alias="contract-size")
-    notional_multiplier: Decimal = Field(alias="notional-multiplier")
-    expiration_date: date = Field(alias="expiration-date")
-    active: bool = Field(alias="active")
+
+    # --- Informational: Optional with defaults ---
+    product_code: Optional[str] = Field(default=None, alias="product-code")
+    contract_size: Optional[Decimal] = Field(default=None, alias="contract-size")
+    notional_multiplier: Optional[Decimal] = Field(
+        default=None, alias="notional-multiplier"
+    )
+    expiration_date: Optional[date] = Field(default=None, alias="expiration-date")
+    active: Optional[bool] = Field(default=None, alias="active")
 
 
 class CryptocurrencyInstrument(InstrumentModel):
     """Cryptocurrency instrument from GET /instruments/cryptocurrencies.
 
     Core fields defined; no live data available for full inventory.
-    extra="allow" will capture any additional fields.
     """
 
+    # --- Required: consumed by our code ---
     symbol: str = Field(alias="symbol")
-    instrument_type: str = Field(alias="instrument-type")
+
+    # --- Informational: Optional with defaults ---
+    instrument_type: Optional[str] = Field(default=None, alias="instrument-type")
     description: Optional[str] = Field(default=None, alias="description")
-    active: bool = Field(alias="active")
+    active: Optional[bool] = Field(default=None, alias="active")

--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -341,6 +341,47 @@ def positions_summary_cmd() -> None:
     asyncio.run(_run())
 
 
+@cli.command(name="strategies")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output in JSON format for machine consumption.",
+)
+def strategies_cmd(as_json: bool) -> None:
+    """Classify positions into named option strategies.
+
+    Uses deterministic pattern matching to identify strategies like
+    iron condors, strangles, jade lizards, covered calls, etc.
+    Includes health monitoring alerts.
+
+    \b
+    Example:
+      tasty-subscription strategies
+      tasty-subscription strategies --json
+    """
+
+    async def _run() -> None:
+        from tastytrade.analytics.positions import PositionMetricsReader
+
+        reader = PositionMetricsReader()
+        try:
+            await reader.read()
+            summary = reader.strategy_summary
+            if summary.empty:
+                click.echo("No positions found in Redis. Is account-stream running?")
+                return
+            if as_json:
+                click.echo(summary.to_json(orient="records", indent=2))
+            else:
+                click.echo(summary.to_string(index=False))
+        finally:
+            await reader.close()
+
+    asyncio.run(_run())
+
+
 def main() -> None:
     """Entry point for the tasty-subscription CLI."""
     cli()

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -220,8 +220,6 @@ async def failure_trigger_listener(
         await pubsub.close()
 
 
-
-
 async def _run_subscription_once(
     symbols: list[str],
     intervals: list[str],
@@ -412,9 +410,7 @@ async def _run_subscription_once(
         from tastytrade.subscription.resolver import PositionSymbolResolver
 
         resolver = PositionSymbolResolver(dxlink=dxlink)
-        resolver_task = asyncio.create_task(
-            resolver.listen(), name="position_resolver"
-        )
+        resolver_task = asyncio.create_task(resolver.listen(), name="position_resolver")
 
         async def reconnection_monitor() -> ReconnectReason:
             """Wait for reconnection signal and return reason."""
@@ -464,7 +460,7 @@ async def _run_subscription_once(
                 monitor_task = asyncio.create_task(reconnection_monitor())
 
         finally:
-            for task in [monitor_task, failure_listener_task, resolver_task]:
+            for task in [monitor_task, failure_listener_task, resolver_task]:  # type: ignore[assignment]
                 if task is None:
                     continue
                 task.cancel()

--- a/src/tastytrade/subscription/resolver.py
+++ b/src/tastytrade/subscription/resolver.py
@@ -37,7 +37,7 @@ class PositionSymbolResolver:
     ) -> None:
         host = redis_host or os.environ.get("REDIS_HOST", "localhost")
         port = redis_port or int(os.environ.get("REDIS_PORT", "6379"))
-        self.redis: aioredis.Redis = aioredis.Redis(host=host, port=port)  # type: ignore[type-arg]
+        self.redis: aioredis.Redis = aioredis.Redis(host=host, port=port)  # type: ignore[type-arg,arg-type]
         self.dxlink = dxlink
         self.subscribed_symbols: set[str] = set()
 

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -3,9 +3,13 @@
 import json
 from datetime import date
 from decimal import Decimal
+
 from tastytrade.accounts.models import InstrumentType, QuantityDirection
 from tastytrade.analytics.metrics import SecurityMetrics
-from tastytrade.analytics.strategies.classifier import StrategyClassifier
+from tastytrade.analytics.strategies.classifier import (
+    StrategyClassifier,
+    snap_to_option_tick,
+)
 from tastytrade.analytics.strategies.models import StrategyType
 
 
@@ -356,3 +360,113 @@ class TestClassifyGreedy:
         classifier = StrategyClassifier()
         strategies = classifier.classify({}, {})
         assert strategies == []
+
+
+class TestSnapToOptionTick:
+    """Test tick-snapping for truncated future option prices."""
+
+    def test_zb_put_snaps_to_64ths(self):
+        """/ZB put: 0.23 → 15/64 = 0.234375."""
+        tick_sizes = [{"value": "0.015625"}]
+        assert snap_to_option_tick(0.23, tick_sizes) == 0.234375
+
+    def test_zb_call_snaps_to_64ths(self):
+        """/ZB call: 0.28 → 18/64 = 0.28125."""
+        tick_sizes = [{"value": "0.015625"}]
+        assert snap_to_option_tick(0.28, tick_sizes) == 0.28125
+
+    def test_gc_snaps_to_tenths(self):
+        """/GC options: 0.1 tick size, 4.5 stays 4.5."""
+        tick_sizes = [{"value": "0.1"}]
+        assert snap_to_option_tick(4.5, tick_sizes) == 4.5
+
+    def test_tiered_tick_sizes(self):
+        """/MES options use tiered ticks based on price level."""
+        tick_sizes = [
+            {"threshold": "5.0", "value": "0.05"},
+            {"threshold": "20.0", "value": "0.1"},
+            {"threshold": "100.0", "value": "0.25"},
+            {"value": "0.5"},
+        ]
+        # Price 3.5 → tick 0.05, already on tick
+        assert snap_to_option_tick(3.5, tick_sizes) == 3.5
+        # Price 15.0 → tick 0.1, already on tick
+        assert snap_to_option_tick(15.0, tick_sizes) == 15.0
+        # Price 47.58 → tick 0.25, snaps to 47.50
+        assert snap_to_option_tick(47.58, tick_sizes) == 47.5
+
+    def test_zero_price_unchanged(self):
+        """Price of 0.0 is not snapped (handled as None elsewhere)."""
+        tick_sizes = [{"value": "0.015625"}]
+        assert snap_to_option_tick(0.0, tick_sizes) == 0.0
+
+    def test_empty_tick_sizes_unchanged(self):
+        """No tick sizes → price unchanged."""
+        assert snap_to_option_tick(0.23, []) == 0.23
+
+    def test_exact_price_stays_exact(self):
+        """A price already on a tick boundary is unchanged."""
+        tick_sizes = [{"value": "0.015625"}]
+        assert snap_to_option_tick(0.234375, tick_sizes) == 0.234375
+
+
+class TestBuildParsedLegFutureOptions:
+    """Test future option price correction in build_parsed_leg."""
+
+    def test_zero_average_open_price_becomes_none(self):
+        """API returning 0.0 for average-open-price is treated as missing."""
+        sec = make_security(
+            symbol="./6EM6 EUUJ6 260403P1.16",
+            streamer_symbol="./EUUJ26P1.16:XCME",
+            underlying_symbol="/6EM6",
+            instrument_type=InstrumentType.FUTURE_OPTION,
+            quantity=2,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        sec.average_open_price = 0.0
+        instruments = {
+            "./6EM6 EUUJ6 260403P1.16": {
+                "option-type": "P",
+                "strike-price": "1.16",
+                "expiration-date": "2026-04-03",
+                "days-to-expiration": 33,
+            },
+            "/6EM6": {
+                "notional-multiplier": "125000.0",
+                "option-tick-sizes": [
+                    {"threshold": "0.0005", "value": "0.00005"},
+                    {"value": "0.0001"},
+                ],
+            },
+        }
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments)
+        assert leg.average_open_price is None
+
+    def test_zb_price_snapped_to_tick(self):
+        """/ZB option price 0.23 is snapped to 15/64 = 0.234375."""
+        sec = make_security(
+            symbol="./ZBM6 OZBJ6 260327P115",
+            streamer_symbol="./OZBJ26P115:XCBT",
+            underlying_symbol="/ZBM6",
+            instrument_type=InstrumentType.FUTURE_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        sec.average_open_price = 0.23
+        instruments = {
+            "./ZBM6 OZBJ6 260327P115": {
+                "option-type": "P",
+                "strike-price": "115.0",
+                "expiration-date": "2026-03-27",
+                "days-to-expiration": 26,
+            },
+            "/ZBM6": {
+                "notional-multiplier": "1000.0",
+                "option-tick-sizes": [{"value": "0.015625"}],
+            },
+        }
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments)
+        assert leg.average_open_price == 0.234375
+        assert leg.multiplier == Decimal("1000.0")

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -6,10 +6,7 @@ from decimal import Decimal
 
 from tastytrade.accounts.models import InstrumentType, QuantityDirection
 from tastytrade.analytics.metrics import SecurityMetrics
-from tastytrade.analytics.strategies.classifier import (
-    StrategyClassifier,
-    snap_to_option_tick,
-)
+from tastytrade.analytics.strategies.classifier import StrategyClassifier
 from tastytrade.analytics.strategies.models import StrategyType
 
 
@@ -362,56 +359,8 @@ class TestClassifyGreedy:
         assert strategies == []
 
 
-class TestSnapToOptionTick:
-    """Test tick-snapping for truncated future option prices."""
-
-    def test_zb_put_snaps_to_64ths(self):
-        """/ZB put: 0.23 → 15/64 = 0.234375."""
-        tick_sizes = [{"value": "0.015625"}]
-        assert snap_to_option_tick(0.23, tick_sizes) == 0.234375
-
-    def test_zb_call_snaps_to_64ths(self):
-        """/ZB call: 0.28 → 18/64 = 0.28125."""
-        tick_sizes = [{"value": "0.015625"}]
-        assert snap_to_option_tick(0.28, tick_sizes) == 0.28125
-
-    def test_gc_snaps_to_tenths(self):
-        """/GC options: 0.1 tick size, 4.5 stays 4.5."""
-        tick_sizes = [{"value": "0.1"}]
-        assert snap_to_option_tick(4.5, tick_sizes) == 4.5
-
-    def test_tiered_tick_sizes(self):
-        """/MES options use tiered ticks based on price level."""
-        tick_sizes = [
-            {"threshold": "5.0", "value": "0.05"},
-            {"threshold": "20.0", "value": "0.1"},
-            {"threshold": "100.0", "value": "0.25"},
-            {"value": "0.5"},
-        ]
-        # Price 3.5 → tick 0.05, already on tick
-        assert snap_to_option_tick(3.5, tick_sizes) == 3.5
-        # Price 15.0 → tick 0.1, already on tick
-        assert snap_to_option_tick(15.0, tick_sizes) == 15.0
-        # Price 47.58 → tick 0.25, snaps to 47.50
-        assert snap_to_option_tick(47.58, tick_sizes) == 47.5
-
-    def test_zero_price_unchanged(self):
-        """Price of 0.0 is not snapped (handled as None elsewhere)."""
-        tick_sizes = [{"value": "0.015625"}]
-        assert snap_to_option_tick(0.0, tick_sizes) == 0.0
-
-    def test_empty_tick_sizes_unchanged(self):
-        """No tick sizes → price unchanged."""
-        assert snap_to_option_tick(0.23, []) == 0.23
-
-    def test_exact_price_stays_exact(self):
-        """A price already on a tick boundary is unchanged."""
-        tick_sizes = [{"value": "0.015625"}]
-        assert snap_to_option_tick(0.234375, tick_sizes) == 0.234375
-
-
 class TestBuildParsedLegFutureOptions:
-    """Test future option price correction in build_parsed_leg."""
+    """Test future option price handling in build_parsed_leg."""
 
     def test_zero_average_open_price_becomes_none(self):
         """API returning 0.0 for average-open-price is treated as missing."""
@@ -433,18 +382,14 @@ class TestBuildParsedLegFutureOptions:
             },
             "/6EM6": {
                 "notional-multiplier": "125000.0",
-                "option-tick-sizes": [
-                    {"threshold": "0.0005", "value": "0.00005"},
-                    {"value": "0.0001"},
-                ],
             },
         }
         classifier = StrategyClassifier()
         leg = classifier.build_parsed_leg(sec, instruments)
         assert leg.average_open_price is None
 
-    def test_zb_price_snapped_to_tick(self):
-        """/ZB option price 0.23 is snapped to 15/64 = 0.234375."""
+    def test_nonzero_price_preserved(self):
+        """Non-zero average-open-price passes through as-is."""
         sec = make_security(
             symbol="./ZBM6 OZBJ6 260327P115",
             streamer_symbol="./OZBJ26P115:XCBT",
@@ -463,10 +408,9 @@ class TestBuildParsedLegFutureOptions:
             },
             "/ZBM6": {
                 "notional-multiplier": "1000.0",
-                "option-tick-sizes": [{"value": "0.015625"}],
             },
         }
         classifier = StrategyClassifier()
         leg = classifier.build_parsed_leg(sec, instruments)
-        assert leg.average_open_price == 0.234375
+        assert leg.average_open_price == 0.23
         assert leg.multiplier == Decimal("1000.0")

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -1,0 +1,358 @@
+"""Unit tests for StrategyClassifier end-to-end greedy matching."""
+
+import json
+from datetime import date
+from decimal import Decimal
+from tastytrade.accounts.models import InstrumentType, QuantityDirection
+from tastytrade.analytics.metrics import SecurityMetrics
+from tastytrade.analytics.strategies.classifier import StrategyClassifier
+from tastytrade.analytics.strategies.models import StrategyType
+
+
+def make_security(
+    symbol: str,
+    streamer_symbol: str,
+    underlying_symbol: str,
+    instrument_type: InstrumentType,
+    quantity: float,
+    quantity_direction: QuantityDirection,
+    delta: float | None = None,
+    mid_price: float | None = None,
+) -> SecurityMetrics:
+    """Create a SecurityMetrics object for testing."""
+    sec = SecurityMetrics(
+        symbol=symbol,
+        streamer_symbol=streamer_symbol,
+        underlying_symbol=underlying_symbol,
+        instrument_type=instrument_type,
+        quantity=quantity,
+        quantity_direction=quantity_direction,
+    )
+    sec.delta = delta
+    sec.mid_price = mid_price
+    return sec
+
+
+def make_instrument_json(
+    option_type: str = "C",
+    strike_price: float = 300.0,
+    expiration_date: str = "2026-03-20",
+    days_to_expiration: int = 30,
+) -> dict:
+    """Create instrument dict as stored in Redis."""
+    return {
+        "option-type": option_type,
+        "strike-price": strike_price,
+        "expiration-date": expiration_date,
+        "days-to-expiration": days_to_expiration,
+    }
+
+
+class TestBuildParsedLeg:
+    def test_option_with_instrument(self):
+        sec = make_security(
+            symbol="SPY  260320C00300000",
+            streamer_symbol=".SPY260320C300",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+            delta=-0.3,
+            mid_price=5.50,
+        )
+        instruments = {
+            "SPY  260320C00300000": make_instrument_json("C", 300.0, "2026-03-20", 30),
+        }
+
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments)
+
+        assert leg.symbol == "SPY  260320C00300000"
+        assert leg.underlying == "SPY"
+        assert leg.option_type == "C"
+        assert leg.strike == Decimal("300.0")
+        assert leg.expiration == date(2026, 3, 20)
+        assert leg.days_to_expiration == 30
+        assert leg.signed_quantity == -1  # Short → negative
+        assert leg.delta == -0.3
+        assert leg.mid_price == 5.50
+
+    def test_stock_without_instrument(self):
+        sec = make_security(
+            symbol="SPY",
+            streamer_symbol="SPY",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY,
+            quantity=100,
+            quantity_direction=QuantityDirection.LONG,
+        )
+        instruments = {}
+
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments)
+
+        assert leg.signed_quantity == 100
+        assert leg.option_type is None
+        assert leg.strike is None
+        assert leg.is_stock is True
+
+    def test_long_direction_positive(self):
+        sec = make_security(
+            symbol="SPY  260320C00300000",
+            streamer_symbol=".SPY260320C300",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=2,
+            quantity_direction=QuantityDirection.LONG,
+        )
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, {})
+        assert leg.signed_quantity == 2
+
+    def test_instrument_json_string(self):
+        """Instrument data may arrive as a JSON string (from Redis bytes)."""
+        sec = make_security(
+            symbol="SPY  260320P00290000",
+            streamer_symbol=".SPY260320P290",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        instruments = {
+            "SPY  260320P00290000": json.dumps(
+                make_instrument_json("P", 290.0, "2026-03-20", 30)
+            ),
+        }
+
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments)
+
+        assert leg.option_type == "P"
+        assert leg.strike == Decimal("290.0")
+
+
+class TestClassifyGreedy:
+    """Test end-to-end greedy classification."""
+
+    def test_iron_condor(self):
+        """4 options on same underlying → iron condor."""
+        securities = {}
+        instruments = {}
+
+        legs_data = [
+            ("P280", "P", 280, QuantityDirection.LONG),
+            ("P290", "P", 290, QuantityDirection.SHORT),
+            ("C310", "C", 310, QuantityDirection.SHORT),
+            ("C320", "C", 320, QuantityDirection.LONG),
+        ]
+        for suffix, opt_type, strike, direction in legs_data:
+            sym = f"SPY  {suffix}"
+            sec = make_security(
+                symbol=sym,
+                streamer_symbol=f".SPY{suffix}",
+                underlying_symbol="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                quantity=1,
+                quantity_direction=direction,
+                delta=0.1,
+                mid_price=2.0,
+            )
+            securities[sec.streamer_symbol] = sec
+            instruments[sym] = make_instrument_json(opt_type, strike)
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, instruments)
+
+        assert len(strategies) == 1
+        assert strategies[0].strategy_type == StrategyType.IRON_CONDOR
+        assert strategies[0].underlying == "SPY"
+
+    def test_short_strangle(self):
+        """Short call + short put at different strikes → short strangle."""
+        securities = {}
+        instruments = {}
+
+        sym_call = "SPY  260320C00310000"
+        sec_call = make_security(
+            symbol=sym_call,
+            streamer_symbol=".SPYC310",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+            delta=-0.2,
+            mid_price=3.0,
+        )
+        securities[sec_call.streamer_symbol] = sec_call
+        instruments[sym_call] = make_instrument_json("C", 310.0)
+
+        sym_put = "SPY  260320P00290000"
+        sec_put = make_security(
+            symbol=sym_put,
+            streamer_symbol=".SPYP290",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+            delta=-0.3,
+            mid_price=2.5,
+        )
+        securities[sec_put.streamer_symbol] = sec_put
+        instruments[sym_put] = make_instrument_json("P", 290.0)
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, instruments)
+
+        assert len(strategies) == 1
+        assert strategies[0].strategy_type == StrategyType.SHORT_STRANGLE
+
+    def test_covered_call(self):
+        """Long stock + short call → covered call."""
+        securities = {}
+        instruments = {}
+
+        sec_stock = make_security(
+            symbol="SPY",
+            streamer_symbol="SPY",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY,
+            quantity=100,
+            quantity_direction=QuantityDirection.LONG,
+        )
+        securities[sec_stock.streamer_symbol] = sec_stock
+
+        sym_call = "SPY  260320C00310000"
+        sec_call = make_security(
+            symbol=sym_call,
+            streamer_symbol=".SPYC310",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+            delta=-0.3,
+            mid_price=2.5,
+        )
+        securities[sec_call.streamer_symbol] = sec_call
+        instruments[sym_call] = make_instrument_json("C", 310.0)
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, instruments)
+
+        assert len(strategies) == 1
+        assert strategies[0].strategy_type == StrategyType.COVERED_CALL
+
+    def test_multiple_underlyings_separate(self):
+        """Positions on different underlyings classify independently."""
+        securities = {}
+        instruments = {}
+
+        # SPY: single naked put
+        sym_spy = "SPY  260320P00290000"
+        sec_spy = make_security(
+            symbol=sym_spy,
+            streamer_symbol=".SPYP290",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        securities[sec_spy.streamer_symbol] = sec_spy
+        instruments[sym_spy] = make_instrument_json("P", 290.0)
+
+        # AAPL: single naked call
+        sym_aapl = "AAPL 260320C00200000"
+        sec_aapl = make_security(
+            symbol=sym_aapl,
+            streamer_symbol=".AAPLC200",
+            underlying_symbol="AAPL",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        securities[sec_aapl.streamer_symbol] = sec_aapl
+        instruments[sym_aapl] = make_instrument_json("C", 200.0)
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, instruments)
+
+        assert len(strategies) == 2
+        types = {s.strategy_type for s in strategies}
+        underlyings = {s.underlying for s in strategies}
+        assert StrategyType.NAKED_PUT in types
+        assert StrategyType.NAKED_CALL in types
+        assert underlyings == {"SPY", "AAPL"}
+
+    def test_greedy_consumes_legs(self):
+        """3 short puts + 1 short call → 1 strangle + 2 naked puts.
+
+        Greedy matcher should match strangle first (1 put + 1 call),
+        leaving 2 unmatched puts as single-leg strategies.
+        """
+        securities = {}
+        instruments = {}
+
+        # 3 short puts at different strikes
+        for strike in [280, 285, 290]:
+            sym = f"SPY  260320P00{strike}000"
+            sec = make_security(
+                symbol=sym,
+                streamer_symbol=f".SPYP{strike}",
+                underlying_symbol="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                quantity=1,
+                quantity_direction=QuantityDirection.SHORT,
+            )
+            securities[sec.streamer_symbol] = sec
+            instruments[sym] = make_instrument_json("P", float(strike))
+
+        # 1 short call
+        sym_call = "SPY  260320C00310000"
+        sec_call = make_security(
+            symbol=sym_call,
+            streamer_symbol=".SPYC310",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        securities[sec_call.streamer_symbol] = sec_call
+        instruments[sym_call] = make_instrument_json("C", 310.0)
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, instruments)
+
+        strangles = [
+            s for s in strategies if s.strategy_type == StrategyType.SHORT_STRANGLE
+        ]
+        naked_puts = [
+            s for s in strategies if s.strategy_type == StrategyType.NAKED_PUT
+        ]
+
+        assert len(strangles) == 1
+        assert len(naked_puts) == 2
+
+    def test_single_stock(self):
+        """Single stock position → Long Stock."""
+        securities = {}
+        sec = make_security(
+            symbol="AAPL",
+            streamer_symbol="AAPL",
+            underlying_symbol="AAPL",
+            instrument_type=InstrumentType.EQUITY,
+            quantity=100,
+            quantity_direction=QuantityDirection.LONG,
+        )
+        securities[sec.streamer_symbol] = sec
+
+        classifier = StrategyClassifier()
+        strategies = classifier.classify(securities, {})
+
+        assert len(strategies) == 1
+        assert strategies[0].strategy_type == StrategyType.LONG_STOCK
+
+    def test_empty_positions(self):
+        """Empty input → empty output."""
+        classifier = StrategyClassifier()
+        strategies = classifier.classify({}, {})
+        assert strategies == []

--- a/unit_tests/analytics/strategies/test_health.py
+++ b/unit_tests/analytics/strategies/test_health.py
@@ -208,6 +208,60 @@ class TestHealthChecks:
         assert len(delta_alerts) == 1
         assert delta_alerts[0].level == AlertLevel.WARNING
 
+    def test_no_delta_alert_for_long_stock(self):
+        """Long Stock is delta-exempt — no delta drift warning."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol="SPY",
+                symbol="SPY",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY,
+                signed_quantity=100,
+                delta=100.0,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.LONG_STOCK,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 0
+
+    def test_no_delta_alert_for_covered_call(self):
+        """Covered Call is delta-exempt — no delta drift warning."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol="SPY",
+                symbol="SPY",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY,
+                signed_quantity=100,
+                delta=100.0,
+            ),
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=-0.30,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.COVERED_CALL,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 0
+
     def test_no_delta_alert_when_none(self):
         """Strategy with no delta data → no delta alert."""
         legs = (

--- a/unit_tests/analytics/strategies/test_health.py
+++ b/unit_tests/analytics/strategies/test_health.py
@@ -1,0 +1,320 @@
+"""Unit tests for StrategyHealthMonitor."""
+
+import tempfile
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from tastytrade.accounts.models import InstrumentType
+from tastytrade.analytics.strategies.health import (
+    AlertLevel,
+    HealthThresholds,
+    StrategyHealthMonitor,
+)
+from tastytrade.analytics.strategies.models import ParsedLeg, Strategy, StrategyType
+
+
+def make_strategy(
+    strategy_type: StrategyType = StrategyType.SHORT_STRANGLE,
+    underlying: str = "SPY",
+    legs: tuple[ParsedLeg, ...] | None = None,
+) -> Strategy:
+    """Create a Strategy with sane defaults for testing."""
+    if legs is None:
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  260320C00310000",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=0.15,
+                theta=-0.05,
+                mid_price=3.0,
+            ),
+            ParsedLeg(
+                streamer_symbol=".SPYP290",
+                symbol="SPY  260320P00290000",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="P",
+                strike=Decimal("290"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=-0.15,
+                theta=-0.05,
+                mid_price=2.5,
+            ),
+        )
+    return Strategy(strategy_type=strategy_type, underlying=underlying, legs=legs)
+
+
+class TestHealthThresholds:
+    def test_defaults(self):
+        t = HealthThresholds()
+        assert t.dte_warning == 21
+        assert t.dte_critical == 7
+        assert t.max_loss_warning == 0.75
+        assert t.max_loss_critical == 0.90
+        assert t.delta_drift_warning == 0.30
+
+    def test_frozen(self):
+        t = HealthThresholds()
+        with pytest.raises(AttributeError):
+            t.dte_warning = 10  # type: ignore[misc]
+
+
+class TestStrategyHealthMonitor:
+    def test_load_default_config(self):
+        """Monitor loads the project TOML config successfully."""
+        monitor = StrategyHealthMonitor()
+        assert monitor.default_thresholds.dte_warning == 21
+        assert "iron_condor" in monitor.thresholds_map
+        assert "short_strangle" in monitor.thresholds_map
+        assert "jade_lizard" in monitor.thresholds_map
+
+    def test_thresholds_for_known_type(self):
+        monitor = StrategyHealthMonitor()
+        t = monitor.thresholds_for(StrategyType.IRON_CONDOR)
+        assert t.dte_warning == 30
+        assert t.dte_critical == 14
+        assert t.delta_drift_warning == 0.20
+
+    def test_thresholds_for_unknown_type_falls_back_to_default(self):
+        monitor = StrategyHealthMonitor()
+        t = monitor.thresholds_for(StrategyType.CUSTOM)
+        assert t == monitor.default_thresholds
+
+    def test_missing_config_uses_defaults(self):
+        monitor = StrategyHealthMonitor(config_path=Path("/nonexistent/config.toml"))
+        assert monitor.default_thresholds == HealthThresholds()
+        assert monitor.thresholds_map == {}
+
+    def test_custom_config(self):
+        toml_content = b"""
+[default]
+dte_warning = 15
+dte_critical = 5
+delta_drift_warning = 0.50
+
+[short_strangle]
+dte_warning = 20
+"""
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as f:
+            f.write(toml_content)
+            f.flush()
+            monitor = StrategyHealthMonitor(config_path=Path(f.name))
+
+        assert monitor.default_thresholds.dte_warning == 15
+        assert monitor.default_thresholds.dte_critical == 5
+        assert monitor.default_thresholds.delta_drift_warning == 0.50
+
+        t = monitor.thresholds_for(StrategyType.SHORT_STRANGLE)
+        assert t.dte_warning == 20
+        assert t.dte_critical == 5  # inherited from default
+
+
+class TestHealthChecks:
+    def test_no_alerts_healthy(self):
+        """Strategy with good DTE and small delta → no alerts."""
+        strategy = make_strategy()
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        assert len(alerts) == 0
+
+    def test_dte_warning(self):
+        """DTE between critical and warning → WARNING alert."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=15,
+                delta=0.10,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.SHORT_STRANGLE,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        # default dte_warning=21 for unspecified, but short_strangle has dte_warning=25
+        alerts = monitor.check(strategy)
+        dte_alerts = [a for a in alerts if "DTE" in a.message]
+        assert len(dte_alerts) == 1
+        assert dte_alerts[0].level == AlertLevel.WARNING
+
+    def test_dte_critical(self):
+        """DTE below critical threshold → CRITICAL alert."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=3,
+                delta=0.10,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.NAKED_CALL,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        dte_alerts = [a for a in alerts if "DTE" in a.message]
+        assert len(dte_alerts) == 1
+        assert dte_alerts[0].level == AlertLevel.CRITICAL
+
+    def test_delta_drift_warning(self):
+        """High net delta triggers delta drift warning."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=-0.50,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.NAKED_CALL,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 1
+        assert delta_alerts[0].level == AlertLevel.WARNING
+
+    def test_no_delta_alert_when_none(self):
+        """Strategy with no delta data → no delta alert."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=None,
+            ),
+        )
+        strategy = make_strategy(legs=legs)
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 0
+
+    def test_check_all(self):
+        """check_all aggregates alerts from multiple strategies."""
+        # Strategy 1: healthy
+        s1 = make_strategy()
+        # Strategy 2: critical DTE
+        legs2 = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=3,
+                delta=0.05,
+            ),
+        )
+        s2 = make_strategy(strategy_type=StrategyType.NAKED_CALL, legs=legs2)
+
+        monitor = StrategyHealthMonitor()
+        all_alerts = monitor.check_all([s1, s2])
+        assert len(all_alerts) >= 1
+
+    def test_iron_condor_specific_thresholds(self):
+        """Iron condor uses its custom thresholds from TOML."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYP280",
+                symbol="SPY  P280",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=1,
+                option_type="P",
+                strike=Decimal("280"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=25,
+                delta=-0.05,
+            ),
+            ParsedLeg(
+                streamer_symbol=".SPYP290",
+                symbol="SPY  P290",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="P",
+                strike=Decimal("290"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=25,
+                delta=-0.15,
+            ),
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=25,
+                delta=0.15,
+            ),
+            ParsedLeg(
+                streamer_symbol=".SPYC320",
+                symbol="SPY  C320",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=1,
+                option_type="C",
+                strike=Decimal("320"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=25,
+                delta=0.05,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.IRON_CONDOR,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+
+        # Iron condor has dte_warning=30, so DTE=25 should trigger warning
+        dte_alerts = [a for a in alerts if "DTE" in a.message]
+        assert len(dte_alerts) == 1
+        assert dte_alerts[0].level == AlertLevel.WARNING

--- a/unit_tests/analytics/strategies/test_health.py
+++ b/unit_tests/analytics/strategies/test_health.py
@@ -59,7 +59,7 @@ def make_strategy(
 class TestHealthThresholds:
     def test_defaults(self):
         t = HealthThresholds()
-        assert t.dte_warning == 21
+        assert t.dte_warning == 14
         assert t.dte_critical == 7
         assert t.max_loss_warning == 0.75
         assert t.max_loss_critical == 0.90
@@ -68,14 +68,14 @@ class TestHealthThresholds:
     def test_frozen(self):
         t = HealthThresholds()
         with pytest.raises(AttributeError):
-            t.dte_warning = 10  # type: ignore[misc]
+            t.dte_warning = 99  # type: ignore[misc]
 
 
 class TestStrategyHealthMonitor:
     def test_load_default_config(self):
         """Monitor loads the project TOML config successfully."""
         monitor = StrategyHealthMonitor()
-        assert monitor.default_thresholds.dte_warning == 21
+        assert monitor.default_thresholds.dte_warning == 14
         assert "iron_condor" in monitor.thresholds_map
         assert "short_strangle" in monitor.thresholds_map
         assert "jade_lizard" in monitor.thresholds_map
@@ -83,8 +83,8 @@ class TestStrategyHealthMonitor:
     def test_thresholds_for_known_type(self):
         monitor = StrategyHealthMonitor()
         t = monitor.thresholds_for(StrategyType.IRON_CONDOR)
-        assert t.dte_warning == 30
-        assert t.dte_critical == 14
+        assert t.dte_warning == 14
+        assert t.dte_critical == 7
         assert t.delta_drift_warning == 0.20
 
     def test_thresholds_for_unknown_type_falls_back_to_default(self):
@@ -141,7 +141,7 @@ class TestHealthChecks:
                 option_type="C",
                 strike=Decimal("310"),
                 expiration=date(2026, 3, 20),
-                days_to_expiration=15,
+                days_to_expiration=10,
                 delta=0.10,
             ),
         )
@@ -150,7 +150,7 @@ class TestHealthChecks:
             legs=legs,
         )
         monitor = StrategyHealthMonitor()
-        # default dte_warning=21 for unspecified, but short_strangle has dte_warning=25
+        # short_strangle has dte_warning=14, dte_critical=7
         alerts = monitor.check(strategy)
         dte_alerts = [a for a in alerts if "DTE" in a.message]
         assert len(dte_alerts) == 1
@@ -267,7 +267,7 @@ class TestHealthChecks:
                 option_type="P",
                 strike=Decimal("280"),
                 expiration=date(2026, 3, 20),
-                days_to_expiration=25,
+                days_to_expiration=12,
                 delta=-0.05,
             ),
             ParsedLeg(
@@ -279,7 +279,7 @@ class TestHealthChecks:
                 option_type="P",
                 strike=Decimal("290"),
                 expiration=date(2026, 3, 20),
-                days_to_expiration=25,
+                days_to_expiration=12,
                 delta=-0.15,
             ),
             ParsedLeg(
@@ -291,7 +291,7 @@ class TestHealthChecks:
                 option_type="C",
                 strike=Decimal("310"),
                 expiration=date(2026, 3, 20),
-                days_to_expiration=25,
+                days_to_expiration=12,
                 delta=0.15,
             ),
             ParsedLeg(
@@ -303,7 +303,7 @@ class TestHealthChecks:
                 option_type="C",
                 strike=Decimal("320"),
                 expiration=date(2026, 3, 20),
-                days_to_expiration=25,
+                days_to_expiration=12,
                 delta=0.05,
             ),
         )
@@ -314,7 +314,7 @@ class TestHealthChecks:
         monitor = StrategyHealthMonitor()
         alerts = monitor.check(strategy)
 
-        # Iron condor has dte_warning=30, so DTE=25 should trigger warning
+        # Iron condor has dte_warning=14, so DTE=12 should trigger warning
         dte_alerts = [a for a in alerts if "DTE" in a.message]
         assert len(dte_alerts) == 1
         assert dte_alerts[0].level == AlertLevel.WARNING

--- a/unit_tests/analytics/strategies/test_patterns.py
+++ b/unit_tests/analytics/strategies/test_patterns.py
@@ -1,0 +1,611 @@
+"""Unit tests for strategy pattern matchers."""
+
+from datetime import date
+from decimal import Decimal
+
+from tastytrade.accounts.models import InstrumentType
+from tastytrade.analytics.strategies.models import ParsedLeg, StrategyType
+from tastytrade.analytics.strategies.patterns import (
+    match_big_lizard,
+    match_call_butterfly,
+    match_calendar_spread,
+    match_collar,
+    match_covered_call,
+    match_covered_jade_lizard,
+    match_diagonal_spread,
+    match_iron_butterfly,
+    match_iron_condor,
+    match_jade_lizard,
+    match_protective_put,
+    match_put_butterfly,
+    match_ratio_spread,
+    match_single_leg,
+    match_straddle,
+    match_strangle,
+    match_synthetic,
+    match_vertical_spread,
+    same_abs_quantity,
+    same_expiration,
+)
+
+EXP = date(2026, 3, 20)
+EXP2 = date(2026, 4, 17)
+
+
+def make_option(
+    option_type: str,
+    strike: Decimal,
+    signed_quantity: float,
+    expiration: date = EXP,
+    underlying: str = "SPY",
+    symbol: str = "",
+) -> ParsedLeg:
+    """Factory for option ParsedLeg."""
+    return ParsedLeg(
+        streamer_symbol=f".SPY{option_type}{strike}",
+        symbol=symbol or f"SPY  260320{option_type}{int(strike * 1000):08d}",
+        underlying=underlying,
+        instrument_type=InstrumentType.EQUITY_OPTION,
+        signed_quantity=signed_quantity,
+        option_type=option_type,
+        strike=strike,
+        expiration=expiration,
+        days_to_expiration=30,
+        delta=0.3 if option_type == "C" else -0.3,
+        mid_price=2.50,
+    )
+
+
+def make_stock(
+    signed_quantity: float,
+    underlying: str = "SPY",
+) -> ParsedLeg:
+    """Factory for stock ParsedLeg."""
+    return ParsedLeg(
+        streamer_symbol=underlying,
+        symbol=underlying,
+        underlying=underlying,
+        instrument_type=InstrumentType.EQUITY,
+        signed_quantity=signed_quantity,
+    )
+
+
+# ===== Helper function tests =====
+
+
+class TestHelpers:
+    def test_same_expiration_true(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),
+            make_option("P", Decimal("290"), -1),
+        ]
+        assert same_expiration(legs) is True
+
+    def test_same_expiration_false(self):
+        legs = [
+            make_option("C", Decimal("300"), 1, expiration=EXP),
+            make_option("P", Decimal("290"), -1, expiration=EXP2),
+        ]
+        assert same_expiration(legs) is False
+
+    def test_same_abs_quantity_true(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),
+            make_option("P", Decimal("290"), -1),
+        ]
+        assert same_abs_quantity(legs) is True
+
+    def test_same_abs_quantity_false(self):
+        legs = [
+            make_option("C", Decimal("300"), 2),
+            make_option("P", Decimal("290"), -1),
+        ]
+        assert same_abs_quantity(legs) is False
+
+
+# ===== Iron Condor =====
+
+
+class TestIronCondor:
+    def test_match(self):
+        legs = [
+            make_option("P", Decimal("280"), 1),  # long low put
+            make_option("P", Decimal("290"), -1),  # short high put
+            make_option("C", Decimal("310"), -1),  # short low call
+            make_option("C", Decimal("320"), 1),  # long high call
+        ]
+        result = match_iron_condor(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.IRON_CONDOR
+        assert len(result.matched_legs) == 4
+
+    def test_no_match_same_strikes(self):
+        """Iron condor requires put strikes < call strikes."""
+        legs = [
+            make_option("P", Decimal("300"), 1),
+            make_option("P", Decimal("310"), -1),
+            make_option("C", Decimal("300"), -1),
+            make_option("C", Decimal("310"), 1),
+        ]
+        # Puts overlap with calls, but short put at 310 >= short call at 300
+        result = match_iron_condor(legs)
+        assert result is None
+
+    def test_no_match_different_quantities(self):
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("290"), -2),
+            make_option("C", Decimal("310"), -1),
+            make_option("C", Decimal("320"), 1),
+        ]
+        result = match_iron_condor(legs)
+        assert result is None
+
+    def test_no_match_insufficient_legs(self):
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("290"), -1),
+        ]
+        result = match_iron_condor(legs)
+        assert result is None
+
+
+# ===== Iron Butterfly =====
+
+
+class TestIronButterfly:
+    def test_match(self):
+        legs = [
+            make_option("P", Decimal("280"), 1),  # long low put
+            make_option("P", Decimal("300"), -1),  # short put at center
+            make_option("C", Decimal("300"), -1),  # short call at center
+            make_option("C", Decimal("320"), 1),  # long high call
+        ]
+        result = match_iron_butterfly(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.IRON_BUTTERFLY
+
+    def test_no_match_different_center_strikes(self):
+        """Iron butterfly requires short put strike == short call strike."""
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("295"), -1),
+            make_option("C", Decimal("305"), -1),
+            make_option("C", Decimal("320"), 1),
+        ]
+        result = match_iron_butterfly(legs)
+        assert result is None
+
+
+# ===== Call Butterfly =====
+
+
+class TestCallButterfly:
+    def test_match(self):
+        legs = [
+            make_option("C", Decimal("290"), 1),  # long low
+            make_option("C", Decimal("300"), -2),  # short 2x middle
+            make_option("C", Decimal("310"), 1),  # long high
+        ]
+        result = match_call_butterfly(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.CALL_BUTTERFLY
+        assert len(result.matched_legs) == 3
+
+    def test_no_match_wrong_ratio(self):
+        legs = [
+            make_option("C", Decimal("290"), 1),
+            make_option("C", Decimal("300"), -1),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_call_butterfly(legs)
+        assert result is None
+
+    def test_no_match_unequal_spacing(self):
+        legs = [
+            make_option("C", Decimal("290"), 1),
+            make_option("C", Decimal("295"), -2),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_call_butterfly(legs)
+        assert result is None
+
+
+# ===== Put Butterfly =====
+
+
+class TestPutButterfly:
+    def test_match(self):
+        legs = [
+            make_option("P", Decimal("290"), 1),
+            make_option("P", Decimal("300"), -2),
+            make_option("P", Decimal("310"), 1),
+        ]
+        result = match_put_butterfly(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.PUT_BUTTERFLY
+
+
+# ===== Jade Lizard =====
+
+
+class TestJadeLizard:
+    def test_match(self):
+        legs = [
+            make_option("P", Decimal("280"), -1),  # short OTM put
+            make_option("C", Decimal("310"), -1),  # short call
+            make_option("C", Decimal("320"), 1),  # long higher call
+        ]
+        result = match_jade_lizard(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.JADE_LIZARD
+        assert len(result.matched_legs) == 3
+
+    def test_no_match_wrong_call_direction(self):
+        legs = [
+            make_option("P", Decimal("280"), -1),
+            make_option("C", Decimal("310"), 1),  # wrong: long lower call
+            make_option("C", Decimal("320"), -1),  # wrong: short higher call
+        ]
+        result = match_jade_lizard(legs)
+        assert result is None
+
+
+# ===== Covered Jade Lizard =====
+
+
+class TestCoveredJadeLizard:
+    def test_match(self):
+        legs = [
+            make_stock(100),  # long stock
+            make_option("P", Decimal("280"), -1),  # short put
+            make_option("C", Decimal("310"), -1),  # short lower call
+            make_option("C", Decimal("320"), 1),  # long higher call
+        ]
+        result = match_covered_jade_lizard(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.COVERED_JADE_LIZARD
+        assert len(result.matched_legs) == 4
+
+
+# ===== Big Lizard =====
+
+
+class TestBigLizard:
+    def test_match(self):
+        legs = [
+            make_option("P", Decimal("300"), -1),  # short put at 300
+            make_option("C", Decimal("300"), -1),  # short call at 300
+            make_option("C", Decimal("320"), 1),  # long call at 320
+        ]
+        result = match_big_lizard(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.BIG_LIZARD
+
+    def test_no_match_straddle_strikes_differ(self):
+        legs = [
+            make_option("P", Decimal("295"), -1),
+            make_option("C", Decimal("300"), -1),
+            make_option("C", Decimal("320"), 1),
+        ]
+        result = match_big_lizard(legs)
+        assert result is None
+
+
+# ===== Collar =====
+
+
+class TestCollar:
+    def test_match(self):
+        legs = [
+            make_stock(100),
+            make_option("P", Decimal("280"), 1),  # long put
+            make_option("C", Decimal("310"), -1),  # short call
+        ]
+        result = match_collar(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.COLLAR
+        assert len(result.matched_legs) == 3
+
+
+# ===== Covered Call =====
+
+
+class TestCoveredCall:
+    def test_match(self):
+        legs = [
+            make_stock(100),
+            make_option("C", Decimal("310"), -1),
+        ]
+        result = match_covered_call(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.COVERED_CALL
+
+    def test_no_match_long_call(self):
+        legs = [
+            make_stock(100),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_covered_call(legs)
+        assert result is None
+
+
+# ===== Protective Put =====
+
+
+class TestProtectivePut:
+    def test_match(self):
+        legs = [
+            make_stock(100),
+            make_option("P", Decimal("280"), 1),
+        ]
+        result = match_protective_put(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.PROTECTIVE_PUT
+
+
+# ===== Vertical Spreads =====
+
+
+class TestVerticalSpread:
+    def test_bull_call_spread(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),  # long lower call
+            make_option("C", Decimal("310"), -1),  # short higher call
+        ]
+        result = match_vertical_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.BULL_CALL_SPREAD
+
+    def test_bear_call_spread(self):
+        legs = [
+            make_option("C", Decimal("300"), -1),  # short lower call
+            make_option("C", Decimal("310"), 1),  # long higher call
+        ]
+        result = match_vertical_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.BEAR_CALL_SPREAD
+
+    def test_bull_put_spread(self):
+        legs = [
+            make_option("P", Decimal("280"), -1),  # short lower put
+            make_option("P", Decimal("290"), 1),  # long higher put
+        ]
+        result = match_vertical_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.BULL_PUT_SPREAD
+
+    def test_bear_put_spread(self):
+        legs = [
+            make_option("P", Decimal("280"), 1),  # long lower put
+            make_option("P", Decimal("290"), -1),  # short higher put
+        ]
+        result = match_vertical_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.BEAR_PUT_SPREAD
+
+    def test_no_match_different_expirations(self):
+        legs = [
+            make_option("C", Decimal("300"), 1, expiration=EXP),
+            make_option("C", Decimal("310"), -1, expiration=EXP2),
+        ]
+        result = match_vertical_spread(legs)
+        assert result is None
+
+    def test_no_match_same_strike(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),
+            make_option("C", Decimal("300"), -1),
+        ]
+        result = match_vertical_spread(legs)
+        assert result is None
+
+
+# ===== Ratio Spread =====
+
+
+class TestRatioSpread:
+    def test_match(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),  # 1x long
+            make_option("C", Decimal("310"), -2),  # 2x short
+        ]
+        result = match_ratio_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.RATIO_SPREAD
+
+    def test_no_match_same_quantity(self):
+        """Same quantity = vertical spread, not ratio."""
+        legs = [
+            make_option("C", Decimal("300"), 1),
+            make_option("C", Decimal("310"), -1),
+        ]
+        result = match_ratio_spread(legs)
+        assert result is None
+
+
+# ===== Straddle =====
+
+
+class TestStraddle:
+    def test_short_straddle(self):
+        legs = [
+            make_option("C", Decimal("300"), -1),
+            make_option("P", Decimal("300"), -1),
+        ]
+        result = match_straddle(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.SHORT_STRADDLE
+
+    def test_long_straddle(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),
+            make_option("P", Decimal("300"), 1),
+        ]
+        result = match_straddle(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.LONG_STRADDLE
+
+    def test_no_match_different_strikes(self):
+        legs = [
+            make_option("C", Decimal("305"), -1),
+            make_option("P", Decimal("300"), -1),
+        ]
+        result = match_straddle(legs)
+        assert result is None
+
+
+# ===== Strangle =====
+
+
+class TestStrangle:
+    def test_short_strangle(self):
+        legs = [
+            make_option("C", Decimal("310"), -1),
+            make_option("P", Decimal("290"), -1),
+        ]
+        result = match_strangle(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.SHORT_STRANGLE
+
+    def test_long_strangle(self):
+        legs = [
+            make_option("C", Decimal("310"), 1),
+            make_option("P", Decimal("290"), 1),
+        ]
+        result = match_strangle(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.LONG_STRANGLE
+
+    def test_no_match_same_strike(self):
+        """Same strike = straddle, not strangle."""
+        legs = [
+            make_option("C", Decimal("300"), -1),
+            make_option("P", Decimal("300"), -1),
+        ]
+        result = match_strangle(legs)
+        assert result is None
+
+    def test_no_match_opposite_directions(self):
+        legs = [
+            make_option("C", Decimal("310"), 1),
+            make_option("P", Decimal("290"), -1),
+        ]
+        result = match_strangle(legs)
+        assert result is None
+
+
+# ===== Synthetic =====
+
+
+class TestSynthetic:
+    def test_synthetic_long(self):
+        legs = [
+            make_option("C", Decimal("300"), 1),  # long call
+            make_option("P", Decimal("300"), -1),  # short put
+        ]
+        result = match_synthetic(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.SYNTHETIC_LONG
+
+    def test_synthetic_short(self):
+        legs = [
+            make_option("C", Decimal("300"), -1),  # short call
+            make_option("P", Decimal("300"), 1),  # long put
+        ]
+        result = match_synthetic(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.SYNTHETIC_SHORT
+
+
+# ===== Calendar Spread =====
+
+
+class TestCalendarSpread:
+    def test_match(self):
+        legs = [
+            make_option("C", Decimal("300"), -1, expiration=EXP),
+            make_option("C", Decimal("300"), 1, expiration=EXP2),
+        ]
+        result = match_calendar_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.CALENDAR_SPREAD
+
+    def test_no_match_different_strikes(self):
+        legs = [
+            make_option("C", Decimal("300"), -1, expiration=EXP),
+            make_option("C", Decimal("310"), 1, expiration=EXP2),
+        ]
+        result = match_calendar_spread(legs)
+        assert result is None
+
+    def test_no_match_same_expiration(self):
+        legs = [
+            make_option("C", Decimal("300"), -1, expiration=EXP),
+            make_option("C", Decimal("300"), 1, expiration=EXP),
+        ]
+        result = match_calendar_spread(legs)
+        assert result is None
+
+
+# ===== Diagonal Spread =====
+
+
+class TestDiagonalSpread:
+    def test_match(self):
+        legs = [
+            make_option("C", Decimal("300"), -1, expiration=EXP),
+            make_option("C", Decimal("310"), 1, expiration=EXP2),
+        ]
+        result = match_diagonal_spread(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.DIAGONAL_SPREAD
+
+
+# ===== Single Leg =====
+
+
+class TestSingleLeg:
+    def test_long_stock(self):
+        leg = make_stock(100)
+        assert match_single_leg(leg) == StrategyType.LONG_STOCK
+
+    def test_short_stock(self):
+        leg = make_stock(-100)
+        assert match_single_leg(leg) == StrategyType.SHORT_STOCK
+
+    def test_long_call(self):
+        leg = make_option("C", Decimal("300"), 1)
+        assert match_single_leg(leg) == StrategyType.LONG_CALL
+
+    def test_naked_call(self):
+        leg = make_option("C", Decimal("300"), -1)
+        assert match_single_leg(leg) == StrategyType.NAKED_CALL
+
+    def test_long_put(self):
+        leg = make_option("P", Decimal("300"), 1)
+        assert match_single_leg(leg) == StrategyType.LONG_PUT
+
+    def test_naked_put(self):
+        leg = make_option("P", Decimal("300"), -1)
+        assert match_single_leg(leg) == StrategyType.NAKED_PUT
+
+    def test_long_future(self):
+        leg = ParsedLeg(
+            streamer_symbol="/ES",
+            symbol="/ES",
+            underlying="/ES",
+            instrument_type=InstrumentType.FUTURE,
+            signed_quantity=1,
+        )
+        assert match_single_leg(leg) == StrategyType.LONG_FUTURE
+
+    def test_short_crypto(self):
+        leg = ParsedLeg(
+            streamer_symbol="BTC/USD",
+            symbol="BTC/USD",
+            underlying="BTC/USD",
+            instrument_type=InstrumentType.CRYPTOCURRENCY,
+            signed_quantity=-1,
+        )
+        assert match_single_leg(leg) == StrategyType.SHORT_CRYPTO

--- a/unit_tests/analytics/strategies/test_patterns.py
+++ b/unit_tests/analytics/strategies/test_patterns.py
@@ -241,11 +241,33 @@ class TestJadeLizard:
         assert result.strategy_type == StrategyType.JADE_LIZARD
         assert len(result.matched_legs) == 3
 
+    def test_variant_b_short_call_plus_bull_put_spread(self):
+        """Variant B: short call + bull put spread (short put + long lower put)."""
+        legs = [
+            make_option("C", Decimal("320"), -1),  # short OTM call
+            make_option("P", Decimal("290"), -1),  # short put (higher strike)
+            make_option("P", Decimal("280"), 1),  # long put (lower strike)
+        ]
+        result = match_jade_lizard(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.JADE_LIZARD
+        assert len(result.matched_legs) == 3
+
     def test_no_match_wrong_call_direction(self):
         legs = [
             make_option("P", Decimal("280"), -1),
             make_option("C", Decimal("310"), 1),  # wrong: long lower call
             make_option("C", Decimal("320"), -1),  # wrong: short higher call
+        ]
+        result = match_jade_lizard(legs)
+        assert result is None
+
+    def test_no_match_variant_b_wrong_put_direction(self):
+        """Variant B fails when put spread direction is inverted."""
+        legs = [
+            make_option("C", Decimal("320"), -1),  # short call
+            make_option("P", Decimal("290"), 1),  # wrong: long higher put
+            make_option("P", Decimal("280"), -1),  # wrong: short lower put
         ]
         result = match_jade_lizard(legs)
         assert result is None

--- a/unit_tests/analytics/test_position_reader.py
+++ b/unit_tests/analytics/test_position_reader.py
@@ -63,6 +63,9 @@ def mock_redis() -> AsyncMock:
 def reader(mock_redis: AsyncMock) -> PositionMetricsReader:
     r = PositionMetricsReader.__new__(PositionMetricsReader)
     r.redis = mock_redis
+    r.position_metrics_df = pd.DataFrame()
+    r.tracker = None
+    r.instruments = {}
     return r
 
 
@@ -74,6 +77,7 @@ async def test_read_returns_dataframe(
         {b"SPY": make_position_json("SPY", "SPY").encode()},  # positions
         {b"SPY": make_quote_json("SPY", 690.0, 691.0).encode()},  # quotes
         {},  # greeks
+        {},  # instruments
     ]
     df = await reader.read()
     assert isinstance(df, pd.DataFrame)
@@ -91,16 +95,9 @@ async def test_read_joins_greeks_for_options(
                 "SPY P666", ".SPY260402P666", inst_type="Equity Option"
             ).encode()
         },
-        {
-            b".SPY260402P666": make_quote_json(
-                ".SPY260402P666", 5.75, 5.80
-            ).encode()
-        },
-        {
-            b".SPY260402P666": make_greeks_json(
-                ".SPY260402P666", -0.24, 0.19
-            ).encode()
-        },
+        {b".SPY260402P666": make_quote_json(".SPY260402P666", 5.75, 5.80).encode()},
+        {b".SPY260402P666": make_greeks_json(".SPY260402P666", -0.24, 0.19).encode()},
+        {},  # instruments
     ]
     df = await reader.read()
     assert len(df) == 1
@@ -112,7 +109,7 @@ async def test_read_joins_greeks_for_options(
 async def test_read_empty_positions_returns_empty_df(
     reader: PositionMetricsReader, mock_redis: AsyncMock
 ) -> None:
-    mock_redis.hgetall.side_effect = [{}, {}, {}]
+    mock_redis.hgetall.side_effect = [{}, {}, {}, {}]
     df = await reader.read()
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 0
@@ -125,7 +122,8 @@ async def test_read_includes_required_columns(
     mock_redis.hgetall.side_effect = [
         {b"SPY": make_position_json("SPY", "SPY").encode()},
         {b"SPY": make_quote_json("SPY", 690.0, 691.0).encode()},
-        {},
+        {},  # greeks
+        {},  # instruments
     ]
     df = await reader.read()
     for col in [

--- a/unit_tests/market/test_instruments_client.py
+++ b/unit_tests/market/test_instruments_client.py
@@ -1,0 +1,327 @@
+"""Tests for InstrumentsClient and instrument models."""
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tastytrade.market.instruments import INSTRUMENT_BATCH_SIZE, InstrumentsClient
+from tastytrade.market.models import (
+    CryptocurrencyInstrument,
+    EquityInstrument,
+    EquityOptionInstrument,
+    FutureInstrument,
+    FutureOptionInstrument,
+    OptionType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_ok_response(json_data: dict[str, Any]) -> AsyncMock:
+    """Create a mock aiohttp response with status=200 and given JSON payload."""
+    response_mock = AsyncMock()
+    response_mock.status = 200
+    response_mock.json.return_value = json_data
+    response_mock.__aenter__ = AsyncMock(return_value=response_mock)
+    response_mock.__aexit__ = AsyncMock(return_value=False)
+    return response_mock
+
+
+def make_equity_option_json(**overrides: Any) -> dict[str, Any]:
+    """Factory for equity option instrument API response."""
+    base: dict[str, Any] = {
+        "symbol": "SPY   260320C00500000",
+        "instrument-type": "Equity Option",
+        "strike-price": "500.0",
+        "option-type": "C",
+        "root-symbol": "SPY",
+        "underlying-symbol": "SPY",
+        "expiration-date": "2026-03-20",
+        "days-to-expiration": 20,
+        "expires-at": "2026-03-20T21:00:00Z",
+        "exercise-style": "American",
+        "settlement-type": "PM",
+        "shares-per-contract": 100,
+        "streamer-symbol": ".SPY260320C500",
+        "active": True,
+        "is-closing-only": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def make_future_option_json(**overrides: Any) -> dict[str, Any]:
+    """Factory for future option instrument API response."""
+    base: dict[str, Any] = {
+        "symbol": "./MESM6EX3H6 260320P6450",
+        "underlying-symbol": "/MESM6",
+        "product-code": "EX3",
+        "expiration-date": "2026-03-20",
+        "strike-price": "6450.0",
+        "option-type": "P",
+        "exchange": "CME",
+        "streamer-symbol": "./EX3H26P6450:XCME",
+    }
+    base.update(overrides)
+    return base
+
+
+def make_equity_json(**overrides: Any) -> dict[str, Any]:
+    """Factory for equity instrument API response."""
+    base: dict[str, Any] = {
+        "symbol": "SPY",
+        "instrument-type": "Equity",
+        "description": "SPDR S&P 500 ETF Trust",
+        "is-etf": True,
+        "active": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def make_future_json(**overrides: Any) -> dict[str, Any]:
+    """Factory for future instrument API response."""
+    base: dict[str, Any] = {
+        "symbol": "/MESM6",
+        "product-code": "MES",
+        "contract-size": "5.0",
+        "notional-multiplier": "5.0",
+        "expiration-date": "2026-06-19",
+        "active": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def make_crypto_json(**overrides: Any) -> dict[str, Any]:
+    """Factory for cryptocurrency instrument API response."""
+    base: dict[str, Any] = {
+        "symbol": "BTC/USD",
+        "instrument-type": "Cryptocurrency",
+        "description": "Bitcoin",
+        "active": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def make_api_response(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap items in TT API response shape."""
+    return {"data": {"items": items}}
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    """Mock AsyncSessionHandler with controllable responses."""
+    session = MagicMock()
+    session.base_url = "https://api.tastyworks.com"
+    session.session = MagicMock()
+    return session
+
+
+@pytest.fixture
+def client(mock_session: MagicMock) -> InstrumentsClient:
+    return InstrumentsClient(mock_session)
+
+
+# ---------------------------------------------------------------------------
+# Model validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_equity_option_instrument_parses() -> None:
+    inst = EquityOptionInstrument.model_validate(make_equity_option_json())
+    assert inst.symbol == "SPY   260320C00500000"
+    assert inst.strike_price == Decimal("500.0")
+    assert inst.option_type == OptionType.CALL
+    assert inst.root_symbol == "SPY"
+    assert inst.underlying_symbol == "SPY"
+    assert inst.days_to_expiration == 20
+    assert inst.shares_per_contract == 100
+    assert inst.streamer_symbol == ".SPY260320C500"
+    assert inst.active is True
+    assert inst.is_closing_only is False
+
+
+def test_equity_option_instrument_put() -> None:
+    inst = EquityOptionInstrument.model_validate(
+        make_equity_option_json(**{"option-type": "P", "strike-price": "305.0"})
+    )
+    assert inst.option_type == OptionType.PUT
+    assert inst.strike_price == Decimal("305.0")
+
+
+def test_future_option_instrument_parses() -> None:
+    inst = FutureOptionInstrument.model_validate(make_future_option_json())
+    assert inst.symbol == "./MESM6EX3H6 260320P6450"
+    assert inst.underlying_symbol == "/MESM6"
+    assert inst.product_code == "EX3"
+    assert inst.strike_price == Decimal("6450.0")
+    assert inst.option_type == OptionType.PUT
+    assert inst.exchange == "CME"
+
+
+def test_equity_instrument_parses() -> None:
+    inst = EquityInstrument.model_validate(make_equity_json())
+    assert inst.symbol == "SPY"
+    assert inst.is_etf is True
+    assert inst.active is True
+    assert inst.description == "SPDR S&P 500 ETF Trust"
+
+
+def test_future_instrument_parses() -> None:
+    inst = FutureInstrument.model_validate(make_future_json())
+    assert inst.symbol == "/MESM6"
+    assert inst.product_code == "MES"
+    assert inst.contract_size == Decimal("5.0")
+    assert inst.notional_multiplier == Decimal("5.0")
+
+
+def test_cryptocurrency_instrument_parses() -> None:
+    inst = CryptocurrencyInstrument.model_validate(make_crypto_json())
+    assert inst.symbol == "BTC/USD"
+    assert inst.instrument_type == "Cryptocurrency"
+    assert inst.active is True
+
+
+def test_equity_option_instrument_is_frozen() -> None:
+    from pydantic import ValidationError
+
+    inst = EquityOptionInstrument.model_validate(make_equity_option_json())
+    with pytest.raises(ValidationError):
+        inst.symbol = "OTHER"  # type: ignore[misc]
+
+
+def test_equity_option_instrument_rejects_extra_fields() -> None:
+    data = make_equity_option_json()
+    data["unknown-field"] = "value"
+    with pytest.raises(ValueError):
+        EquityOptionInstrument.model_validate(data)
+
+
+def test_model_dump_json_uses_aliases() -> None:
+    inst = EquityOptionInstrument.model_validate(make_equity_option_json())
+    json_str = inst.model_dump_json(by_alias=True)
+    assert "strike-price" in json_str
+    assert "option-type" in json_str
+    assert "underlying-symbol" in json_str
+
+
+# ---------------------------------------------------------------------------
+# InstrumentsClient tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_equity_options(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_equity_option_json()])
+    )
+
+    result = await client.get_equity_options(["SPY   260320C00500000"])
+    assert len(result) == 1
+    assert isinstance(result[0], EquityOptionInstrument)
+    assert result[0].strike_price == Decimal("500.0")
+
+
+@pytest.mark.asyncio
+async def test_get_future_options(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_future_option_json()])
+    )
+
+    result = await client.get_future_options(["./MESM6EX3H6 260320P6450"])
+    assert len(result) == 1
+    assert isinstance(result[0], FutureOptionInstrument)
+
+
+@pytest.mark.asyncio
+async def test_get_equities(client: InstrumentsClient, mock_session: MagicMock) -> None:
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_equity_json()])
+    )
+
+    result = await client.get_equities(["SPY"])
+    assert len(result) == 1
+    assert isinstance(result[0], EquityInstrument)
+
+
+@pytest.mark.asyncio
+async def test_get_futures(client: InstrumentsClient, mock_session: MagicMock) -> None:
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_future_json()])
+    )
+
+    result = await client.get_futures(["/MESM6"])
+    assert len(result) == 1
+    assert isinstance(result[0], FutureInstrument)
+
+
+@pytest.mark.asyncio
+async def test_get_cryptocurrencies(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_crypto_json()])
+    )
+
+    result = await client.get_cryptocurrencies(["BTC/USD"])
+    assert len(result) == 1
+    assert isinstance(result[0], CryptocurrencyInstrument)
+
+
+@pytest.mark.asyncio
+async def test_empty_symbols_returns_empty(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    result = await client.get_equity_options([])
+    assert result == []
+    mock_session.session.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_size_respected(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    """Many symbols should be batched into groups of INSTRUMENT_BATCH_SIZE."""
+    symbols = [f"SYM{i}" for i in range(INSTRUMENT_BATCH_SIZE + 10)]
+    mock_session.session.get.return_value = make_ok_response(make_api_response([]))
+
+    await client.get_equity_options(symbols)
+    assert mock_session.session.get.call_count == 2  # 50 + 10
+
+
+@pytest.mark.asyncio
+async def test_malformed_item_skipped(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    """Malformed items in API response should be skipped, not crash."""
+    mock_session.session.get.return_value = make_ok_response(
+        make_api_response([make_equity_option_json(), {"bad": "data"}])
+    )
+
+    result = await client.get_equity_options(["SPY   260320C00500000"])
+    assert len(result) == 1  # Only the valid one parsed
+
+
+@pytest.mark.asyncio
+async def test_url_construction(
+    client: InstrumentsClient, mock_session: MagicMock
+) -> None:
+    mock_session.session.get.return_value = make_ok_response(make_api_response([]))
+
+    await client.get_equity_options(["SPY   260320C00500000"])
+    call_args = mock_session.session.get.call_args
+    assert call_args[0][0] == "https://api.tastyworks.com/instruments/equity-options"
+    # Check symbol[] params
+    params = call_args[1]["params"]
+    assert params == [("symbol[]", "SPY   260320C00500000")]

--- a/unit_tests/market/test_instruments_client.py
+++ b/unit_tests/market/test_instruments_client.py
@@ -301,6 +301,66 @@ def test_model_dump_json_uses_aliases() -> None:
 
 
 # ---------------------------------------------------------------------------
+# API resilience tests — models must survive schema changes
+# ---------------------------------------------------------------------------
+
+
+def test_equity_option_fails_without_required_fields() -> None:
+    """Option instruments must have strategy-critical fields — fail fast on bad data."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        EquityOptionInstrument.model_validate({"symbol": "SPY   260320C00500000"})
+
+
+def test_future_option_fails_without_required_fields() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        FutureOptionInstrument.model_validate({"symbol": "./MESM6EX3H6 260320P6450"})
+
+
+def test_equity_option_survives_missing_informational_fields() -> None:
+    """Informational fields are Optional — only strategy-critical ones are required."""
+    data = {
+        "symbol": "SPY   260320C00500000",
+        "strike-price": "500.0",
+        "option-type": "C",
+        "underlying-symbol": "SPY",
+        "expiration-date": "2026-03-20",
+        "days-to-expiration": 20,
+        "streamer-symbol": ".SPY260320C500",
+    }
+    inst = EquityOptionInstrument.model_validate(data)
+    assert inst.symbol == "SPY   260320C00500000"
+    assert inst.strike_price == Decimal("500.0")
+    # Informational fields default to None
+    assert inst.exercise_style is None
+    assert inst.settlement_type is None
+    assert inst.shares_per_contract is None
+
+
+def test_equity_parses_with_only_symbol() -> None:
+    """Equities only require symbol — no strategy-critical option fields."""
+    inst = EquityInstrument.model_validate({"symbol": "SPY"})
+    assert inst.symbol == "SPY"
+    assert inst.is_etf is None
+    assert inst.active is None
+
+
+def test_future_parses_with_only_symbol() -> None:
+    inst = FutureInstrument.model_validate({"symbol": "/MESM6"})
+    assert inst.symbol == "/MESM6"
+    assert inst.product_code is None
+
+
+def test_crypto_parses_with_only_symbol() -> None:
+    inst = CryptocurrencyInstrument.model_validate({"symbol": "BTC/USD"})
+    assert inst.symbol == "BTC/USD"
+    assert inst.instrument_type is None
+
+
+# ---------------------------------------------------------------------------
 # InstrumentsClient tests
 # ---------------------------------------------------------------------------
 

--- a/unit_tests/market/test_instruments_client.py
+++ b/unit_tests/market/test_instruments_client.py
@@ -33,7 +33,10 @@ def make_ok_response(json_data: dict[str, Any]) -> AsyncMock:
 
 
 def make_equity_option_json(**overrides: Any) -> dict[str, Any]:
-    """Factory for equity option instrument API response."""
+    """Factory for equity option instrument API response.
+
+    Mirrors the full 19-field shape returned by GET /instruments/equity-options.
+    """
     base: dict[str, Any] = {
         "symbol": "SPY   260320C00500000",
         "instrument-type": "Equity Option",
@@ -50,13 +53,20 @@ def make_equity_option_json(**overrides: Any) -> dict[str, Any]:
         "streamer-symbol": ".SPY260320C500",
         "active": True,
         "is-closing-only": False,
+        "expiration-type": "Weekly",
+        "market-time-instrument-collection": "Cash Settled Equity Option",
+        "option-chain-type": "Standard",
+        "stops-trading-at": "2026-03-20T20:15:00.000+00:00",
     }
     base.update(overrides)
     return base
 
 
 def make_future_option_json(**overrides: Any) -> dict[str, Any]:
-    """Factory for future option instrument API response."""
+    """Factory for future option instrument API response.
+
+    Mirrors the full 34-field shape returned by GET /instruments/future-options.
+    """
     base: dict[str, Any] = {
         "symbol": "./MESM6EX3H6 260320P6450",
         "underlying-symbol": "/MESM6",
@@ -66,19 +76,72 @@ def make_future_option_json(**overrides: Any) -> dict[str, Any]:
         "option-type": "P",
         "exchange": "CME",
         "streamer-symbol": "./EX3H26P6450:XCME",
+        "active": True,
+        "days-to-expiration": 20,
+        "display-factor": "0.01",
+        "exchange-symbol": "EX3H6 P6450",
+        "exercise-style": "American",
+        "expires-at": "2026-03-20T17:30:00.000+00:00",
+        "future-option-product": {
+            "root-symbol": "EX3",
+            "exchange": "CME",
+            "product-type": "Physical",
+        },
+        "future-price-ratio": "1.0",
+        "is-closing-only": False,
+        "is-confirmed": True,
+        "is-exercisable-weekly": True,
+        "is-primary-deliverable": True,
+        "is-vanilla": True,
+        "last-trade-time": "0",
+        "maturity-date": "2026-03-20",
+        "multiplier": "1.0",
+        "notional-value": "1.0",
+        "option-root-symbol": "EX3",
+        "root-symbol": "/MES",
+        "security-exchange": "4",
+        "security-id": "12345678",
+        "settlement-type": "Future",
+        "stops-trading-at": "2026-03-20T17:30:00.000+00:00",
+        "strike-factor": "1.0",
+        "sx-id": "0",
+        "underlying-count": "1.0",
     }
     base.update(overrides)
     return base
 
 
 def make_equity_json(**overrides: Any) -> dict[str, Any]:
-    """Factory for equity instrument API response."""
+    """Factory for equity instrument API response.
+
+    Mirrors the full 27-field shape returned by GET /instruments/equities.
+    """
     base: dict[str, Any] = {
         "symbol": "SPY",
         "instrument-type": "Equity",
-        "description": "SPDR S&P 500 ETF Trust",
+        "description": "SPDR S&P 500 ETF TRUST",
         "is-etf": True,
         "active": True,
+        "id": 27854,
+        "cusip": "78462F103",
+        "short-description": "SPDR S&P 500 ET",
+        "streamer-symbol": "SPY",
+        "is-closing-only": False,
+        "is-index": False,
+        "is-illiquid": False,
+        "is-fraud-risk": False,
+        "is-options-closing-only": False,
+        "is-fractional-quantity-eligible": True,
+        "bypass-manual-review": False,
+        "overnight-trading-permitted": True,
+        "borrow-rate": "0.0",
+        "lendability": "Easy To Borrow",
+        "instrument-sub-type": "ETF",
+        "listed-market": "ARCX",
+        "market-time-instrument-collection": "Equity",
+        "country-of-incorporation": "US",
+        "tick-sizes": [{"threshold": "1.0", "value": "0.0001"}, {"value": "0.01"}],
+        "option-tick-sizes": [{"value": "0.01"}],
     }
     base.update(overrides)
     return base
@@ -146,6 +209,11 @@ def test_equity_option_instrument_parses() -> None:
     assert inst.streamer_symbol == ".SPY260320C500"
     assert inst.active is True
     assert inst.is_closing_only is False
+    # Fields discovered from live API
+    assert inst.expiration_type == "Weekly"
+    assert inst.market_time_instrument_collection == "Cash Settled Equity Option"
+    assert inst.option_chain_type == "Standard"
+    assert inst.stops_trading_at == "2026-03-20T20:15:00.000+00:00"
 
 
 def test_equity_option_instrument_put() -> None:
@@ -164,6 +232,15 @@ def test_future_option_instrument_parses() -> None:
     assert inst.strike_price == Decimal("6450.0")
     assert inst.option_type == OptionType.PUT
     assert inst.exchange == "CME"
+    # Fields discovered from live API
+    assert inst.active is True
+    assert inst.days_to_expiration == 20
+    assert inst.exercise_style == "American"
+    assert inst.settlement_type == "Future"
+    assert inst.is_closing_only is False
+    assert inst.root_symbol == "/MES"
+    assert inst.option_root_symbol == "EX3"
+    assert inst.is_vanilla is True
 
 
 def test_equity_instrument_parses() -> None:
@@ -171,7 +248,17 @@ def test_equity_instrument_parses() -> None:
     assert inst.symbol == "SPY"
     assert inst.is_etf is True
     assert inst.active is True
-    assert inst.description == "SPDR S&P 500 ETF Trust"
+    assert inst.description == "SPDR S&P 500 ETF TRUST"
+    # Fields discovered from live API
+    assert inst.id == 27854
+    assert inst.cusip == "78462F103"
+    assert inst.streamer_symbol == "SPY"
+    assert inst.is_closing_only is False
+    assert inst.is_fractional_quantity_eligible is True
+    assert inst.lendability == "Easy To Borrow"
+    assert inst.instrument_sub_type == "ETF"
+    assert inst.listed_market == "ARCX"
+    assert inst.country_of_incorporation == "US"
 
 
 def test_future_instrument_parses() -> None:
@@ -199,8 +286,8 @@ def test_equity_option_instrument_is_frozen() -> None:
 
 def test_equity_option_instrument_allows_extra_fields() -> None:
     data = make_equity_option_json()
-    data["expiration-type"] = "Weekly"
-    data["option-chain-type"] = "Standard"
+    data["some-future-field"] = "unknown-value"
+    data["another-new-field"] = 42
     inst = EquityOptionInstrument.model_validate(data)
     assert inst.symbol == data["symbol"]
 

--- a/unit_tests/market/test_instruments_client.py
+++ b/unit_tests/market/test_instruments_client.py
@@ -197,11 +197,12 @@ def test_equity_option_instrument_is_frozen() -> None:
         inst.symbol = "OTHER"  # type: ignore[misc]
 
 
-def test_equity_option_instrument_rejects_extra_fields() -> None:
+def test_equity_option_instrument_allows_extra_fields() -> None:
     data = make_equity_option_json()
-    data["unknown-field"] = "value"
-    with pytest.raises(ValueError):
-        EquityOptionInstrument.model_validate(data)
+    data["expiration-type"] = "Weekly"
+    data["option-chain-type"] = "Standard"
+    inst = EquityOptionInstrument.model_validate(data)
+    assert inst.symbol == data["symbol"]
 
 
 def test_model_dump_json_uses_aliases() -> None:


### PR DESCRIPTION
## Summary

Deterministic strategy classifier replaces LLM-based `just positions-strategies` -- greedy pattern matching identifies 30+ option strategy types (iron condors, jade lizards, strangles, covered calls, verticals, butterflies, etc.). Full analytics pipeline: instrument enrichment from TT API, Redis persistence, PositionMetricsReader, StrategyClassifier, StrategyHealthMonitor. Strategy summary with computed Greeks (dollar-denominated theta), max profit/loss from entry prices, DTE, and TOML-configurable health alerts. New CLI commands: `tasty-subscription strategies` and `tasty-subscription strategies --json`. Architecture map updated with Strategy Engine components and functional view.

## Related Jira Issue

**Jira**: [TT-62](https://mandeng.atlassian.net/browse/TT-62)

## Acceptance Criteria - Functional Evidence

### AC1: Deterministic strategy classification identifies 30+ strategy types

**Real Example: Live account classification**

The classifier uses greedy pattern matching with 4-leg to 1-leg priority ordering to identify strategies. Pattern matchers in `analytics/strategies/patterns.py` cover iron condors, iron butterflies, jade lizards (variants A and B), strangles, straddles, covered calls/puts, verticals (call/put spreads), butterflies, calendar spreads, diagonal spreads, ratio spreads, and single-leg options.

**Results:**
- 25+ pattern matchers implemented in priority order (4-leg -> 3-leg -> 2-leg -> 1-leg)
- Greedy classification ensures multi-leg strategies are matched before their component legs
- StrategyType enum defines all supported strategy types
- 83 unit tests validate correct classification across all strategy types

### AC2: Full analytics pipeline with instrument enrichment

**Real Example: Pipeline flow from TT API to strategy output**

```
TT API -> InstrumentsClient (batch fetch) -> Redis HSET (instruments:details)
-> PositionMetricsReader (positions + Greeks) -> StrategyClassifier (pattern matching)
-> StrategyHealthMonitor (TOML alerts) -> CLI output (table or JSON)
```

**Results:**
- `market/instruments.py` -- InstrumentsClient fetches instrument details from TT API with per-type endpoints (equity options, future options, etc.)
- `accounts/publisher.py` -- Extended to persist instrument details to Redis HSET
- `accounts/orchestrator.py` -- Enriches instruments on startup and on live position updates
- `market/models.py` -- Per-type instrument models (EquityOption, FutureOption, etc.) with proper field types

### AC3: Strategy summary with computed Greeks, max P&L, and DTE

**Real Example: Functional verification with live account data**

```bash
$ just strategies
```

Output shows strategies with:
- Dollar-denominated theta (theta x multiplier x 100)
- Max profit/loss computed from entry prices (not mark prices)
- DTE calculated from expiration dates
- Contract multipliers applied correctly (/ZB x1000, /MES x5, /6E x125000)

**Results:**
- Jade lizard, iron condor, short strangle, covered call all correctly identified
- Future option multipliers applied correctly for dollar amounts
- Max profit/loss rounded to nearest dollar with comma formatting
- DTE shown as integer days

### AC4: TOML-configurable health monitoring

**Real Example: Health alerts from `config/strategy_health.toml`**

```toml
[thresholds]
dte_warning = 14
delta_drift_warning = 0.35
```

- StrategyHealthMonitor reads TOML config and generates alerts
- Delta-1 and covered strategies exempted from delta drift warnings
- DTE warning threshold configurable (default 14 days)

**Results:**
- Health warnings displayed inline with strategy table
- TOML configuration allows per-deployment tuning
- Alert types: DTE warning, delta drift, undefined risk

### AC5: New CLI commands for strategy output

**Real Example: CLI commands**

```bash
# Table format (human-readable)
$ tasty-subscription strategies

# JSON format (machine-readable)
$ tasty-subscription strategies --json
```

**Results:**
- `strategies` subcommand added to `tasty-subscription` CLI
- Table output includes: strategy type, underlying, legs, qty, theta, max P&L, DTE, health alerts
- JSON output provides structured data for downstream consumption
- Integrated into justfile as `just strategies`

## Test Evidence

- **83 unit tests** across classifier, patterns, health, and instruments client -- all passing
- Pre-commit hooks passed (ruff, ruff-format, mypy) -- enforced at commit level
- Functional verification with live account data via `just strategies`

**Test breakdown:**
- `test_patterns.py` (633 lines) -- Pattern matching for all strategy types
- `test_classifier.py` (416 lines) -- Greedy classification engine logic
- `test_health.py` (374 lines) -- Health monitoring and TOML configuration
- `test_instruments_client.py` (475 lines) -- Instrument fetching and model validation

## Changes Made

- `analytics/strategies/patterns.py`: 25+ pattern matchers for option strategy identification (4-leg to 1-leg priority)
- `analytics/strategies/classifier.py`: Greedy classification engine that matches positions to strategies
- `analytics/strategies/models.py`: StrategyType enum, ParsedLeg, Strategy dataclass with P&L computation
- `analytics/strategies/health.py`: TOML-configurable health monitoring with delta drift, DTE, undefined risk alerts
- `market/models.py`: Per-type instrument models (EquityOption, FutureOption, Equity, etc.)
- `market/instruments.py`: InstrumentsClient for batch-fetching instrument details from TT API
- `accounts/publisher.py`: Extended with instruments Redis HSET persistence
- `accounts/orchestrator.py`: Instrument enrichment on startup and live position updates
- `config/strategy_health.toml`: Default health monitoring thresholds
- `docs/plans/TT-62-strategy-engine.md`: Implementation plan
- `docs/architecture-map/architecture_layouts.json`: Updated with Strategy Engine components
- 4 new test files with 83 unit tests (1,898 lines of test code)
- **25 files changed, ~4,400 lines added**

[TT-62]: https://mandeng.atlassian.net/browse/TT-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ