### PR TITLE
TT-68: Enable Grafana Cloud observability for account-stream CLI

### DIFF
--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -247,9 +247,15 @@ def account_stream(log_level: str, health_interval: int) -> None:
       tasty-subscription account-stream
       tasty-subscription account-stream --log-level DEBUG
     """
-    log_level_int = getattr(logging, log_level)
-    setup_logging(level=log_level_int, console=True, file=False)
-    local_logger = logging.getLogger(__name__)
+    os.environ["LOG_LEVEL"] = log_level
+    if os.getenv("GRAFANA_CLOUD_TOKEN"):
+        init_observability()
+        local_logger = logging.getLogger(__name__)
+        local_logger.info("Grafana Cloud logging enabled")
+    else:
+        log_level_int = getattr(logging, log_level)
+        setup_logging(level=log_level_int, console=True, file=False)
+        local_logger = logging.getLogger(__name__)
 
     local_logger.info("=" * 60)
     local_logger.info("TastyTrade Account Stream - Starting")
@@ -264,6 +270,9 @@ def account_stream(log_level: str, health_interval: int) -> None:
     except Exception as e:
         local_logger.error("Fatal error: %s", e, exc_info=True)
         sys.exit(1)
+    finally:
+        if os.getenv("GRAFANA_CLOUD_TOKEN"):
+            shutdown_observability()
 
     sys.exit(0)
 


### PR DESCRIPTION
## Summary

The `account-stream` CLI command in `cli.py` was missing observability initialization. Unlike the `subscribe` command, it called `setup_logging()` directly and never checked for `GRAFANA_CLOUD_TOKEN`, so logs were only written to stdout and never shipped to Grafana Cloud via OTLP.

This fix mirrors the existing `subscribe` command pattern:
- Check for `GRAFANA_CLOUD_TOKEN` environment variable
- If present, call `init_observability()` for OpenTelemetry/OTLP logging
- If absent, fall back to local `setup_logging()`
- Call `shutdown_observability()` in the `finally` block to flush on exit

## Related Jira Issue

[TT-68](https://mandeng.atlassian.net/browse/TT-68)

## Changes

- **`src/tastytrade/subscription/cli.py`** — Updated the `account_stream()` function to check for `GRAFANA_CLOUD_TOKEN` and conditionally initialize OpenTelemetry observability, matching the pattern already used by the `subscribe` command. Added `shutdown_observability()` to the finally block for proper flush on exit.

## Test Plan

- [ ] All unit tests pass (`just test`)
- [ ] Pre-commit hooks pass (ruff, mypy)
- [ ] With `GRAFANA_CLOUD_TOKEN` set: run `account-stream` and verify logs appear in Grafana Cloud
- [ ] Without `GRAFANA_CLOUD_TOKEN`: run `account-stream` and verify local logging works as before
- [ ] Pattern matches existing `subscribe` command implementation in the same file

[TT-68]: https://mandeng.atlassian.net/browse/TT-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ