### PR TITLE
TT-74: Fix devcontainer environment variable injection from .env

### DIFF
--- a/.claude/hooks/stop_hook.sh
+++ b/.claude/hooks/stop_hook.sh
@@ -6,6 +6,14 @@
 
 set -e
 
+# Source .env if present (needed in Docker containers where env vars aren't in shell profile)
+if [ -f "$PWD/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$PWD/.env"
+    set +a
+fi
+
 # Config (needed early for logging)
 # Use project-specific state directory if available, otherwise use global
 if [ -d "$PWD/.claude/state" ]; then

--- a/.claude/hooks/subagent_stop_hook.sh
+++ b/.claude/hooks/subagent_stop_hook.sh
@@ -7,6 +7,14 @@
 
 set -e
 
+# Source .env if present (needed in Docker containers where env vars aren't in shell profile)
+if [ -f "$PWD/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$PWD/.env"
+    set +a
+fi
+
 # Read hook input
 HOOK_INPUT=$(cat)
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,11 +58,5 @@
     "PYTHONUNBUFFERED": "1"
   },
 
-  // Run arguments to pass environment variables from .env file
-  "runArgs": [
-    "--env-file",
-    "${localWorkspaceFolder}/.env"
-  ],
-
   "remoteUser": "developer"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - ~/.claude.json:/home/developer/.claude.json
       # Docker-from-Docker: mount host Docker socket
       - /var/run/docker.sock:/var/run/docker.sock
+    env_file:
+      - ../.env
     environment:
       # Host home directory for Claude plugin path compatibility
       HOST_HOME: "${HOME}"


### PR DESCRIPTION
## Summary

Fixes environment variables from `.env` not being available inside the devcontainer. The root cause was that `runArgs --env-file` in `devcontainer.json` is silently ignored when using `dockerComposeFile`. This PR adds `env_file: ../.env` to `docker-compose.yml` (the canonical Docker Compose approach), removes the dead `runArgs` from `devcontainer.json`, and adds `.env` sourcing to both hook scripts as a fallback for non-login shell contexts.

## Related Jira Issue

**Jira**: [TT-74](https://mandeng.atlassian.net/browse/TT-74)

## Acceptance Criteria - Functional Evidence

### AC1: `env_file: ../.env` added to docker-compose.yml

The `docker-compose.yml` now includes `env_file: ../.env` under the service definition, which is the canonical Docker Compose mechanism for injecting environment variables from a file. This ensures all variables defined in the project root `.env` are available inside the container at runtime.

### AC2: Dead `runArgs` removed from devcontainer.json

The `runArgs` block containing `--env-file` has been removed from `devcontainer.json`. When `dockerComposeFile` is specified, VS Code ignores `runArgs` entirely — the previous configuration gave a false sense of coverage without actually injecting any variables.

### AC3: Both hooks source `.env` for Docker container compatibility

Both `.claude/hooks/stop_hook.sh` and `.claude/hooks/subagent_stop_hook.sh` now source the `.env` file at script start. This serves as a fallback for non-login shell contexts inside the container where the `env_file` directive may not propagate to subprocesses spawned outside the normal shell initialization chain.

## Test Evidence

- Infrastructure/configuration change — no unit tests affected
- Pre-commit hooks passed (linting, formatting)
- Changes are limited to devcontainer configuration and shell hook scripts

## Changes Made

- `.devcontainer/docker-compose.yml` — Added `env_file: ../.env` directive for canonical env var injection
- `.devcontainer/devcontainer.json` — Removed ignored `runArgs` block that gave false sense of coverage
- `.claude/hooks/stop_hook.sh` — Added `.env` sourcing at script start as fallback
- `.claude/hooks/subagent_stop_hook.sh` — Added `.env` sourcing at script start as fallback

## Dependencies

None — independent infrastructure fix.

[TT-74]: https://mandeng.atlassian.net/browse/TT-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ