### PR TITLE
TT-63: Entry price reconciliation via transaction LIFO replay

### DIFF
--- a/docs/plans/TT-63-design-review.html
+++ b/docs/plans/TT-63-design-review.html
@@ -691,45 +691,74 @@ This means \`max_profit\` and \`max_loss\` are wrong or missing for future optio
       {
         id: "transaction-model",
         title: "Step 1: Transaction Data Model & API Client",
+        revised: true,
         content: `**File:** \`src/tastytrade/accounts/transactions.py\`
 
-A new Pydantic model and API client for fetching transaction history:
+**Revised:** Scope expanded from futures options only to **all option types** (equity + futures). The API returns identical field structure for both — confirmed against live production data.
+
+### API Response Fields (Verified)
+
+The \`GET /accounts/{acct}/transactions\` endpoint returns these fields per fill:
+
+| Field | Example (Equity) | Example (Futures) | Description |
+|-------|-------------------|-------------------|-------------|
+| \`price\` | \`0.8\` | \`0.002\` | Per-unit price |
+| \`value\` | \`80.0\` | \`500.0\` | Dollar amount (price x multiplier x qty) |
+| \`value-effect\` | \`Credit\` | \`Credit\` | Direction of dollar flow |
+| \`net-value\` | \`78.877\` | \`493.66\` | Dollar amount after fees |
+| \`net-value-effect\` | \`Credit\` | \`Credit\` | Direction after fees |
+
+**\`value\` already accounts for multiplier and quantity** — the API does the math:
+- Equity: \`price=0.80 * 100 shares * 1 contract = value=80.0\`
+- /6E: \`price=0.002 * 125,000 multiplier * 2 contracts = value=500.0\`
+
+### Transaction Model
 
 \`\`\`python
 class Transaction(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     id: int
     executed_at: datetime             # When the fill occurred
     action: str                       # "Sell to Open", "Buy to Open",
                                       # "Buy to Close", "Sell to Close"
     symbol: str                       # Option symbol (matches position)
-    underlying_symbol: str            # e.g., "/6EM6"
-    instrument_type: str              # "Future Option"
-    value: Decimal                    # Dollar amount of fill
+    underlying_symbol: str            # e.g., "/6EM6" or "CSCO"
+    instrument_type: str              # "Equity Option" or "Future Option"
+    price: Decimal                    # Per-unit price
+    value: Decimal                    # Dollar amount of fill (pre-fee)
     value_effect: str                 # "Credit" or "Debit"
-    quantity: int                     # Number of contracts in this fill
+    net_value: Decimal                # Dollar amount after fees
+    net_value_effect: str             # "Credit" or "Debit"
+    quantity: Decimal                 # Number of contracts in this fill
+    order_id: int                     # Links legs of the same order
+    leg_count: int                    # How many legs in the original order
 \`\`\`
+
+### Transactions Client
 
 \`\`\`python
 class TransactionsClient:
     def get_transactions(
         self,
         account_number: str,
-        instrument_type: str = "Future Option",
+        instrument_type: Optional[str] = None,  # None = all types
         start_date: Optional[date] = None,
     ) -> list[Transaction]:
         # GET /accounts/{acct}/transactions
-        # Filters by instrument-type server-side
+        # Filters by instrument-type server-side if provided
         ...
 \`\`\`
 
 ### Key Decisions
 
-- **CHOSEN:** Fetch ALL futures option transactions (not just problematic subset)
-- **CHOSEN:** Store dollar \`value\` directly (not per-unit prices)
-- Transaction \`value\` already accounts for multiplier x quantity
-- \`value_effect\` disambiguates credit vs debit (sign convention)`
+- **REVISED:** Fetch transactions for **all option types** uniformly — not just futures options
+- **CHOSEN:** Store dollar \`value\` (pre-fee) for position cost basis accounting
+- **Noted:** \`net-value\` (post-fee) available if true P&L including fees is needed later
+- Transaction \`value\` already accounts for multiplier x quantity — no manual computation
+- \`value_effect\` disambiguates credit vs debit (sign convention)
+- Multi-leg orders produce **separate transaction records per leg** with the same \`order_id\`
+- Each leg has its own \`symbol\`, \`action\`, \`value\` — LIFO processes per-symbol independently`
       },
       {
         id: "lifo-algorithm",
@@ -814,9 +843,12 @@ T1: Sell to Open 1 -> consumed=0, surviving=1, take=1
       {
         id: "dollar-normalization",
         title: "Step 3: Dollar Normalization of P&L Formulas",
+        revised: true,
         content: `**File:** \`src/tastytrade/analytics/strategies/models.py\`
 
-### Current Formula (per-unit prices)
+**Revised:** With transactions API used uniformly for all option types, the bifurcated equity/futures path is eliminated. Every option leg gets its \`entry_value\` from transactions — no fallback to \`average_open_price\`.
+
+### Current Formula (per-unit prices — being replaced)
 
 \`\`\`python
 # Current: per-unit -> then multiply
@@ -824,9 +856,9 @@ net_credit = sum(avg_open_price * (-signed_qty) for leg in legs)
 max_profit = net_credit * multiplier  # e.g., 0.80 * 100 = $80
 \`\`\`
 
-### New Formula (dollar values)
+### New Formula (uniform dollar values)
 
-Normalize ALL option types to dollar-valued entry credits:
+Single path — all option types use transaction-derived dollar values:
 
 \`\`\`python
 def compute_net_entry_credit_dollars(
@@ -835,34 +867,31 @@ def compute_net_entry_credit_dollars(
     """Compute net dollar credit received at entry.
     Positive = net credit. Returns None if data missing."""
 
-    for leg in option_legs:
-        if leg.entry_value is not None:
-            continue
-        elif leg.average_open_price is not None:
-            continue
-        else:
-            return None
+    # All legs must have transaction-derived entry values
+    if any(leg.entry_value is None for leg in option_legs):
+        return None
 
     total = Decimal("0")
     for leg in option_legs:
-        if leg.entry_value is not None:
-            # Transaction-derived: already in dollars
-            sign = 1 if leg.signed_quantity < 0 else -1
-            total += leg.entry_value * sign
-        else:
-            # Equity options: compute from price
-            price = Decimal(str(leg.average_open_price))
-            qty = Decimal(str(abs(leg.signed_quantity)))
-            sign = 1 if leg.signed_quantity < 0 else -1
-            total += price * qty * leg.multiplier * sign
+        sign = 1 if leg.signed_quantity < 0 else -1
+        total += leg.entry_value * sign
     return total
 \`\`\`
+
+**What changed:** No more \`if entry_value ... elif average_open_price\` branching. Every leg uses \`entry_value\` from the transactions API. The \`value\` field already accounts for multiplier and quantity — the API does the math for us.
 
 ### Impact on \`compute_max_profit\` / \`compute_max_loss\`
 
 - **Credit strategies:** \`max_profit = net_credit_dollars\` (no multiplier step)
 - **Width-based:** \`max_loss = (width * multiplier) - net_credit_dollars\`
 - **Debit strategies:** \`max_loss = abs(net_credit_dollars)\`
+
+### What Gets Removed
+
+- The \`average_open_price\` fallback path in the classifier
+- The \`average_open_price == 0.0\` workaround in \`classifier.py:81-87\`
+- Per-unit price multiplication logic (\`price * qty * multiplier\`)
+- The concept of "equity options use position API, futures use transactions API"
 
 **Renaming:** \`_net_entry_credit()\` becomes \`compute_net_entry_credit_dollars()\`, \`_strategy_multiplier()\` becomes \`strategy_multiplier()\``
       },
@@ -919,20 +948,25 @@ async def publish_entry_credits(
       {
         id: "orchestrator-classifier",
         title: "Step 5: Orchestrator & Classifier Changes",
+        revised: true,
         content: `**Files:** \`src/tastytrade/accounts/orchestrator.py\`, \`src/tastytrade/analytics/strategies/classifier.py\`
 
 ### Orchestrator: Fetch Transactions at Startup
+
+**Revised (v2):** Steps 4 and 5 swapped (replay-first, rollup-second). Scope expanded to **all option types** — not just futures options.
 
 \`\`\`
 # In orchestrator startup sequence:
 1. Fetch positions (existing)
 2. Fetch instruments for position symbols (existing)
-3. Fetch futures option transactions              <-- NEW
-4. Group transactions by symbol                   <-- NEW
-5. Run LIFO replay per symbol -> entry credits    <-- NEW
+3. Fetch option transactions (equity + futures)   <-- NEW (all options)
+4. Run LIFO replay per symbol -> identify fills   <-- NEW (replay first)
+5. Roll up entry credits from identified fills    <-- NEW (rollup second)
 6. Publish entry credits to Redis                 <-- NEW
 7. Run strategy classification (existing, now reads entry credits)
 \`\`\`
+
+**Rationale:** Using the transactions API uniformly for all option types eliminates the bifurcated equity/futures path. The API returns identical \`value\` (dollar) fields for both — confirmed against production data (CSCO equity options and /6E futures options).
 
 ### Classifier: \`build_parsed_leg()\` Changes
 
@@ -940,21 +974,22 @@ async def publish_entry_credits(
 # In build_parsed_leg():
 entry_credits = await redis.hgetall("tastytrade:entry_credits")
 
-# For each future option position:
+# For ALL option positions (equity + futures):
 credit_data = entry_credits.get(streamer_symbol)
 if credit_data:
     parsed = json.loads(credit_data)
     leg.entry_value = Decimal(parsed["value"])
 else:
-    # Fall back to average_open_price (equity options)
-    leg.entry_value = None
+    leg.entry_value = None  # No transaction data available
 \`\`\`
 
-### Remove the 0.0 Workaround
+### What Gets Removed
 
-The current workaround in \`classifier.py:81-87\` that treats \`average_open_price == 0.0\` as \`None\` becomes unnecessary. Futures options no longer depend on \`average_open_price\` at all.
+- The \`average_open_price == 0.0\` workaround in \`classifier.py:81-87\`
+- The \`average_open_price\` fallback path for equity options
+- The concept of "equity options use Position API prices, futures use transactions"
 
-**Backward compatibility:** Equity options continue to use \`average_open_price\` from the Position API (sufficient precision). No changes needed for equity options.
+**All option types now use a single, uniform flow:** transactions API -> LIFO replay -> dollar-valued entry credits.
 
 ### Files Modified
 

--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -13,11 +13,13 @@ from datetime import datetime, timezone
 
 import redis.asyncio as aioredis  # type: ignore[import-untyped]
 
-import redis.asyncio as aioredis
-
 from tastytrade.accounts.models import InstrumentType, Position
 from tastytrade.accounts.publisher import AccountStreamPublisher, Instrument
 from tastytrade.accounts.streamer import AccountStreamer
+from tastytrade.accounts.transactions import (
+    TransactionsClient,
+    compute_entry_credits_for_positions,
+)
 from tastytrade.config import RedisConfigManager
 from tastytrade.config.enumerations import AccountEventType, ReconnectReason
 from tastytrade.connections import Credentials
@@ -250,6 +252,26 @@ async def run_account_stream_once(
 
             await publisher.publish_instruments(all_instruments)
             logger.info("Enriched positions with %d instruments", len(all_instruments))
+
+            # === Compute entry credits from transaction history ===
+            option_positions = [
+                p
+                for p in hydrated_positions
+                if p.instrument_type
+                in (InstrumentType.EQUITY_OPTION, InstrumentType.FUTURE_OPTION)
+            ]
+            if option_positions:
+                account_number = credentials.account_number
+                txn_client = TransactionsClient(streamer.session)
+                all_txns = await txn_client.get_transactions(account_number)
+                positions_map: dict[str, int] = {}
+                for p in option_positions:
+                    positions_map[p.symbol] = int(abs(p.quantity))
+
+                entry_credits = compute_entry_credits_for_positions(
+                    all_txns, positions_map
+                )
+                await publisher.publish_entry_credits(entry_credits)
 
         for item in hydrated_items:
             position_queue.put_nowait(item)

--- a/src/tastytrade/accounts/publisher.py
+++ b/src/tastytrade/accounts/publisher.py
@@ -5,13 +5,12 @@ for on-demand reads, plus pub/sub for real-time consumers.
 Single responsibility: account events -> Redis.
 """
 
+import json
 import logging
 import os
-from typing import Optional
+from typing import Optional, Union
 
 import redis.asyncio as aioredis  # type: ignore[import-untyped]
-
-from typing import Union
 
 from tastytrade.accounts.models import (
     AccountBalance,
@@ -19,6 +18,7 @@ from tastytrade.accounts.models import (
     PlacedOrder,
     Position,
 )
+from tastytrade.accounts.transactions import EntryCredit
 from tastytrade.market.models import (
     CryptocurrencyInstrument,
     EquityInstrument,
@@ -46,6 +46,8 @@ class AccountStreamPublisher:
     INSTRUMENTS_KEY = "tastytrade:instruments"
     ORDERS_KEY = "tastytrade:orders"
     COMPLEX_ORDERS_KEY = "tastytrade:complex-orders"
+    ENTRY_CREDITS_KEY = "tastytrade:entry_credits"
+    ENTRY_CREDITS_CHANNEL = "tastytrade:events:EntryCreditsUpdated"
 
     def __init__(
         self,
@@ -129,6 +131,28 @@ class AccountStreamPublisher:
             )
         await pipe.execute()
         logger.info("Published %d instruments to Redis", len(instruments))
+
+    async def publish_entry_credits(self, credits: dict[str, EntryCredit]) -> None:
+        """Write entry credits to Redis HSET and notify downstream consumers."""
+        if not credits:
+            return
+        pipe = self.redis.pipeline()
+        symbols = []
+        for symbol, credit in credits.items():
+            pipe.hset(self.ENTRY_CREDITS_KEY, symbol, credit.model_dump_json())
+            symbols.append(symbol)
+        await pipe.execute()
+
+        await self.redis.publish(
+            self.ENTRY_CREDITS_CHANNEL,
+            json.dumps({"symbols": symbols, "count": len(symbols)}),
+        )
+        logger.info("Published entry credits for %d symbols", len(symbols))
+
+    async def remove_entry_credit(self, symbol: str) -> None:
+        """Remove an entry credit record for a closed position."""
+        await self.redis.hdel(self.ENTRY_CREDITS_KEY, symbol)
+        logger.info("Removed entry credit for closed position: %s", symbol)
 
     async def close(self) -> None:
         """Close Redis connection."""

--- a/src/tastytrade/accounts/transactions.py
+++ b/src/tastytrade/accounts/transactions.py
@@ -1,0 +1,263 @@
+"""Transaction history client and LIFO entry credit computation.
+
+Fetches trade fills from GET /accounts/{acct}/transactions and computes
+dollar-valued entry credits via reverse (LIFO) replay. Used for all option
+types — the API returns identical ``value`` (dollar) fields for both equity
+and futures options.
+
+**API quirk — mixed transaction types in response:**
+The Transactions API may return non-Trade items (e.g. "Money Movement" /
+"Balance Adjustment" for regulatory fee adjustments) even when the request
+explicitly filters by ``transaction-type=Trade``. These items have a
+different schema (no ``action``, ``symbol``, ``quantity``, etc.) and must
+be filtered out before parsing. The ``TransactionsClient`` handles this
+automatically via a ``transaction-type`` check on each item.
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tastytrade.connections.requests import AsyncSessionHandler
+from tastytrade.utils.validators import validate_async_response
+
+logger = logging.getLogger(__name__)
+
+
+class Transaction(BaseModel):
+    """A single trade fill from the Transactions API."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="allow",
+        populate_by_name=True,
+    )
+
+    id: int
+    executed_at: datetime = Field(alias="executed-at")
+    action: str = Field(alias="action")
+    symbol: str = Field(alias="symbol")
+    underlying_symbol: str = Field(alias="underlying-symbol")
+    instrument_type: str = Field(alias="instrument-type")
+    price: Decimal = Field(alias="price")
+    value: Decimal = Field(alias="value")
+    value_effect: str = Field(alias="value-effect")
+    net_value: Decimal = Field(alias="net-value")
+    net_value_effect: str = Field(alias="net-value-effect")
+    quantity: Decimal = Field(alias="quantity")
+    order_id: int = Field(alias="order-id")
+    leg_count: int = Field(alias="leg-count")
+
+
+class EntryCredit(BaseModel):
+    """Computed entry credit for a single position, stored in Redis."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    value: Decimal
+    fees: Decimal = Decimal("0")
+    per_unit_price: Optional[Decimal] = None
+    method: str = "transaction_lifo"
+    transaction_count: int
+    computed_at: Optional[datetime] = None
+
+
+class TransactionsClient:
+    """Fetches transaction history from the TastyTrade REST API."""
+
+    def __init__(self, session: AsyncSessionHandler) -> None:
+        self.session = session
+
+    async def get_transactions(
+        self,
+        account_number: str,
+        instrument_type: Optional[str] = None,
+        per_page: int = 250,
+    ) -> list[Transaction]:
+        """Fetch trade transactions for an account.
+
+        Note: The API may return non-Trade items (fee adjustments, balance
+        adjustments) even with ``transaction-type=Trade`` filter. These are
+        filtered out automatically before parsing.
+
+        Args:
+            account_number: The account to query.
+            instrument_type: Optional filter (e.g., "Equity Option", "Future Option").
+            per_page: Page size for pagination.
+
+        Returns:
+            All matching Trade transactions across all pages, newest first.
+        """
+        all_transactions: list[Transaction] = []
+        page_offset = 0
+
+        while True:
+            params: dict[str, str | int] = {
+                "per-page": per_page,
+                "page-offset": page_offset,
+                "sort": "Desc",
+                "transaction-type": "Trade",
+            }
+            if instrument_type:
+                params["instrument-type"] = instrument_type
+
+            async with self.session.session.get(
+                f"{self.session.base_url}/accounts/{account_number}/transactions",
+                params=params,
+            ) as response:
+                await validate_async_response(response)
+                data = await response.json()
+
+            items = data["data"]["items"]
+            for item in items:
+                # The API may include non-trade items (e.g. fee adjustments)
+                # even when filtering by transaction-type=Trade. Skip them.
+                if item.get("transaction-type") != "Trade":
+                    continue
+                all_transactions.append(Transaction.model_validate(item))
+
+            pagination = data.get("pagination", {})
+            total_pages = pagination.get("total-pages", 1)
+            page_offset += 1
+
+            if page_offset >= total_pages:
+                break
+
+        logger.info("Fetched %d transactions", len(all_transactions))
+        return all_transactions
+
+
+OPEN_ACTIONS = {"Sell to Open", "Buy to Open"}
+CLOSE_ACTIONS = {"Buy to Close", "Sell to Close"}
+
+
+@dataclass(frozen=True)
+class LifoResult:
+    """Result of a LIFO reverse replay for a single symbol."""
+
+    entry_credit: Decimal
+    fees: Decimal
+    weighted_price: Optional[Decimal]
+
+
+def compute_entry_credit_lifo(
+    transactions: list[Transaction],
+    current_qty: int,
+) -> Optional[LifoResult]:
+    """Walk transactions newest-to-oldest, reconstruct entry credit via LIFO.
+
+    The LIFO replay identifies which specific fills constitute the current
+    position. The position-level rollup (dollar entry credit) is derived
+    from those identified fills.
+
+    Args:
+        transactions: All transactions for a single symbol, any order.
+        current_qty: Absolute quantity of the current position.
+
+    Returns:
+        LifoResult with entry credit, fees, and weighted average price,
+        or None if transactions don't fully account for the position.
+    """
+    if current_qty == 0:
+        return LifoResult(Decimal("0"), Decimal("0"), None)
+
+    txns = sorted(transactions, key=lambda t: t.executed_at, reverse=True)
+
+    remaining = abs(current_qty)
+    close_buffer = 0
+    entry_credit = Decimal("0")
+    total_fees = Decimal("0")
+    price_x_qty = Decimal("0")
+    total_qty = Decimal("0")
+
+    for txn in txns:
+        if remaining == 0:
+            break
+
+        qty = int(txn.quantity)
+
+        if txn.action in CLOSE_ACTIONS:
+            close_buffer += qty
+            continue
+
+        if txn.action in OPEN_ACTIONS:
+            consumed = min(qty, close_buffer)
+            close_buffer -= consumed
+            surviving = qty - consumed
+
+            take = min(surviving, remaining)
+            if take > 0:
+                fraction = Decimal(take) / Decimal(qty)
+                proportional_value = txn.value * fraction
+                sign = Decimal("1") if txn.value_effect == "Credit" else Decimal("-1")
+                entry_credit += proportional_value * sign
+
+                # Accumulate fees: difference between value and net_value
+                proportional_fees = abs(txn.net_value - txn.value) * fraction
+                total_fees += proportional_fees
+
+                # Weighted average price (per-unit)
+                price_x_qty += txn.price * take
+                total_qty += take
+
+                remaining -= take
+
+    if remaining != 0:
+        logger.warning(
+            "LIFO replay incomplete: %d contracts unaccounted for", remaining
+        )
+        return None
+
+    weighted_price = (price_x_qty / total_qty) if total_qty > 0 else None
+
+    return LifoResult(
+        entry_credit=entry_credit,
+        fees=total_fees,
+        weighted_price=weighted_price,
+    )
+
+
+def compute_entry_credits_for_positions(
+    transactions: list[Transaction],
+    positions: dict[str, int],
+) -> dict[str, EntryCredit]:
+    """Compute entry credits for multiple positions from transaction history.
+
+    Args:
+        transactions: All option transactions for the account.
+        positions: Map of symbol → abs_quantity.
+
+    Returns:
+        Map of symbol → EntryCredit for positions where computation succeeded.
+    """
+    by_symbol: dict[str, list[Transaction]] = defaultdict(list)
+    for txn in transactions:
+        by_symbol[txn.symbol].append(txn)
+
+    results: dict[str, EntryCredit] = {}
+
+    for symbol, qty in positions.items():
+        symbol_txns = by_symbol.get(symbol, [])
+        if not symbol_txns:
+            continue
+
+        result = compute_entry_credit_lifo(symbol_txns, qty)
+        if result is not None:
+            results[symbol] = EntryCredit(
+                value=result.entry_credit,
+                fees=result.fees,
+                per_unit_price=result.weighted_price,
+                transaction_count=len(symbol_txns),
+            )
+
+    logger.info(
+        "Computed entry credits for %d of %d positions",
+        len(results),
+        len(positions),
+    )
+    return results

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -9,6 +9,7 @@ No API calls, no socket connections.
 import json
 import logging
 import os
+from decimal import Decimal
 from typing import Any, Optional
 
 import pandas as pd
@@ -16,6 +17,7 @@ import redis.asyncio as aioredis  # type: ignore[import-untyped]
 
 from tastytrade.accounts.models import Position
 from tastytrade.accounts.publisher import AccountStreamPublisher
+from tastytrade.accounts.transactions import EntryCredit
 from tastytrade.analytics.metrics import MetricsTracker
 from tastytrade.analytics.strategies.classifier import StrategyClassifier
 from tastytrade.analytics.strategies.health import StrategyHealthMonitor
@@ -42,6 +44,8 @@ class PositionMetricsReader:
         self.position_metrics_df: pd.DataFrame = pd.DataFrame()
         self.tracker: Optional[MetricsTracker] = None
         self.instruments: dict[str, Any] = {}
+        self.entry_credit_records: dict[str, EntryCredit] = {}
+        self.entry_credits: dict[str, Decimal] = {}
 
     @property
     def summary(self) -> pd.DataFrame:
@@ -79,7 +83,11 @@ class PositionMetricsReader:
         if self.tracker is None:
             return []
         classifier = StrategyClassifier()
-        return classifier.classify(self.tracker.securities, self.instruments)
+        return classifier.classify(
+            self.tracker.securities,
+            self.instruments,
+            self.entry_credits or None,
+        )
 
     @property
     def strategy_summary(self) -> pd.DataFrame:
@@ -208,7 +216,59 @@ class PositionMetricsReader:
         if self.instruments:
             logger.info("Loaded %d instruments from Redis", len(self.instruments))
 
-        self.position_metrics_df = tracker.df
+        # 6. Read entry credits (transaction-derived dollar values)
+        raw_credits = await self.redis.hgetall(AccountStreamPublisher.ENTRY_CREDITS_KEY)
+        self.entry_credit_records = {}
+        self.entry_credits = {}
+        for key, value in raw_credits.items():
+            try:
+                symbol = key.decode() if isinstance(key, bytes) else key
+                credit = EntryCredit.model_validate_json(value)
+                self.entry_credit_records[symbol] = credit
+                self.entry_credits[symbol] = credit.value
+            except Exception as e:
+                logger.debug("Skipped entry credit: %s", e)
+
+        if self.entry_credits:
+            logger.info("Loaded %d entry credits from Redis", len(self.entry_credits))
+
+        # 7. Enrich DataFrame with entry credit data
+        df = tracker.df
+        if not df.empty and self.entry_credit_records:
+            records = self.entry_credit_records
+
+            def get_entry_value(sym: str) -> float | None:
+                rec = records.get(sym)
+                return float(rec.value) if rec else None
+
+            def get_entry_price(sym: str) -> float | None:
+                rec = records.get(sym)
+                if rec and rec.per_unit_price is not None:
+                    return float(rec.per_unit_price)
+                return None
+
+            def get_fees(sym: str) -> float | None:
+                rec = records.get(sym)
+                return float(rec.fees) if rec else None
+
+            df["entry_value"] = df["symbol"].map(get_entry_value)
+            df["entry_price"] = df["symbol"].map(get_entry_price)
+            df["fees"] = df["symbol"].map(get_fees)
+
+        # 8. Enrich with DTE from instrument data
+        if not df.empty and self.instruments:
+            instruments = self.instruments
+
+            def get_dte(sym: str) -> int | None:
+                inst = instruments.get(sym)
+                if inst and isinstance(inst, dict):
+                    dte = inst.get("days-to-expiration")
+                    return int(dte) if dte is not None else None
+                return None
+
+            df["dte"] = df["symbol"].map(get_dte).astype("Int64")
+
+        self.position_metrics_df = df
         return self.position_metrics_df
 
     async def close(self) -> None:

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -29,6 +29,7 @@ class StrategyClassifier:
     def build_parsed_leg(
         security: SecurityMetrics,
         instruments: dict[str, Any],
+        entry_credits: Optional[dict[str, Decimal]] = None,
     ) -> ParsedLeg:
         """Build a ParsedLeg by joining SecurityMetrics + instrument data."""
         signed_qty = security.quantity
@@ -80,11 +81,16 @@ class StrategyClassifier:
 
         # The Position API returns 0.0 for average-open-price on some
         # future options (e.g. /6E) where the premium is too small to
-        # represent. Treat as missing data — the transactions API can
-        # provide precise entry prices (see future ticket).
+        # represent. Treat as missing data — the transactions API
+        # provides precise entry values via LIFO replay.
         avg_open = security.average_open_price
         if avg_open is not None and avg_open == 0.0:
             avg_open = None
+
+        # Look up transaction-derived entry value (dollar credit for this position)
+        entry_value: Optional[Decimal] = None
+        if entry_credits is not None:
+            entry_value = entry_credits.get(security.symbol)
 
         return ParsedLeg(
             streamer_symbol=security.streamer_symbol,
@@ -97,6 +103,7 @@ class StrategyClassifier:
             expiration=expiration,
             days_to_expiration=dte,
             multiplier=multiplier,
+            entry_value=entry_value,
             average_open_price=avg_open,
             delta=security.delta,
             gamma=security.gamma,
@@ -109,6 +116,7 @@ class StrategyClassifier:
         self,
         securities: dict[str, SecurityMetrics],
         instruments: dict[str, Any],
+        entry_credits: Optional[dict[str, Decimal]] = None,
     ) -> list[Strategy]:
         """Classify all positions into strategies.
 
@@ -120,7 +128,7 @@ class StrategyClassifier:
         # Build parsed legs
         all_legs: list[ParsedLeg] = []
         for security in securities.values():
-            leg = self.build_parsed_leg(security, instruments)
+            leg = self.build_parsed_leg(security, instruments, entry_credits)
             all_legs.append(leg)
 
         # Group by underlying

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -96,7 +96,11 @@ class ParsedLeg:
     # Future options: underlying future's notional-multiplier.
     multiplier: Decimal = Decimal("1")
 
-    # Entry price (from position's average-open-price)
+    # Entry value in dollars (from transactions API LIFO replay)
+    entry_value: Optional[Decimal] = None
+
+    # Legacy entry price (from position's average-open-price) — kept for
+    # backward compatibility but no longer used in P&L calculations.
     average_open_price: Optional[float] = None
 
     # Market data (from real-time feeds)
@@ -241,7 +245,7 @@ class Strategy:
         return compute_max_loss(self)
 
 
-def _strategy_multiplier(strategy: Strategy) -> Decimal:
+def strategy_multiplier(strategy: Strategy) -> Decimal:
     """Get the contract multiplier for a strategy.
 
     All legs in a strategy share the same underlying, so the multiplier
@@ -253,30 +257,31 @@ def _strategy_multiplier(strategy: Strategy) -> Decimal:
     return Decimal("1")
 
 
-def _net_entry_credit(option_legs: list[ParsedLeg]) -> Optional[Decimal]:
-    """Compute the net credit received at entry from average_open_price.
+def compute_net_entry_credit_dollars(
+    option_legs: list[ParsedLeg],
+) -> Optional[Decimal]:
+    """Compute the net dollar credit received at entry.
 
-    Positive = net credit (sold premium > bought premium).
-    Returns None if any leg is missing open price data.
+    Uses transaction-derived ``entry_value`` which is already signed by
+    the LIFO replay: positive = credit received (Sell to Open), negative =
+    debit paid (Buy to Open). Simply sums all leg values.
+
+    Positive result = net credit (sold premium > bought premium).
+    Returns None if any leg is missing entry value data.
     """
-    if any(leg.average_open_price is None for leg in option_legs):
+    if any(leg.entry_value is None for leg in option_legs):
         return None
-    # Short legs contribute credit (+), long legs contribute debit (-)
-    return sum(
-        (
-            Decimal(str(leg.average_open_price))
-            * Decimal(str(leg.signed_quantity * -1))
-            for leg in option_legs
-            if leg.average_open_price is not None
-        ),
-        Decimal("0"),
-    )
+    total = Decimal("0")
+    for leg in option_legs:
+        assert leg.entry_value is not None  # guarded above
+        total += leg.entry_value
+    return total
 
 
 def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
     """Compute max profit in dollars based on strategy type and entry prices.
 
-    Uses average_open_price (the actual fill) — not the current mark.
+    Uses transaction-derived dollar entry values — not the current mark.
     Max profit is fixed at entry and does not change with market moves.
     Returns None if insufficient data.
     """
@@ -285,8 +290,8 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     st = strategy.strategy_type
-    mult = _strategy_multiplier(strategy)
-    net_credit = _net_entry_credit(option_legs)
+    mult = strategy_multiplier(strategy)
+    net_credit = compute_net_entry_credit_dollars(option_legs)
 
     if net_credit is None:
         return None
@@ -301,16 +306,15 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         StrategyType.NAKED_PUT,
         StrategyType.JADE_LIZARD,
     ):
-        # Credit strategies: max profit = net credit received × multiplier
-        return (max(net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
+        # Credit strategies: max profit = net credit received (already in dollars)
+        return max(net_credit, Decimal("0")).quantize(Decimal("1"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        # Debit spread: max profit = width - net debit paid
+        # Debit spread: max profit = (width * multiplier) - net debit paid
         w = strategy.width
         if w is None:
             return None
-        # net_credit is negative for debit spreads (we paid more than we received)
-        return (max(w + net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
+        return max(w * mult + net_credit, Decimal("0")).quantize(Decimal("1"))
 
     return None
 
@@ -318,7 +322,7 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
 def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
     """Compute max loss in dollars based on strategy type and entry prices.
 
-    Uses average_open_price (the actual fill) — not the current mark.
+    Uses transaction-derived dollar entry values — not the current mark.
     Returns None for unlimited-risk strategies or insufficient data.
     """
     option_legs = [leg for leg in strategy.legs if leg.is_option]
@@ -326,8 +330,8 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     st = strategy.strategy_type
-    mult = _strategy_multiplier(strategy)
-    net_credit = _net_entry_credit(option_legs)
+    mult = strategy_multiplier(strategy)
+    net_credit = compute_net_entry_credit_dollars(option_legs)
 
     if net_credit is None:
         return None
@@ -341,16 +345,16 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
-        # Credit spread: max loss = width - net credit
+        # Credit spread: max loss = (width * multiplier) - net credit
         w = strategy.width
         if w is None:
             return None
-        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
+        return max(w * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        # Debit spread: max loss = net debit paid
-        net_debit = -net_credit  # flip sign: positive = what we paid
-        return (max(net_debit, Decimal("0")) * mult).quantize(Decimal("1"))
+        # Debit spread: max loss = net debit paid (already in dollars)
+        net_debit = -net_credit
+        return max(net_debit, Decimal("0")).quantize(Decimal("1"))
 
     if st == StrategyType.IRON_CONDOR:
         put_strikes = sorted(
@@ -371,15 +375,12 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             else Decimal("0")
         )
         wing_width = max(put_width, call_width)
-        return (max(wing_width - net_credit, Decimal("0")) * mult).quantize(
-            Decimal("1")
-        )
+        return max(wing_width * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
 
     if st == StrategyType.JADE_LIZARD:
-        # Jade lizard has a defined-risk side (the vertical spread)
         w = strategy.width
         if w is None:
             return None
-        return (max(w - net_credit, Decimal("0")) * mult).quantize(Decimal("1"))
+        return max(w * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
 
     return None

--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -306,6 +306,11 @@ def positions_cmd() -> None:
                 "quantity",
                 "quantity_direction",
                 "mid_price",
+                "entry_price",
+                "entry_value",
+                "multiplier",
+                "fees",
+                "dte",
                 "delta",
                 "implied_volatility",
             ]

--- a/unit_tests/accounts/test_transactions.py
+++ b/unit_tests/accounts/test_transactions.py
@@ -1,0 +1,343 @@
+"""Unit tests for transaction LIFO entry credit computation."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from tastytrade.accounts.transactions import (
+    Transaction,
+    compute_entry_credit_lifo,
+    compute_entry_credits_for_positions,
+)
+
+
+def make_txn(
+    txn_id: int,
+    action: str,
+    symbol: str,
+    quantity: int,
+    value: Decimal,
+    value_effect: str,
+    executed_at: datetime | None = None,
+    underlying: str = "SPY",
+    price: Decimal = Decimal("1.00"),
+    net_value: Decimal | None = None,
+) -> Transaction:
+    """Create a Transaction for testing."""
+    if executed_at is None:
+        executed_at = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    if net_value is None:
+        net_value = value
+    return Transaction.model_validate(
+        {
+            "id": txn_id,
+            "executed-at": executed_at.isoformat(),
+            "action": action,
+            "symbol": symbol,
+            "underlying-symbol": underlying,
+            "instrument-type": "Equity Option",
+            "price": price,
+            "value": value,
+            "value-effect": value_effect,
+            "net-value": net_value,
+            "net-value-effect": value_effect,
+            "quantity": Decimal(str(quantity)),
+            "order-id": 1000 + txn_id,
+            "leg-count": 1,
+        }
+    )
+
+
+class TestComputeEntryCreditLifo:
+    """Test LIFO reverse replay algorithm."""
+
+    def test_single_open_credit(self) -> None:
+        """Single sell-to-open → full credit."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                2,
+                Decimal("300.00"),
+                "Credit",
+                price=Decimal("1.50"),
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 2)
+        assert result is not None
+        assert result.entry_credit == Decimal("300.00")
+        assert result.weighted_price == Decimal("1.50")
+
+    def test_single_open_debit(self) -> None:
+        """Single buy-to-open → negative (debit)."""
+        txns = [
+            make_txn(
+                1,
+                "Buy to Open",
+                "SPY 260C",
+                3,
+                Decimal("450.00"),
+                "Debit",
+                price=Decimal("1.50"),
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 3)
+        assert result is not None
+        assert result.entry_credit == Decimal("-450.00")
+        assert result.weighted_price == Decimal("1.50")
+
+    def test_partial_close_lifo(self) -> None:
+        """Open 5, close 2 → LIFO keeps last 3 from the open fill."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                5,
+                Decimal("500.00"),
+                "Credit",
+                datetime(2025, 1, 1, tzinfo=timezone.utc),
+            ),
+            make_txn(
+                2,
+                "Buy to Close",
+                "SPY 250P",
+                2,
+                Decimal("180.00"),
+                "Debit",
+                datetime(2025, 1, 5, tzinfo=timezone.utc),
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 3)
+        assert result is not None
+        # Open 5 for $500, close 2 → 3 surviving, proportional = 500 * 3/5 = 300
+        assert result.entry_credit == Decimal("300.00")
+
+    def test_multiple_opens_lifo_order(self) -> None:
+        """Two opens, close 1 → LIFO consumes from most recent open first."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                2,
+                Decimal("200.00"),
+                "Credit",
+                datetime(2025, 1, 1, tzinfo=timezone.utc),
+                price=Decimal("1.00"),
+            ),
+            make_txn(
+                2,
+                "Sell to Open",
+                "SPY 250P",
+                3,
+                Decimal("360.00"),
+                "Credit",
+                datetime(2025, 1, 10, tzinfo=timezone.utc),
+                price=Decimal("1.20"),
+            ),
+            make_txn(
+                3,
+                "Buy to Close",
+                "SPY 250P",
+                1,
+                Decimal("100.00"),
+                "Debit",
+                datetime(2025, 1, 15, tzinfo=timezone.utc),
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 4)
+        assert result is not None
+        # Newest-to-oldest: close(1), open(3@1.20), open(2@1.00)
+        # Close buffer=1, open(3): consumed=1, surviving=2, take=2 → 360*2/3=240
+        # open(2): consumed=0, surviving=2, take=2 → 200
+        # Total = 440
+        assert result.entry_credit == Decimal("440.00")
+        # Weighted price: (1.20*2 + 1.00*2) / 4 = 4.40/4 = 1.10
+        assert result.weighted_price == Decimal("1.10")
+
+    def test_zero_quantity_returns_zero(self) -> None:
+        result = compute_entry_credit_lifo([], 0)
+        assert result is not None
+        assert result.entry_credit == Decimal("0")
+
+    def test_incomplete_replay_returns_none(self) -> None:
+        """Not enough opens to account for current qty → None."""
+        txns = [
+            make_txn(1, "Sell to Open", "SPY 250P", 1, Decimal("100.00"), "Credit"),
+        ]
+        result = compute_entry_credit_lifo(txns, 5)
+        assert result is None
+
+    def test_full_rollover(self) -> None:
+        """Open 2, close 2, re-open 2 → only the re-open contributes."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                2,
+                Decimal("200.00"),
+                "Credit",
+                datetime(2025, 1, 1, tzinfo=timezone.utc),
+            ),
+            make_txn(
+                2,
+                "Buy to Close",
+                "SPY 250P",
+                2,
+                Decimal("150.00"),
+                "Debit",
+                datetime(2025, 1, 5, tzinfo=timezone.utc),
+            ),
+            make_txn(
+                3,
+                "Sell to Open",
+                "SPY 250P",
+                2,
+                Decimal("250.00"),
+                "Credit",
+                datetime(2025, 1, 10, tzinfo=timezone.utc),
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 2)
+        assert result is not None
+        assert result.entry_credit == Decimal("250.00")
+
+    def test_fees_accumulated(self) -> None:
+        """Fees are computed from value vs net_value difference."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                2,
+                Decimal("300.00"),
+                "Credit",
+                net_value=Decimal("299.80"),  # 0.20 in fees
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 2)
+        assert result is not None
+        assert result.fees == Decimal("0.20")
+
+    def test_fees_proportional(self) -> None:
+        """Fees are proportional when only part of a fill is used."""
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                4,
+                Decimal("400.00"),
+                "Credit",
+                net_value=Decimal("399.60"),  # 0.40 total fees
+            ),
+        ]
+        result = compute_entry_credit_lifo(txns, 2)
+        assert result is not None
+        # Only 2 of 4 contracts used → fees = 0.40 * 2/4 = 0.20
+        assert result.fees == Decimal("0.20")
+
+
+class TestComputeEntryCreditsForPositions:
+    """Test batch entry credit computation."""
+
+    def test_multiple_symbols(self) -> None:
+        txns = [
+            make_txn(
+                1,
+                "Sell to Open",
+                "SPY 250P",
+                1,
+                Decimal("100"),
+                "Credit",
+                price=Decimal("1.00"),
+            ),
+            make_txn(
+                2,
+                "Buy to Open",
+                "SPY 260C",
+                1,
+                Decimal("200"),
+                "Debit",
+                price=Decimal("2.00"),
+            ),
+        ]
+        positions = {
+            "SPY 250P": 1,
+            "SPY 260C": 1,
+        }
+        results = compute_entry_credits_for_positions(txns, positions)
+        assert "SPY 250P" in results
+        assert results["SPY 250P"].value == Decimal("100")
+        assert results["SPY 250P"].per_unit_price == Decimal("1.00")
+        assert "SPY 260C" in results
+        assert results["SPY 260C"].value == Decimal("-200")
+        assert results["SPY 260C"].per_unit_price == Decimal("2.00")
+
+    def test_missing_transactions_skipped(self) -> None:
+        """Positions with no matching transactions are omitted."""
+        positions = {"AAPL 150C": 1}
+        results = compute_entry_credits_for_positions([], positions)
+        assert len(results) == 0
+
+    def test_incomplete_lifo_excluded(self) -> None:
+        """If LIFO can't account for full qty, symbol is excluded."""
+        txns = [
+            make_txn(1, "Sell to Open", "SPY 250P", 1, Decimal("50"), "Credit"),
+        ]
+        positions = {"SPY 250P": 10}
+        results = compute_entry_credits_for_positions(txns, positions)
+        assert "SPY 250P" not in results
+
+
+class TestTransactionModel:
+    """Test Transaction Pydantic model."""
+
+    def test_parse_api_response(self) -> None:
+        raw = {
+            "id": 42,
+            "executed-at": "2025-03-01T14:30:00+00:00",
+            "action": "Sell to Open",
+            "symbol": "SPY   250321P00500000",
+            "underlying-symbol": "SPY",
+            "instrument-type": "Equity Option",
+            "price": "1.50",
+            "value": "150.00",
+            "value-effect": "Credit",
+            "net-value": "148.70",
+            "net-value-effect": "Credit",
+            "quantity": "1",
+            "order-id": 9999,
+            "leg-count": 2,
+        }
+        txn = Transaction.model_validate(raw)
+        assert txn.id == 42
+        assert txn.action == "Sell to Open"
+        assert txn.value == Decimal("150.00")
+        assert txn.value_effect == "Credit"
+        assert txn.quantity == Decimal("1")
+        assert txn.leg_count == 2
+
+    def test_extra_fields_allowed(self) -> None:
+        """Brokerage may send extra fields — model must not reject them."""
+        raw = {
+            "id": 1,
+            "executed-at": "2025-01-01T00:00:00+00:00",
+            "action": "Buy to Open",
+            "symbol": "AAPL 150C",
+            "underlying-symbol": "AAPL",
+            "instrument-type": "Equity Option",
+            "price": "2.00",
+            "value": "200.00",
+            "value-effect": "Debit",
+            "net-value": "201.30",
+            "net-value-effect": "Debit",
+            "quantity": "1",
+            "order-id": 100,
+            "leg-count": 1,
+            "some-future-field": "surprise",
+        }
+        txn = Transaction.model_validate(raw)
+        assert txn.id == 1

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -414,3 +414,56 @@ class TestBuildParsedLegFutureOptions:
         leg = classifier.build_parsed_leg(sec, instruments)
         assert leg.average_open_price == 0.23
         assert leg.multiplier == Decimal("1000.0")
+
+    def test_entry_value_from_credits(self):
+        """entry_value is populated from entry_credits dict when provided."""
+        sec = make_security(
+            symbol="SPY   260320P00500000",
+            streamer_symbol=".SPY260320P500",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=2,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        instruments = {
+            "SPY   260320P00500000": {
+                "option-type": "P",
+                "strike-price": "500.0",
+                "expiration-date": "2026-03-20",
+                "days-to-expiration": 30,
+                "shares-per-contract": 100,
+            }
+        }
+        entry_credits = {"SPY   260320P00500000": Decimal("350.00")}
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, instruments, entry_credits)
+        assert leg.entry_value == Decimal("350.00")
+
+    def test_entry_value_none_without_credits(self):
+        """entry_value is None when no entry_credits provided."""
+        sec = make_security(
+            symbol="SPY   260320P00500000",
+            streamer_symbol=".SPY260320P500",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.SHORT,
+        )
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, {})
+        assert leg.entry_value is None
+
+    def test_entry_value_none_when_symbol_missing(self):
+        """entry_value is None when symbol not in entry_credits map."""
+        sec = make_security(
+            symbol="SPY   260320C00550000",
+            streamer_symbol=".SPY260320C550",
+            underlying_symbol="SPY",
+            instrument_type=InstrumentType.EQUITY_OPTION,
+            quantity=1,
+            quantity_direction=QuantityDirection.LONG,
+        )
+        entry_credits = {"OTHER_SYMBOL": Decimal("100.00")}
+        classifier = StrategyClassifier()
+        leg = classifier.build_parsed_leg(sec, {}, entry_credits)
+        assert leg.entry_value is None

--- a/unit_tests/analytics/strategies/test_models.py
+++ b/unit_tests/analytics/strategies/test_models.py
@@ -1,0 +1,251 @@
+"""Unit tests for Strategy model P&L calculations with entry_value."""
+
+from decimal import Decimal
+
+from tastytrade.accounts.models import InstrumentType
+from tastytrade.analytics.strategies.models import (
+    ParsedLeg,
+    Strategy,
+    StrategyType,
+    compute_net_entry_credit_dollars,
+)
+
+
+def make_option_leg(
+    option_type: str,
+    strike: Decimal,
+    signed_quantity: float,
+    entry_value: Decimal | None = None,
+    multiplier: Decimal = Decimal("100"),
+    instrument_type: InstrumentType = InstrumentType.EQUITY_OPTION,
+) -> ParsedLeg:
+    """Create a ParsedLeg for strategy model tests.
+
+    entry_value follows LIFO convention: positive = credit received (STO),
+    negative = debit paid (BTO). The sign is baked in by the LIFO replay.
+    """
+    return ParsedLeg(
+        streamer_symbol=f".TEST{option_type}{strike}",
+        symbol=f"TEST {option_type}{strike}",
+        underlying="TEST",
+        instrument_type=instrument_type,
+        signed_quantity=signed_quantity,
+        option_type=option_type,
+        strike=strike,
+        expiration=None,
+        days_to_expiration=30,
+        multiplier=multiplier,
+        entry_value=entry_value,
+    )
+
+
+class TestNetEntryCredit:
+    """Test compute_net_entry_credit_dollars.
+
+    entry_value is already signed by LIFO: positive=credit, negative=debit.
+    Net credit = sum of all entry_values.
+    """
+
+    def test_credit_spread(self) -> None:
+        """Short leg credit + long leg debit → positive net credit."""
+        legs = [
+            # Sold P@250 for $300 credit
+            make_option_leg("P", Decimal("250"), -1, entry_value=Decimal("300")),
+            # Bought P@245 for $150 debit
+            make_option_leg("P", Decimal("245"), 1, entry_value=Decimal("-150")),
+        ]
+        result = compute_net_entry_credit_dollars(legs)
+        assert result == Decimal("150")
+
+    def test_debit_spread(self) -> None:
+        """Long leg debit > short leg credit → negative net credit."""
+        legs = [
+            # Bought C@260 for $500 debit
+            make_option_leg("C", Decimal("260"), 1, entry_value=Decimal("-500")),
+            # Sold C@270 for $200 credit
+            make_option_leg("C", Decimal("270"), -1, entry_value=Decimal("200")),
+        ]
+        result = compute_net_entry_credit_dollars(legs)
+        assert result == Decimal("-300")
+
+    def test_missing_entry_value_returns_none(self) -> None:
+        legs = [
+            make_option_leg("P", Decimal("250"), -1, entry_value=Decimal("300")),
+            make_option_leg("P", Decimal("245"), 1, entry_value=None),
+        ]
+        assert compute_net_entry_credit_dollars(legs) is None
+
+
+class TestMaxProfit:
+    """Test compute_max_profit for various strategy types."""
+
+    def test_bear_call_spread_credit(self) -> None:
+        """Bear call spread: max profit = net credit received."""
+        legs = (
+            # Sold C@250 for $400 credit
+            make_option_leg("C", Decimal("250"), -1, entry_value=Decimal("400")),
+            # Bought C@260 for $150 debit
+            make_option_leg("C", Decimal("260"), 1, entry_value=Decimal("-150")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BEAR_CALL_SPREAD,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Net credit = 400 + (-150) = 250
+        assert strat.max_profit == Decimal("250")
+
+    def test_bull_call_spread_debit(self) -> None:
+        """Bull call spread: max profit = width × multiplier - net debit."""
+        legs = (
+            # Bought C@250 for $500 debit
+            make_option_leg("C", Decimal("250"), 1, entry_value=Decimal("-500")),
+            # Sold C@260 for $200 credit
+            make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("200")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BULL_CALL_SPREAD,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Width = 10, multiplier = 100, net_credit = -300 (debit)
+        # Max profit = 10 * 100 + (-300) = 700
+        assert strat.max_profit == Decimal("700")
+
+    def test_iron_condor_credit(self) -> None:
+        """Iron condor: max profit = net credit."""
+        legs = (
+            # Bought P@240 for $50 debit
+            make_option_leg("P", Decimal("240"), 1, entry_value=Decimal("-50")),
+            # Sold P@245 for $100 credit
+            make_option_leg("P", Decimal("245"), -1, entry_value=Decimal("100")),
+            # Sold C@260 for $120 credit
+            make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("120")),
+            # Bought C@265 for $40 debit
+            make_option_leg("C", Decimal("265"), 1, entry_value=Decimal("-40")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.IRON_CONDOR,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Net credit = -50 + 100 + 120 + (-40) = 130
+        assert strat.max_profit == Decimal("130")
+
+    def test_missing_entry_value_returns_none(self) -> None:
+        legs = (
+            make_option_leg("C", Decimal("250"), -1, entry_value=None),
+            make_option_leg("C", Decimal("260"), 1, entry_value=Decimal("-150")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BEAR_CALL_SPREAD,
+            underlying="SPY",
+            legs=legs,
+        )
+        assert strat.max_profit is None
+
+
+class TestMaxLoss:
+    """Test compute_max_loss for various strategy types."""
+
+    def test_bear_call_spread(self) -> None:
+        """Credit spread: max loss = width × multiplier - net credit."""
+        legs = (
+            make_option_leg("C", Decimal("250"), -1, entry_value=Decimal("400")),
+            make_option_leg("C", Decimal("260"), 1, entry_value=Decimal("-150")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BEAR_CALL_SPREAD,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Width=10, mult=100, net_credit=250
+        # Max loss = 10*100 - 250 = 750
+        assert strat.max_loss == Decimal("750")
+
+    def test_bull_call_spread(self) -> None:
+        """Debit spread: max loss = net debit paid."""
+        legs = (
+            make_option_leg("C", Decimal("250"), 1, entry_value=Decimal("-500")),
+            make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("200")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BULL_CALL_SPREAD,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Net credit = -300 → debit = 300
+        assert strat.max_loss == Decimal("300")
+
+    def test_iron_condor(self) -> None:
+        """Iron condor: max loss = wider wing × multiplier - net credit."""
+        legs = (
+            make_option_leg("P", Decimal("240"), 1, entry_value=Decimal("-50")),
+            make_option_leg("P", Decimal("245"), -1, entry_value=Decimal("100")),
+            make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("120")),
+            make_option_leg("C", Decimal("265"), 1, entry_value=Decimal("-40")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.IRON_CONDOR,
+            underlying="SPY",
+            legs=legs,
+        )
+        # Put width=5, Call width=5, wing_width=5, mult=100, net_credit=130
+        # Max loss = 5*100 - 130 = 370
+        assert strat.max_loss == Decimal("370")
+
+    def test_naked_call_unlimited(self) -> None:
+        """Naked call: max loss is unlimited → None."""
+        legs = (make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("300")),)
+        strat = Strategy(
+            strategy_type=StrategyType.NAKED_CALL,
+            underlying="SPY",
+            legs=legs,
+        )
+        assert strat.max_loss is None
+
+    def test_short_strangle_unlimited(self) -> None:
+        """Short strangle: max loss is unlimited → None."""
+        legs = (
+            make_option_leg("P", Decimal("240"), -1, entry_value=Decimal("200")),
+            make_option_leg("C", Decimal("260"), -1, entry_value=Decimal("200")),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.SHORT_STRANGLE,
+            underlying="SPY",
+            legs=legs,
+        )
+        assert strat.max_loss is None
+
+    def test_futures_option_multiplier(self) -> None:
+        """Future option spread uses the future's notional multiplier."""
+        legs = (
+            # Sold P@1.05 for $625 credit
+            make_option_leg(
+                "P",
+                Decimal("1.05"),
+                -1,
+                entry_value=Decimal("625"),
+                multiplier=Decimal("125000"),
+                instrument_type=InstrumentType.FUTURE_OPTION,
+            ),
+            # Bought P@1.04 for $500 debit
+            make_option_leg(
+                "P",
+                Decimal("1.04"),
+                1,
+                entry_value=Decimal("-500"),
+                multiplier=Decimal("125000"),
+                instrument_type=InstrumentType.FUTURE_OPTION,
+            ),
+        )
+        strat = Strategy(
+            strategy_type=StrategyType.BULL_PUT_SPREAD,
+            underlying="/6E",
+            legs=legs,
+        )
+        # Width=0.01, mult=125000, net_credit=625+(-500)=125
+        # Max loss = 0.01*125000 - 125 = 1250 - 125 = 1125
+        assert strat.max_loss == Decimal("1125")
+        # Max profit = net credit = 125
+        assert strat.max_profit == Decimal("125")

--- a/unit_tests/analytics/test_position_reader.py
+++ b/unit_tests/analytics/test_position_reader.py
@@ -66,6 +66,8 @@ def reader(mock_redis: AsyncMock) -> PositionMetricsReader:
     r.position_metrics_df = pd.DataFrame()
     r.tracker = None
     r.instruments = {}
+    r.entry_credit_records = {}
+    r.entry_credits = {}
     return r
 
 
@@ -78,6 +80,7 @@ async def test_read_returns_dataframe(
         {b"SPY": make_quote_json("SPY", 690.0, 691.0).encode()},  # quotes
         {},  # greeks
         {},  # instruments
+        {},  # entry credits
     ]
     df = await reader.read()
     assert isinstance(df, pd.DataFrame)
@@ -98,6 +101,7 @@ async def test_read_joins_greeks_for_options(
         {b".SPY260402P666": make_quote_json(".SPY260402P666", 5.75, 5.80).encode()},
         {b".SPY260402P666": make_greeks_json(".SPY260402P666", -0.24, 0.19).encode()},
         {},  # instruments
+        {},  # entry credits
     ]
     df = await reader.read()
     assert len(df) == 1
@@ -109,7 +113,7 @@ async def test_read_joins_greeks_for_options(
 async def test_read_empty_positions_returns_empty_df(
     reader: PositionMetricsReader, mock_redis: AsyncMock
 ) -> None:
-    mock_redis.hgetall.side_effect = [{}, {}, {}, {}]
+    mock_redis.hgetall.side_effect = [{}, {}, {}, {}, {}]
     df = await reader.read()
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 0
@@ -124,6 +128,7 @@ async def test_read_includes_required_columns(
         {b"SPY": make_quote_json("SPY", 690.0, 691.0).encode()},
         {},  # greeks
         {},  # instruments
+        {},  # entry credits
     ]
     df = await reader.read()
     for col in [


### PR DESCRIPTION
## Summary

- **New `TransactionsClient` + LIFO replay algorithm** (`transactions.py`) — fetches trades from TastyTrade Transactions API and walks them newest-to-oldest to compute accurate entry prices, credits, and fees for current option positions
- **Orchestrator integration** — account-stream fetches transactions after position hydration, computes entry credits, and publishes to Redis (`tastytrade:entry_credits` HSET)
- **Enriched positions output** — `just positions` now displays `mid_price`, `entry_price`, `entry_value`, `multiplier`, `fees`, and `DTE` columns
- **Strategy P&L wiring** — entry values flow through classifier into `compute_net_entry_credit_dollars`, `compute_max_profit`, and `compute_max_loss`

## Related Jira Issue
**Jira**: [TT-63](https://mandeng.atlassian.net/browse/TT-63)

## Key Design Decisions

- **LIFO reverse replay**: Walk transactions newest-to-oldest, matching opens against closes to identify fills constituting the current position
- **Signed entry_value convention**: LIFO returns already-signed values (positive = credit from Sell to Open, negative = debit from Buy to Open) — consumers never apply additional direction signs
- **Uniform dollar path**: All option types (equity + futures) use `entry_value` from transactions API — no fallback to `average_open_price`
- **Client-side filtering**: API returns non-Trade items (Money Movement, Balance Adjustment) even with `transaction-type=Trade` filter — filtered in client

## Test Evidence

- [x] 14 unit tests for LIFO replay (fees, partial fills, batch processing, model parsing)
- [x] 13 unit tests for strategy models (net entry credit, max profit/loss for credit/debit spreads, iron condors, unlimited risk, futures multipliers)
- [x] 3 unit tests for classifier entry_value passthrough
- [x] Updated position reader tests for new Redis entry_credits call
- [x] All 685 tests pass
- [x] 0 pyright errors (in changed files), 0 ruff errors
- [x] Verified against live production data: RTY iron condor, SPX strangles, equity options

## Changes Made

- `src/tastytrade/accounts/transactions.py` (new): TransactionsClient with LIFO replay algorithm for computing entry prices from transaction history
- `src/tastytrade/accounts/orchestrator.py`: Integration to fetch transactions after position hydration and publish entry credits to Redis
- `src/tastytrade/accounts/publisher.py`: New `publish_entry_credits` method for Redis HSET publishing
- `src/tastytrade/analytics/positions.py`: Enriched position display with mid_price, entry_price, entry_value, multiplier, fees, and DTE columns
- `src/tastytrade/analytics/strategies/classifier.py`: Pass entry_value through to strategy leg construction
- `src/tastytrade/analytics/strategies/models.py`: P&L computation methods (net entry credit, max profit, max loss) using entry values
- `src/tastytrade/subscription/cli.py`: Minor CLI enhancement
- `unit_tests/accounts/test_transactions.py` (new): 14 tests for LIFO replay and transaction model parsing
- `unit_tests/analytics/strategies/test_models.py` (new): 13 tests for strategy P&L computations
- `unit_tests/analytics/strategies/test_classifier.py`: 3 tests for entry_value passthrough
- `unit_tests/analytics/test_position_reader.py`: Updated for new Redis entry_credits dependency

[TT-63]: https://mandeng.atlassian.net/browse/TT-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ