### PR TITLE
TT-71: Add failure simulation listener to account streamer

### DIFF
--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -10,11 +10,13 @@ import asyncio
 import logging
 import time
 
+import redis.asyncio as aioredis
+
 from tastytrade.accounts.models import InstrumentType, Position
 from tastytrade.accounts.publisher import AccountStreamPublisher, Instrument
 from tastytrade.accounts.streamer import AccountStreamer
 from tastytrade.config import RedisConfigManager
-from tastytrade.config.enumerations import AccountEventType
+from tastytrade.config.enumerations import AccountEventType, ReconnectReason
 from tastytrade.connections import Credentials
 from tastytrade.connections.signals import ReconnectSignal
 from tastytrade.market.instruments import InstrumentsClient
@@ -73,6 +75,46 @@ async def consume_complex_orders(
         await publisher.publish_complex_order(order)
 
 
+async def account_failure_trigger_listener(
+    redis_client: aioredis.Redis,  # type: ignore[type-arg]
+    reconnect_signal: ReconnectSignal,
+) -> None:
+    """Listen for failure simulation commands via Redis pub/sub.
+
+    Subscribes to 'account:simulate_failure' channel and triggers
+    reconnection when a valid ReconnectReason value is received.
+
+    Args:
+        redis_client: Async Redis client for pub/sub.
+        reconnect_signal: ReconnectSignal to trigger on valid commands.
+
+    Usage:
+        redis-cli PUBLISH account:simulate_failure "connection_dropped"
+    """
+    pubsub = redis_client.pubsub()
+    await pubsub.subscribe("account:simulate_failure")
+
+    try:
+        async for message in pubsub.listen():
+            if message["type"] == "message":
+                reason_str = (
+                    message["data"].decode()
+                    if isinstance(message["data"], bytes)
+                    else message["data"]
+                )
+                try:
+                    reason = ReconnectReason(reason_str)
+                    logger.info("Received simulate_failure command: %s", reason.value)
+                    reconnect_signal.trigger(reason)
+                except ValueError:
+                    logger.warning("Invalid ReconnectReason received: %s", reason_str)
+    except asyncio.CancelledError:
+        logger.info("Account failure trigger listener stopped")
+    finally:
+        await pubsub.unsubscribe("account:simulate_failure")
+        await pubsub.close()
+
+
 async def run_account_stream_once(
     env_file: str = ".env",
     health_interval: int = 3600,
@@ -94,6 +136,8 @@ async def run_account_stream_once(
     streamer: AccountStreamer | None = None
     publisher: AccountStreamPublisher | None = None
     consumer_tasks: list[asyncio.Task] = []  # type: ignore[type-arg]
+    failure_listener_task: asyncio.Task[None] | None = None
+    failure_redis: aioredis.Redis | None = None  # type: ignore[type-arg]
     connection_established_at: float | None = None
 
     try:
@@ -225,6 +269,13 @@ async def run_account_stream_once(
             )
         )
 
+        # === Start failure simulation listener ===
+        failure_redis = aioredis.Redis()
+        failure_listener_task = asyncio.create_task(
+            account_failure_trigger_listener(failure_redis, reconnect_signal),
+            name="account_failure_listener",
+        )
+
         connection_established_at = time.monotonic()
         logger.info("Account stream active - press Ctrl+C to stop")
 
@@ -268,6 +319,18 @@ async def run_account_stream_once(
         )
         raise AccountStreamError(str(e), was_healthy=was_healthy) from e
     finally:
+        # Cancel failure listener task
+        if failure_listener_task is not None:
+            failure_listener_task.cancel()
+            try:
+                await failure_listener_task
+            except asyncio.CancelledError:
+                pass
+
+        # Close failure listener Redis client
+        if failure_redis is not None:
+            await failure_redis.close()
+
         # Cancel consumer tasks
         for task in consumer_tasks:
             task.cancel()

--- a/unit_tests/accounts/test_account_orchestrator.py
+++ b/unit_tests/accounts/test_account_orchestrator.py
@@ -7,13 +7,14 @@ import pytest
 
 from tastytrade.accounts.orchestrator import (
     AccountStreamError,
+    account_failure_trigger_listener,
     consume_balances,
     consume_positions,
     run_account_stream,
     run_account_stream_once,
 )
 from tastytrade.accounts.models import AccountBalance, Position
-from tastytrade.config.enumerations import AccountEventType
+from tastytrade.config.enumerations import AccountEventType, ReconnectReason
 
 
 # ---------------------------------------------------------------------------
@@ -313,3 +314,93 @@ class TestRunAccountStream:
                 base_delay=0.01,
                 max_delay=0.05,
             )
+
+
+# ---------------------------------------------------------------------------
+# account_failure_trigger_listener
+# ---------------------------------------------------------------------------
+
+
+class TestAccountFailureTriggerListener:
+    @pytest.mark.asyncio
+    async def test_valid_reason_triggers_reconnect(self) -> None:
+        """Valid ReconnectReason triggers reconnect_signal.trigger()."""
+        mock_pubsub = AsyncMock()
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        async def fake_listen():  # type: ignore[no-untyped-def]
+            yield {"type": "subscribe", "data": None}
+            yield {"type": "message", "data": b"connection_dropped"}
+
+        mock_pubsub.listen = fake_listen
+
+        mock_signal = MagicMock()
+
+        task = asyncio.create_task(
+            account_failure_trigger_listener(mock_redis, mock_signal)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        mock_signal.trigger.assert_called_once_with(ReconnectReason.CONNECTION_DROPPED)
+
+    @pytest.mark.asyncio
+    async def test_invalid_reason_logs_warning(self) -> None:
+        """Invalid value logs a warning and does not trigger reconnect."""
+        mock_pubsub = AsyncMock()
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        async def fake_listen():  # type: ignore[no-untyped-def]
+            yield {"type": "subscribe", "data": None}
+            yield {"type": "message", "data": b"not_a_valid_reason"}
+
+        mock_pubsub.listen = fake_listen
+
+        mock_signal = MagicMock()
+
+        task = asyncio.create_task(
+            account_failure_trigger_listener(mock_redis, mock_signal)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        mock_signal.trigger.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_handled_gracefully(self) -> None:
+        """CancelledError is caught and pubsub is cleaned up."""
+        mock_pubsub = AsyncMock()
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        async def fake_listen():  # type: ignore[no-untyped-def]
+            yield {"type": "subscribe", "data": None}
+            # Block forever until cancelled
+            await asyncio.sleep(3600)
+            yield {"type": "message", "data": b"unreachable"}  # pragma: no cover
+
+        mock_pubsub.listen = fake_listen
+
+        mock_signal = MagicMock()
+
+        task = asyncio.create_task(
+            account_failure_trigger_listener(mock_redis, mock_signal)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        # Should not raise — CancelledError is handled gracefully
+        await task
+
+        mock_pubsub.unsubscribe.assert_awaited_once_with("account:simulate_failure")
+        mock_pubsub.close.assert_awaited_once()


### PR DESCRIPTION
## Summary
Adds `account_failure_trigger_listener()` that subscribes to `account:simulate_failure` Redis pub/sub channel, enabling operators to simulate account streamer failures for testing self-healing behavior. Uses the shared `ReconnectSignal` pattern from TT-65.

## Related Jira Issue
**Jira**: [TT-71](https://mandeng.atlassian.net/browse/TT-71)

## Acceptance Criteria - Functional Evidence

### AC1: Subscribes to `account:simulate_failure` Redis pub/sub channel
The listener calls `pubsub.subscribe("account:simulate_failure")` and enters an async loop reading messages from the channel.

### AC2: Valid ReconnectReason values trigger `reconnect_signal.trigger(reason)`
When a valid `ReconnectReason` value (e.g., `connection_dropped`) is published, the listener converts it to a `ReconnectReason` enum and calls `reconnect_signal.trigger(reason)`.

### AC3: Invalid values log a warning without triggering reconnection
When an unrecognized value is published, a warning is logged with the invalid value and no signal is triggered.

### AC4: CancelledError handled gracefully with pubsub cleanup
On cancellation, the listener catches `CancelledError`, unsubscribes from the channel, and closes the pubsub connection cleanly.

### AC5: Integrated into `run_account_stream_once()` lifecycle
The failure trigger listener is spawned as a task within `run_account_stream_once()` and cancelled during cleanup.

### AC6: Unit tests cover valid reason, invalid reason, and cancellation
`TestAccountFailureTriggerListener` includes 3 tests covering valid reason triggering, invalid reason warning, and graceful cancellation.

## Test Evidence
- Unit tests passing (`just test`)
- Pre-commit hooks passed (linting, type checking, formatting)

## Changes Made
- `src/tastytrade/accounts/orchestrator.py` — Added `account_failure_trigger_listener()` function and integration into stream lifecycle
- `unit_tests/accounts/test_account_orchestrator.py` — Added `TestAccountFailureTriggerListener` with 3 tests

## Dependencies
- TT-65 (ReconnectSignal refactor) — merged
- Should merge TT-70 first (both modify orchestrator.py, TT-70's connection status is used alongside this)

## Usage
```bash
redis-cli PUBLISH account:simulate_failure "connection_dropped"
```

[TT-71]: https://mandeng.atlassian.net/browse/TT-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ