### PR TITLE
TT-66: Lightweight reconnect using dynamic lookback from subscription store

### DIFF
--- a/docs/streaming_services.md
+++ b/docs/streaming_services.md
@@ -103,7 +103,7 @@ The two services are **independent processes** that coordinate through Redis:
 | **WebSocket** | DXLink (Quote, Trade, Greeks, Candle) |
 | **Redis writes** | `tastytrade:latest:QuoteEvent` (HSET), `tastytrade:latest:GreeksEvent` (HSET), plus pub/sub per event |
 | **Position resolver** | `src/tastytrade/subscription/resolver.py` — event-driven via Redis pub/sub |
-| **Self-healing** | Exponential backoff, candle backfill on reconnect |
+| **Self-healing** | Exponential backoff with calendar-day lookback on reconnect (see [Reconnect Behavior](#reconnect-behavior)) |
 
 ### positions
 
@@ -116,6 +116,42 @@ The two services are **independent processes** that coordinate through Redis:
 | **Output** | Table sorted by underlying_symbol, symbol |
 
 ---
+
+## Reconnect Behavior
+
+Both services self-heal on connection failures with exponential backoff. The `subscribe` service has additional logic to avoid expensive full re-backfills on reconnect.
+
+### How it works
+
+1. **First run** — uses the original `start_date` for full historical backfill (candles, gap-fill, etc.)
+2. **Reconnect** — derives a lightweight `start_date` from the Redis subscription store:
+   - Reads all subscriptions in Redis, filtered to **this session's symbols only** (ticker symbols + candle keys like `AAPL{=d}`)
+   - Finds the **earliest `last_update`** timestamp among matching subscriptions
+   - Rounds back to **midnight UTC of that calendar day**
+   - Falls back to **yesterday midnight** if no matching subscription data exists
+
+### Why this matters
+
+Without this, a 1-second auth token expiry would trigger re-ingestion of the entire historical backfill (potentially days of candle data across all symbols and intervals). With the lookback, it only backfills from the start of the day the data last flowed.
+
+### Scoping
+
+The lookback is scoped to the symbols and intervals passed to `run_subscription`. If multiple hosts share the same Redis instance with different symbol sets, each host only considers its own symbols when computing the reconnect window. This prevents a stale session or a different host from dragging the lookback further back than necessary.
+
+### Redis keys involved
+
+| Key | Field | Used for |
+|-----|-------|----------|
+| `subscriptions` (HSET) | `last_update` | Timestamp of last event received per symbol |
+| `subscriptions` (HSET) | `active` | Whether subscription is currently active (note: teardown marks inactive before reconnect reads, so `get_all_subscriptions` is used) |
+
+### Reconnect triggers
+
+| Trigger | Source | Example from logs |
+|---------|--------|-------------------|
+| Auth token expired | `handle_auth_state` detects `UNAUTHORIZED` after being authorized | Predictable ~24h TTL, occurs at ~00:50 UTC daily |
+| WebSocket dropped | `socket_listener` catches exception or server close | `no close frame received or sent` |
+| Simulated failure | Redis pub/sub `subscription:simulate_failure` | Manual testing via `redis-cli PUBLISH` |
 
 ## Redis Keys Reference
 

--- a/src/tastytrade/connections/subscription.py
+++ b/src/tastytrade/connections/subscription.py
@@ -29,6 +29,11 @@ class SubscriptionStore(ABC):
         pass
 
     @abstractmethod
+    async def get_all_subscriptions(self) -> dict:
+        """Get all subscriptions regardless of active status"""
+        pass
+
+    @abstractmethod
     async def update_subscription_status(self, symbol: str, data: dict) -> None:
         """Update subscription status"""
         pass
@@ -86,6 +91,17 @@ class RedisSubscriptionStore(SubscriptionStore):
             data = json.loads(data_bytes.decode("utf-8"))
             if data.get("active", False):
                 result[key] = data
+
+        return result
+
+    async def get_all_subscriptions(self) -> dict:
+        all_subscriptions = await self.redis.hgetall(self.hash_key)
+        result = {}
+
+        for key_bytes, data_bytes in all_subscriptions.items():
+            key = key_bytes.decode("utf-8")
+            data = json.loads(data_bytes.decode("utf-8"))
+            result[key] = data
 
         return result
 
@@ -165,6 +181,9 @@ class InMemorySubscriptionStore(SubscriptionStore):
             for symbol, data in self.subscriptions.items()
             if data["active"]
         }
+
+    async def get_all_subscriptions(self) -> dict:
+        return dict(self.subscriptions)
 
     async def update_subscription_status(self, symbol: str, data: dict) -> None:
         # ! FIX THIS TO ALIGN WITH REDIS IMPLEMENTATION ! #

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -613,11 +613,14 @@ async def run_subscription(
             if is_first_run:
                 effective_start = start_date
             else:
+                yesterday = datetime.now(timezone.utc).replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                ) - timedelta(days=1)
                 effective_start = await get_reconnect_start(
                     reconnect_store,
                     symbols=symbols,
                     intervals=intervals,
-                    fallback=start_date,
+                    fallback=yesterday,
                 )
 
             await _run_subscription_once(

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -509,16 +509,20 @@ async def get_reconnect_start(
 ) -> datetime:
     """Derive reconnect start_date from the earliest last_update in Redis.
 
-    Reads all active subscriptions and returns the start of the calendar day
-    (midnight UTC) of the earliest last_update. Falls back to the original
-    start_date if no subscription data is found.
+    Reads all subscriptions (including inactive) and returns the start of
+    the calendar day (midnight UTC) of the earliest last_update. Uses
+    get_all_subscriptions because teardown marks subscriptions inactive
+    before the reconnect loop reads them.
+
+    Falls back to the original start_date if no subscription data is found.
     """
-    active = await store.get_active_subscriptions()
-    if not active:
+
+    all_subs = await store.get_all_subscriptions()
+    if not all_subs:
         return fallback
 
     earliest: datetime | None = None
-    for data in active.values():
+    for data in all_subs.values():
         last_update_str = data.get("last_update") if isinstance(data, dict) else None
         if not last_update_str:
             continue

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -503,6 +503,47 @@ async def _run_subscription_once(
             logger.info("Cleanup complete")
 
 
+async def get_reconnect_start(
+    store: RedisSubscriptionStore,
+    fallback: datetime,
+) -> datetime:
+    """Derive reconnect start_date from the earliest last_update in Redis.
+
+    Reads all active subscriptions and returns the start of the calendar day
+    (midnight UTC) of the earliest last_update. Falls back to the original
+    start_date if no subscription data is found.
+    """
+    active = await store.get_active_subscriptions()
+    if not active:
+        return fallback
+
+    earliest: datetime | None = None
+    for data in active.values():
+        last_update_str = data.get("last_update") if isinstance(data, dict) else None
+        if not last_update_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(last_update_str)
+            if earliest is None or ts < earliest:
+                earliest = ts
+        except (ValueError, TypeError):
+            continue
+
+    if earliest is None:
+        return fallback
+
+    # Round back to start of that calendar day (midnight UTC)
+    reconnect_from = earliest.replace(
+        hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc
+    )
+    logger.info(
+        "Reconnect from %s (earliest data: %s)",
+        reconnect_from.strftime("%Y-%m-%d"),
+        earliest.strftime("%Y-%m-%d %H:%M"),
+    )
+    return reconnect_from
+
+
 async def run_subscription(
     symbols: list[str],
     intervals: list[str],
@@ -520,6 +561,9 @@ async def run_subscription(
 
     This function initializes connections, subscribes to market data feeds,
     performs gap-fill operations, and runs until interrupted.
+
+    On reconnect, the start_date is derived from the earliest last_update
+    in the subscription store, rounded to the start of that calendar day.
 
     Args:
         symbols: List of symbols to subscribe to (e.g., ["AAPL", "SPY", "QQQ"])
@@ -549,13 +593,22 @@ async def run_subscription(
 
     # Auto-reconnect mode with exponential backoff
     attempt = 0
+    is_first_run = True
+    reconnect_store = RedisSubscriptionStore()
 
     while attempt < max_reconnect_attempts:
         try:
+            if is_first_run:
+                effective_start = start_date
+            else:
+                effective_start = await get_reconnect_start(
+                    reconnect_store, fallback=start_date
+                )
+
             await _run_subscription_once(
                 symbols=symbols,
                 intervals=intervals,
-                start_date=start_date,
+                start_date=effective_start,
                 env_file=env_file,
                 lookback_days=lookback_days,
                 health_interval=health_interval,
@@ -565,6 +618,7 @@ async def run_subscription(
             logger.info("Subscription cancelled by user")
             raise  # User interrupt - don't reconnect
         except SubscriptionError as e:
+            is_first_run = False
             if e.was_healthy:
                 logger.info(
                     "Connection was healthy before failure, resetting retry counter"
@@ -582,6 +636,7 @@ async def run_subscription(
             )
             await asyncio.sleep(delay)
         except Exception as e:
+            is_first_run = False
             attempt += 1
             delay = min(base_delay * (2**attempt), max_delay)
             logger.warning(

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -505,24 +505,31 @@ async def _run_subscription_once(
 
 async def get_reconnect_start(
     store: RedisSubscriptionStore,
+    symbols: list[str],
+    intervals: list[str],
     fallback: datetime,
 ) -> datetime:
     """Derive reconnect start_date from the earliest last_update in Redis.
 
-    Reads all subscriptions (including inactive) and returns the start of
-    the calendar day (midnight UTC) of the earliest last_update. Uses
-    get_all_subscriptions because teardown marks subscriptions inactive
-    before the reconnect loop reads them.
+    Scoped to only the symbols and candle feeds this session subscribes to,
+    so other hosts/sessions with different symbols don't affect the lookback.
 
-    Falls back to the original start_date if no subscription data is found.
+    Falls back to the original start_date if no matching data is found.
     """
-
     all_subs = await store.get_all_subscriptions()
     if not all_subs:
         return fallback
 
+    # Build the set of Redis keys this session owns
+    session_keys: set[str] = set(symbols)
+    for symbol in symbols:
+        for interval in intervals:
+            session_keys.add(format_candle_symbol(f"{symbol}{{={interval}}}"))
+
     earliest: datetime | None = None
-    for data in all_subs.values():
+    for key, data in all_subs.items():
+        if key not in session_keys:
+            continue
         last_update_str = data.get("last_update") if isinstance(data, dict) else None
         if not last_update_str:
             continue
@@ -567,7 +574,8 @@ async def run_subscription(
     performs gap-fill operations, and runs until interrupted.
 
     On reconnect, the start_date is derived from the earliest last_update
-    in the subscription store, rounded to the start of that calendar day.
+    in the subscription store for this session's symbols, rounded to the
+    start of that calendar day.
 
     Args:
         symbols: List of symbols to subscribe to (e.g., ["AAPL", "SPY", "QQQ"])
@@ -606,7 +614,10 @@ async def run_subscription(
                 effective_start = start_date
             else:
                 effective_start = await get_reconnect_start(
-                    reconnect_store, fallback=start_date
+                    reconnect_store,
+                    symbols=symbols,
+                    intervals=intervals,
+                    fallback=start_date,
                 )
 
             await _run_subscription_once(

--- a/unit_tests/subscription/test_reconnect_lookback.py
+++ b/unit_tests/subscription/test_reconnect_lookback.py
@@ -10,7 +10,7 @@ from tastytrade.subscription.orchestrator import get_reconnect_start
 @pytest.mark.asyncio
 async def test_no_active_subscriptions_returns_fallback():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(return_value={})
+    store.get_all_subscriptions = AsyncMock(return_value={})
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
     result = await get_reconnect_start(store, fallback=fallback)
@@ -21,7 +21,7 @@ async def test_no_active_subscriptions_returns_fallback():
 @pytest.mark.asyncio
 async def test_rounds_to_start_of_calendar_day():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": {"last_update": "2026-03-04T14:30:00+00:00"},
             "SPY": {"last_update": "2026-03-04T16:45:00+00:00"},
@@ -37,7 +37,7 @@ async def test_rounds_to_start_of_calendar_day():
 @pytest.mark.asyncio
 async def test_uses_earliest_last_update():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": {"last_update": "2026-03-03T08:00:00+00:00"},
             "SPY": {"last_update": "2026-03-04T16:00:00+00:00"},
@@ -55,7 +55,7 @@ async def test_uses_earliest_last_update():
 @pytest.mark.asyncio
 async def test_skips_entries_without_last_update():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": {},
             "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
@@ -72,7 +72,7 @@ async def test_skips_entries_without_last_update():
 @pytest.mark.asyncio
 async def test_skips_invalid_timestamps():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": {"last_update": "not-a-date"},
             "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
@@ -88,7 +88,7 @@ async def test_skips_invalid_timestamps():
 @pytest.mark.asyncio
 async def test_all_invalid_timestamps_returns_fallback():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": {"last_update": "not-a-date"},
             "SPY": {"last_update": ""},
@@ -104,7 +104,7 @@ async def test_all_invalid_timestamps_returns_fallback():
 @pytest.mark.asyncio
 async def test_non_dict_subscription_data_skipped():
     store = Mock()
-    store.get_active_subscriptions = AsyncMock(
+    store.get_all_subscriptions = AsyncMock(
         return_value={
             "AAPL": "just_a_string",
             "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},

--- a/unit_tests/subscription/test_reconnect_lookback.py
+++ b/unit_tests/subscription/test_reconnect_lookback.py
@@ -7,13 +7,19 @@ from unittest.mock import AsyncMock, Mock
 from tastytrade.subscription.orchestrator import get_reconnect_start
 
 
+SYMBOLS = ["AAPL", "SPY"]
+INTERVALS = ["1d", "1h"]
+
+
 @pytest.mark.asyncio
-async def test_no_active_subscriptions_returns_fallback():
+async def test_no_subscriptions_returns_fallback():
     store = Mock()
     store.get_all_subscriptions = AsyncMock(return_value={})
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == fallback
 
@@ -29,7 +35,9 @@ async def test_rounds_to_start_of_calendar_day():
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
 
@@ -41,14 +49,54 @@ async def test_uses_earliest_last_update():
         return_value={
             "AAPL": {"last_update": "2026-03-03T08:00:00+00:00"},
             "SPY": {"last_update": "2026-03-04T16:00:00+00:00"},
-            "QQQ": {"last_update": "2026-03-04T12:00:00+00:00"},
         }
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     # Earliest is AAPL on Mar 3, so midnight Mar 3
+    assert result == datetime(2026, 3, 3, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_ignores_symbols_not_in_session():
+    store = Mock()
+    store.get_all_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "2026-03-04T14:00:00+00:00"},
+            "TSLA": {"last_update": "2026-02-01T10:00:00+00:00"},
+            "BTC/USD": {"last_update": "2026-01-15T08:00:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
+
+    # TSLA and BTC/USD are not in SYMBOLS, so only AAPL is considered
+    assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_includes_candle_keys():
+    store = Mock()
+    store.get_all_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "2026-03-04T14:00:00+00:00"},
+            "AAPL{=d}": {"last_update": "2026-03-03T20:00:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
+
+    # Candle key AAPL{=d} is older, so midnight Mar 3
     assert result == datetime(2026, 3, 3, 0, 0, 0, tzinfo=timezone.utc)
 
 
@@ -59,12 +107,13 @@ async def test_skips_entries_without_last_update():
         return_value={
             "AAPL": {},
             "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
-            "QQQ": {"some_other_field": "value"},
         }
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
 
@@ -80,23 +129,27 @@ async def test_skips_invalid_timestamps():
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.mark.asyncio
-async def test_all_invalid_timestamps_returns_fallback():
+async def test_no_matching_symbols_returns_fallback():
     store = Mock()
     store.get_all_subscriptions = AsyncMock(
         return_value={
-            "AAPL": {"last_update": "not-a-date"},
-            "SPY": {"last_update": ""},
+            "TSLA": {"last_update": "2026-03-04T10:00:00+00:00"},
+            "BTC/USD": {"last_update": "2026-03-04T12:00:00+00:00"},
         }
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == fallback
 
@@ -112,6 +165,8 @@ async def test_non_dict_subscription_data_skipped():
     )
     fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
 
-    result = await get_reconnect_start(store, fallback=fallback)
+    result = await get_reconnect_start(
+        store, symbols=SYMBOLS, intervals=INTERVALS, fallback=fallback
+    )
 
     assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)

--- a/unit_tests/subscription/test_reconnect_lookback.py
+++ b/unit_tests/subscription/test_reconnect_lookback.py
@@ -1,0 +1,117 @@
+"""Unit tests for get_reconnect_start — calendar-day lookback on reconnect."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+from tastytrade.subscription.orchestrator import get_reconnect_start
+
+
+@pytest.mark.asyncio
+async def test_no_active_subscriptions_returns_fallback():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(return_value={})
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == fallback
+
+
+@pytest.mark.asyncio
+async def test_rounds_to_start_of_calendar_day():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "2026-03-04T14:30:00+00:00"},
+            "SPY": {"last_update": "2026-03-04T16:45:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_uses_earliest_last_update():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "2026-03-03T08:00:00+00:00"},
+            "SPY": {"last_update": "2026-03-04T16:00:00+00:00"},
+            "QQQ": {"last_update": "2026-03-04T12:00:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    # Earliest is AAPL on Mar 3, so midnight Mar 3
+    assert result == datetime(2026, 3, 3, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_skips_entries_without_last_update():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {},
+            "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
+            "QQQ": {"some_other_field": "value"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_skips_invalid_timestamps():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "not-a-date"},
+            "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_all_invalid_timestamps_returns_fallback():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": {"last_update": "not-a-date"},
+            "SPY": {"last_update": ""},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == fallback
+
+
+@pytest.mark.asyncio
+async def test_non_dict_subscription_data_skipped():
+    store = Mock()
+    store.get_active_subscriptions = AsyncMock(
+        return_value={
+            "AAPL": "just_a_string",
+            "SPY": {"last_update": "2026-03-04T10:00:00+00:00"},
+        }
+    )
+    fallback = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+    result = await get_reconnect_start(store, fallback=fallback)
+
+    assert result == datetime(2026, 3, 4, 0, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- On reconnect, derives `start_date` from the earliest `last_update` in Redis for this session's symbols, rounded to midnight UTC of that calendar day
- First run still uses the original `start_date` for full historical backfill
- Fallback is yesterday midnight (not the original start_date from weeks ago)
- Scoped to session symbols only — other hosts/sessions with different symbols don't affect the lookback

## Related Jira Issue
**Jira**: [TT-66](https://mandeng.atlassian.net/browse/TT-66)

## Problem
Previously, every reconnect (even a 1-second auth token expiry) replayed the full historical backfill from the original `start_date`, re-ingesting days of candle data across all symbols/intervals.

## Changes
- `get_reconnect_start()` — new function that reads all subscriptions from Redis, filters to session symbols + candle keys, finds earliest `last_update`, rounds to calendar day midnight
- `get_all_subscriptions()` — new method on `SubscriptionStore` (ABC, Redis, InMemory) since teardown marks subscriptions inactive before reconnect reads them
- `run_subscription()` — uses `get_reconnect_start` on reconnect iterations, yesterday midnight as fallback

## Functional Evidence

Tested against live Redis with active subscriptions:

| Test | Symbols | Result |
|---|---|---|
| KO (never subscribed) | `['KO']` | Falls back to yesterday midnight |
| AAPL (active data) | `['AAPL']` | `2026-03-05 midnight UTC` |
| AAPL + KO (mixed) | `['AAPL', 'KO']` | `2026-03-05 midnight UTC` (only AAPL matches) |
| SPX (market closed) | `['SPX']` | `2026-03-05 midnight UTC` |

## Test Evidence
- [x] 9 unit tests for `get_reconnect_start` covering: no data, calendar day rounding, earliest selection, symbol scoping, candle keys, invalid data, fallback
- [x] 613 total tests passing
- [x] mypy clean
- [x] Verified against live Redis with 67 active subscriptions

## Changes Made
- `get_reconnect_start()` — new function that reads all subscriptions from Redis, filters to session symbols + candle keys, finds earliest `last_update`, rounds to calendar day midnight
- `get_all_subscriptions()` — new method on `SubscriptionStore` (ABC, Redis, InMemory) since teardown marks subscriptions inactive before reconnect reads them
- `run_subscription()` — uses `get_reconnect_start` on reconnect iterations, yesterday midnight as fallback

[TT-66]: https://mandeng.atlassian.net/browse/TT-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ