### PR TITLE
TT-67: Enrich account streamer event logging

### DIFF
--- a/src/tastytrade/accounts/streamer.py
+++ b/src/tastytrade/accounts/streamer.py
@@ -32,6 +32,8 @@ from tastytrade.accounts.messages import (
 )
 from tastytrade.accounts.models import (
     AccountBalance,
+    InstrumentType,
+    OrderLeg,
     PlacedComplexOrder,
     PlacedOrder,
     Position,
@@ -44,6 +46,81 @@ logger = logging.getLogger(__name__)
 
 HEARTBEAT_INTERVAL_SECONDS = 20
 CONNECT_TIMEOUT_SECONDS = 10
+
+SHORT_ACTIONS: dict[str, str] = {
+    "Buy to Open": "BTO",
+    "Sell to Open": "STO",
+    "Buy to Close": "BTC",
+    "Sell to Close": "STC",
+}
+
+
+def parse_occ_strike(symbol: str) -> str | None:
+    """Extract strike and put/call from an OCC equity option symbol.
+
+    OCC standard: 6-char root + 6-char date (YYMMDD) + C/P + 8-char strike (*1000).
+    Always 21 characters total.
+
+    'SPY   260306C00700000' → '700C'
+    'GOOGL 260306P00450500' → '450.5P'
+    """
+    s = symbol.strip()
+    if len(s) != 21:
+        return None
+    option_type = s[12]
+    if option_type not in ("C", "P"):
+        return None
+    try:
+        strike = int(s[13:]) / 1000
+        return f"{strike:g}{option_type}"
+    except ValueError:
+        return None
+
+
+def parse_futures_option_strike(symbol: str) -> str | None:
+    """Extract strike and put/call from a TastyTrade futures option symbol.
+
+    Format: './ESH6 EW4G6 250221P5500' — last segment contains date + C/P + strike.
+
+    './ESH6 EW4G6 250221P5500' → '5500P'
+    './MESH6 ME4G6 250221C5500' → '5500C'
+    """
+    parts = symbol.strip().split()
+    if len(parts) < 2:
+        return None
+    tail = parts[-1]
+    for i, c in enumerate(tail):
+        if c in ("C", "P") and i > 0:
+            strike = tail[i + 1 :]
+            if strike and strike.replace(".", "").isdigit():
+                return f"{strike}{c}"
+    return None
+
+
+def format_leg_summary(leg: OrderLeg) -> str:
+    """Format an order leg for logging.
+
+    Dispatches by instrument type to the appropriate symbol parser.
+
+    Equity:         'BTO SPY'
+    Equity Option:  'BTO 700C'
+    Future:         'BTO /ESH6'
+    Future Option:  'STO 5500P'
+    Fallback:       'BTO <symbol>'
+    """
+    action = SHORT_ACTIONS.get(leg.action.value, leg.action.value)
+
+    if leg.instrument_type == InstrumentType.EQUITY_OPTION:
+        strike = parse_occ_strike(leg.symbol)
+        if strike:
+            return f"{action} {strike}"
+    elif leg.instrument_type == InstrumentType.FUTURE_OPTION:
+        strike = parse_futures_option_strike(leg.symbol)
+        if strike:
+            return f"{action} {strike}"
+
+    return f"{action} {leg.symbol.strip()}"
+
 
 STREAMER_URLS: dict[bool, str] = {
     True: "wss://streamer.cert.tastyworks.com",  # sandbox
@@ -315,9 +392,7 @@ class AccountStreamer:
     ) -> None:
         """Log a human-readable summary of the event."""
         if event_type == AccountEventType.ORDER and isinstance(parsed, PlacedOrder):
-            legs_summary = ", ".join(
-                f"{leg.action.value} {leg.symbol}" for leg in parsed.legs
-            )
+            legs_summary = ", ".join(format_leg_summary(leg) for leg in parsed.legs)
             logger.info(
                 "Order %d %s — %s [%s]",
                 parsed.id,


### PR DESCRIPTION
## Summary
- Add instrument-type-dispatched symbol parsers (`parse_occ_strike`, `parse_futures_option_strike`) for compact option leg formatting
- `format_leg_summary` dispatches by `InstrumentType` — equity options parse OCC standard, futures options parse TT format, equities/futures use raw symbol
- Order log lines now show: `Order 444404029 Received — SPY [STO 701C, BTO 700C]`

## Related Jira Issue
**Jira**: [TT-67](https://mandeng.atlassian.net/browse/TT-67)

## Functional Evidence

**Symbol parser output (verified):**
```
=== Equity Options (OCC) ===
SPY 700 Call:  700C
SPY 701 Call:  701C
GOOGL 450.5 Put: 450.5P
AAPL 200 Put:  200P

=== Futures Options ===
/ES Put 5500:  5500P
/MES Call 5500: 5500C

=== Edge Cases ===
Equity (SPY):  None (falls back to raw symbol)
Garbage:       None (falls back to raw symbol)
```

**Expected Grafana output after restart:**
```
Order 444403703 Received — SPY [BTO SPY]
Order 444404029 Received — SPY [STO 701C, BTO 700C]
Order 444404029 Cancelled — SPY [STO 701C, BTO 700C]
Order 67890 Received — /ES [STO 5500P, BTO 5400P]
Position SPY qty=100.0
AccountBalance updated
```

**Previous logging (before):**
```
Queued Order event (ws-sequence=0)
Published order 444404473 status=Cancelled
```

## Acceptance Criteria Coverage
| AC | Description | Evidence |
|----|-------------|----------|
| AC1 | Order events at INFO level | ✅ Already on main (commit 2fd597c) |
| AC2 | Log includes ID, status, symbol, legs | ✅ `Order %d %s — %s [%s]` format |
| AC3 | Equity option OCC parsing | ✅ `parse_occ_strike`: SPY→700C, GOOGL→450.5P |
| AC4 | Futures option parsing | ✅ `parse_futures_option_strike`: /ES→5500P |
| AC5 | No underscore prefixes | ✅ Already on main (commit e78776b) |
| AC6 | All unit tests pass | ✅ 113 account tests pass |

## Test Evidence
- All account unit tests pass (113/113): `just test`
- Symbol parsers verified with real OCC and futures option symbols
- Edge cases: non-option symbols return None, fallback to raw symbol
- Pre-commit hooks pass (ruff, ruff-format, mypy)

## Changes Made
- `src/tastytrade/accounts/streamer.py`: Add `SHORT_ACTIONS` dict for compact action abbreviations (BTO/STO/BTC/STC), `parse_occ_strike()` for OCC equity option symbols, `parse_futures_option_strike()` for TT futures option symbols, `format_leg_summary()` dispatcher by `InstrumentType`, and update `log_event_summary()` to use the new formatter

[TT-67]: https://mandeng.atlassian.net/browse/TT-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ