### PR TITLE
TT-75: Documentation refresh — architecture, changelog, and corrections

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,10 +90,14 @@ The system is a collection of independent services that coordinate through Redis
 
 ### 1. Event-Driven Architecture — Immutable Models Through Queues
 
-Every input from the broker is deserialized into an immutable Pydantic model and processed through a straight-through pipeline. No callbacks cross component boundaries — data flows in one direction through queues and processors.
+Every input from the broker — whether market data or account events — is deserialized into an immutable Pydantic model and processed through a straight-through pipeline. No callbacks cross component boundaries — data flows in one direction through queues and consumers.
+
+Both streaming services implement this pattern with the same structure:
+
+#### Market Data (subscribe service)
 
 ```
-WebSocket JSON
+DXLink WebSocket JSON
     │
     ▼
 DXLinkManager.socket_listener()
@@ -103,8 +107,8 @@ asyncio.Queue (one per channel: Quote, Trade, Greeks, Candle, Control...)
     │
     ▼
 EventHandler.queue_listener()
-    │  deserializes raw data → Pydantic BaseEvent (frozen=True, extra=forbid)
-    │  using CHANNEL_SPECS field mapping
+    │  deserializes raw arrays → Pydantic BaseEvent (frozen=True, extra=forbid)
+    │  using CHANNEL_SPECS field mapping: dict(zip(fields, chunk))
     ▼
 BaseEvent (immutable model)
     │
@@ -116,18 +120,44 @@ Processor.process_event(event)     ← straight-through, no callbacks
     └── MetricsTracker → in-memory metrics
 ```
 
+#### Account Events (account-stream service)
+
+```
+Account Streamer WebSocket JSON
+    │
+    ▼
+AccountStreamer.socket_listener()
+    │  parses envelope → StreamerEventEnvelope (frozen=True, extra=allow)
+    │  routes by event type
+    ▼
+AccountStreamer.handle_event()
+    │  envelope.data → Pydantic model via model_validate()
+    │  Position, AccountBalance, PlacedOrder, PlacedComplexOrder
+    ▼
+asyncio.Queue (one per AccountEventType)
+    │
+    ▼
+consume_positions() / consume_balances() / consume_orders()
+    │  straight-through consumers, one per event type
+    ▼
+AccountStreamPublisher → Redis HSET + pub/sub
+```
+
 **Key properties:**
 
-- **Immutable events** — `BaseEvent` uses `frozen=True` and `extra="forbid"`. Once created, events cannot be modified. This eliminates an entire class of mutation bugs across processors.
-- **Per-channel queues** — Each DXLink channel (Quote, Trade, Greeks, Candle, Control) has its own `asyncio.Queue` and `EventHandler`. This isolates backpressure — a slow candle processor doesn't block quote delivery.
-- **Straight-through processing** — Processors receive events directly via `process_event()`. No callback registration, no observer patterns, no event buses between components within a service. Data enters, gets processed, exits.
-- **Field-driven deserialization** — `CHANNEL_SPECS` maps each channel to its event type and field names. The `EventHandler` chunks raw WebSocket arrays by field count and constructs typed Pydantic models via `dict(zip(fields, chunk))`.
+- **Immutable events** — Both pipelines produce frozen Pydantic models. Market data uses `BaseEvent` (`frozen=True`, `extra="forbid"`). Account events use typed models (`Position`, `AccountBalance`) and wire protocol envelopes (`StreamerEventEnvelope` with `frozen=True`, `extra="allow"` to tolerate new server fields).
+- **Per-channel/per-type queues** — Market data has one `asyncio.Queue` per DXLink channel (Quote, Trade, Greeks, Candle, Control). Account data has one queue per `AccountEventType` (CurrentPosition, AccountBalance, Order, ComplexOrder). This isolates backpressure — a slow processor on one event type doesn't block others.
+- **Straight-through processing** — No callback registration, no observer patterns, no event buses between components within a service. Data enters, gets deserialized, gets consumed, exits.
+- **Field-driven deserialization** — Market data uses `CHANNEL_SPECS` to map channels to event types and field names, chunking raw arrays by field count. Account data uses Pydantic's `model_validate()` on the event envelope's `data` dict.
 
 **Files:**
 - `messaging/models/events.py` — `BaseEvent`, `QuoteEvent`, `TradeEvent`, `CandleEvent`, `GreeksEvent`
 - `messaging/handlers.py` — `EventHandler` (queue listener + deserializer), `ControlHandler` (connection state machine)
 - `connections/routing.py` — `MessageRouter` wires queues to handlers
 - `config/configurations.py` — `CHANNEL_SPECS` channel-to-event-type mapping
+- `accounts/messages.py` — `StreamerEventEnvelope`, `StreamerConnectMessage`, `StreamerResponse`
+- `accounts/streamer.py` — `AccountStreamer.socket_listener()`, `handle_event()`, `parse_event()`
+- `accounts/orchestrator.py` — `consume_positions()`, `consume_balances()`, `consume_orders()`
 
 ### 2. ReconnectSignal — Decoupled Connection Lifecycle
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,16 +14,16 @@ The system is a collection of independent services that coordinate through Redis
 ┌─────────────────────────────────────────────────────────────────────────────────┐
 │                           TastyTrade Platform APIs                              │
 │                                                                                 │
-│   Account Streamer WS          DXLink WS            REST API                   │
+│   Account Streamer WS          DXLink WS            REST API                    │
 │   (positions, balances,        (quotes, trades,      (instruments,              │
-│    orders)                      Greeks, candles)       options chains)           │
+│    orders)                      Greeks, candles)       options chains)          │
 └───────┬─────────────────────────────┬──────────────────────┬────────────────────┘
         │                             │                      │
         ▼                             ▼                      │
 ┌───────────────────┐   ┌────────────────────────┐           │
 │  account-stream   │   │      subscribe         │           │
 │                   │   │                        │           │
-│  AccountStreamer   │   │  DXLinkManager         │           │
+│  AccountStreamer  │   │  DXLinkManager         │           │
 │       │           │   │       │                │           │
 │       ▼           │   │       ▼                │           │
 │  AccountStream    │   │  RedisEventProcessor   │           │
@@ -39,11 +39,11 @@ The system is a collection of independent services that coordinate through Redis
         │                            │
         ▼                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                          Redis                               │
-│                                                              │
-│  HSET: positions, balances, quotes, Greeks, instruments      │
-│  HSET: account_connection, connection (health)               │
-│  pub/sub: position events, market events, failure triggers   │
+│                          Redis                              │
+│                                                             │
+│  HSET: positions, balances, quotes, Greeks, instruments     │
+│  HSET: account_connection, connection (health)              │
+│  pub/sub: position events, market events, failure triggers  │
 └────────┬───────────────────────────────────┬────────────────┘
          │                                   │
          ▼                                   ▼
@@ -88,7 +88,48 @@ The system is a collection of independent services that coordinate through Redis
 
 ## Key Design Patterns
 
-### 1. ReconnectSignal — Decoupled Connection Lifecycle
+### 1. Event-Driven Architecture — Immutable Models Through Queues
+
+Every input from the broker is deserialized into an immutable Pydantic model and processed through a straight-through pipeline. No callbacks cross component boundaries — data flows in one direction through queues and processors.
+
+```
+WebSocket JSON
+    │
+    ▼
+DXLinkManager.socket_listener()
+    │  raw dict dispatched by channel number
+    ▼
+asyncio.Queue (one per channel: Quote, Trade, Greeks, Candle, Control...)
+    │
+    ▼
+EventHandler.queue_listener()
+    │  deserializes raw data → Pydantic BaseEvent (frozen=True, extra=forbid)
+    │  using CHANNEL_SPECS field mapping
+    ▼
+BaseEvent (immutable model)
+    │
+    ▼
+Processor.process_event(event)     ← straight-through, no callbacks
+    │
+    ├── RedisEventProcessor  → Redis HSET + pub/sub
+    ├── TelegrafHTTPEventProcessor → InfluxDB
+    └── MetricsTracker → in-memory metrics
+```
+
+**Key properties:**
+
+- **Immutable events** — `BaseEvent` uses `frozen=True` and `extra="forbid"`. Once created, events cannot be modified. This eliminates an entire class of mutation bugs across processors.
+- **Per-channel queues** — Each DXLink channel (Quote, Trade, Greeks, Candle, Control) has its own `asyncio.Queue` and `EventHandler`. This isolates backpressure — a slow candle processor doesn't block quote delivery.
+- **Straight-through processing** — Processors receive events directly via `process_event()`. No callback registration, no observer patterns, no event buses between components within a service. Data enters, gets processed, exits.
+- **Field-driven deserialization** — `CHANNEL_SPECS` maps each channel to its event type and field names. The `EventHandler` chunks raw WebSocket arrays by field count and constructs typed Pydantic models via `dict(zip(fields, chunk))`.
+
+**Files:**
+- `messaging/models/events.py` — `BaseEvent`, `QuoteEvent`, `TradeEvent`, `CandleEvent`, `GreeksEvent`
+- `messaging/handlers.py` — `EventHandler` (queue listener + deserializer), `ControlHandler` (connection state machine)
+- `connections/routing.py` — `MessageRouter` wires queues to handlers
+- `config/configurations.py` — `CHANNEL_SPECS` channel-to-event-type mapping
+
+### 2. ReconnectSignal — Decoupled Connection Lifecycle
 
 Both streaming services use a shared `ReconnectSignal` object for connection lifecycle management. The signal is created by the orchestrator, injected into the connection pipeline, and outlives individual connection cycles.
 
@@ -111,7 +152,7 @@ Orchestrator creates ReconnectSignal
 - `src/tastytrade/accounts/orchestrator.py` — Account stream usage
 - `src/tastytrade/subscription/orchestrator.py` — Subscription usage
 
-### 2. Redis-as-Bus — Service Boundary Communication
+### 3. Redis-as-Bus — Service Boundary Communication
 
 Services communicate exclusively through Redis. No callbacks, no shared memory, no direct function calls across service boundaries.
 
@@ -129,7 +170,7 @@ Each service is a black box: Redis in → process → output. The producer doesn
 - `tastytrade:events:CurrentPosition` — Position change events
 - `account:simulate_failure` / `subscription:simulate_failure` — Failure simulation
 
-### 3. Protocol-Based Design — Structural Subtyping
+### 4. Protocol-Based Design — Structural Subtyping
 
 Interfaces are defined as Python `Protocol` classes. Any class with matching method signatures satisfies the protocol — no inheritance required.
 
@@ -142,7 +183,7 @@ Interfaces are defined as Python `Protocol` classes. Any class with matching met
 
 **Why:** Protocols enable dependency injection without inheritance hierarchies. New implementations can be added without modifying existing code. Testing uses mock objects that match the protocol shape.
 
-### 4. Self-Healing Orchestrators — Exponential Backoff
+### 5. Self-Healing Orchestrators — Exponential Backoff
 
 Both streaming services wrap their connection logic in a retry loop with exponential backoff. The pattern is identical across services:
 
@@ -164,7 +205,7 @@ while attempt < max_attempts:
 
 **Why:** WebSocket connections fail for many reasons (auth expiry, network blips, server maintenance). The `was_healthy` flag distinguishes between "worked for hours then dropped" (reset counter, reconnect immediately) and "failed on startup" (increment counter, back off). This prevents infinite rapid retries on configuration errors while being aggressive about recovering from transient failures.
 
-### 5. Event-Driven Position Resolution
+### 6. Event-Driven Position Resolution
 
 The subscription service discovers which symbols to stream by listening to position changes — not by polling.
 
@@ -180,7 +221,7 @@ PositionSymbolResolver.listener() receives event
 
 **Why:** Polling introduces latency and wasted cycles. The pub/sub listener reacts to changes in real time. When a new position is opened on the TastyTrade platform, the market data subscription updates within milliseconds.
 
-### 6. Layered Configuration Resolution
+### 7. Layered Configuration Resolution
 
 Configuration values resolve through a three-layer precedence chain:
 


### PR DESCRIPTION
## Summary

Comprehensive documentation refresh capturing recent sprint work and correcting stale references:

- **CHANGELOG.md** — Sprint-by-sprint record of all 48 Jira tickets (TT-6 through TT-74)
- **docs/ARCHITECTURE.md** — "Start here" system overview with 7 key design patterns, full component map, and system topology diagram
- **Stale doc corrections** — Fixed wrong Jira URL (tastytrade-sdk to mandeng), rewrote SERVICE_DISCOVERY.md for network_mode:host reality, added missing doc references to CLAUDE.md

### Key addition: Event-Driven Architecture pattern

Documents the foundational pattern both streaming services share — broker WebSocket input deserialized into immutable Pydantic models, routed through per-channel/per-type asyncio.Queues, consumed by straight-through processors. Covers both the market data pipeline (CHANNEL_SPECS field-driven deserialization) and account streamer pipeline (StreamerEventEnvelope + model_validate).

## Related Jira Issue
**Jira**: [TT-75](https://mandeng.atlassian.net/browse/TT-75)

## Acceptance Criteria

- [x] CHANGELOG.md exists at project root with recent sprint history
- [x] docs/ARCHITECTURE.md provides comprehensive current-state overview with 7 design patterns
- [x] Event-driven architecture pattern documents both market data and account streamer pipelines
- [x] Stale Jira URL corrected (tastytrade-sdk.atlassian.net to mandeng.atlassian.net)
- [x] SERVICE_DISCOVERY.md rewritten for network_mode:host + env_file setup
- [x] CLAUDE.md Reference Documents section includes all key docs
- [x] All tests pass (documentation-only change)

## Test Plan

- [x] uv run pytest — all tests pass
- [x] All factual claims verified against source code (10-point verification)
- [x] Cross-references between docs verified (no duplication)

[TT-75]: https://mandeng.atlassian.net/browse/TT-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ