### PR TITLE
TT-82: Add Broken Wing Butterfly strategy pattern matchers

### DIFF
--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -58,6 +58,9 @@ class StrategyType(str, Enum):
     # Butterfly/Condor
     CALL_BUTTERFLY = "Call Butterfly"
     PUT_BUTTERFLY = "Put Butterfly"
+    CALL_BWB = "Call BWB"
+    PUT_BWB = "Put BWB"
+    IRON_BWB = "Iron BWB"
     CONDOR = "Condor"
 
     # Calendar/Diagonal

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -58,8 +58,7 @@ class StrategyType(str, Enum):
     # Butterfly/Condor
     CALL_BUTTERFLY = "Call Butterfly"
     PUT_BUTTERFLY = "Put Butterfly"
-    CALL_BWB = "Call BWB"
-    PUT_BWB = "Put BWB"
+    BROKEN_WING_BUTTERFLY = "Broken Wing Butterfly"
     IRON_BWB = "Iron BWB"
     CONDOR = "Condor"
 

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -58,8 +58,8 @@ class StrategyType(str, Enum):
     # Butterfly/Condor
     CALL_BUTTERFLY = "Call Butterfly"
     PUT_BUTTERFLY = "Put Butterfly"
-    BROKEN_WING_BUTTERFLY = "Broken Wing Butterfly"
-    IRON_BWB = "Iron BWB"
+    BROKEN_FLY = "Broken Fly"
+    IRON_BROKEN_FLY = "Iron Broken Fly"
     CONDOR = "Condor"
 
     # Calendar/Diagonal

--- a/src/tastytrade/analytics/strategies/patterns.py
+++ b/src/tastytrade/analytics/strategies/patterns.py
@@ -240,7 +240,7 @@ def match_iron_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
                 call_width = calls[1].strike - calls[0].strike
                 # Require UNequal wing widths (equal = regular iron butterfly)
                 if put_width != call_width:
-                    return MatchResult(StrategyType.IRON_BWB, tuple(combo_list))
+                    return MatchResult(StrategyType.IRON_BROKEN_FLY, tuple(combo_list))
 
     return None
 
@@ -273,9 +273,7 @@ def match_broken_wing_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
                 and low.abs_quantity == high.abs_quantity
                 and mid.abs_quantity == 2 * low.abs_quantity
             ):
-                return MatchResult(
-                    StrategyType.BROKEN_WING_BUTTERFLY, tuple(combo_list)
-                )
+                return MatchResult(StrategyType.BROKEN_FLY, tuple(combo_list))
 
     return None
 

--- a/src/tastytrade/analytics/strategies/patterns.py
+++ b/src/tastytrade/analytics/strategies/patterns.py
@@ -3,7 +3,7 @@
 Each matcher: match_X(legs: list[ParsedLeg]) -> MatchResult | None
 
 Priority order (greedy -- most legs first):
-1. 4+ legs: Iron Condor, Iron Butterfly, Covered Jade Lizard, Big Lizard, Butterfly
+1. 4+ legs: Iron Condor, Iron Butterfly, Iron BWB, Covered Jade Lizard, Big Lizard, Butterfly, BWB
 2. 3 legs: Jade Lizard, Collar
 3. 2 legs (with stock): Covered Call, Protective Put
 4. 2 legs (same exp, same type): Vertical spreads, Ratio Spread
@@ -88,7 +88,8 @@ def match_iron_condor(legs: list[ParsedLeg]) -> MatchResult | None:
 
 def match_iron_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
     """Iron Butterfly: 4 options, same exp, same qty.
-    Like iron condor but short put strike == short call strike.
+    Like iron condor but short put strike == short call strike,
+    and equal wing widths.
     """
     options = [leg for leg in legs if leg.is_option]
     if len(options) < 4:
@@ -117,8 +118,17 @@ def match_iron_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
             and calls[0].is_short
             and calls[1].is_long
         ):
-            if puts[1].strike is not None and calls[0].strike is not None:
-                if puts[1].strike == calls[0].strike:
+            if (
+                puts[0].strike is not None
+                and puts[1].strike is not None
+                and calls[0].strike is not None
+                and calls[1].strike is not None
+                and puts[1].strike == calls[0].strike
+            ):
+                # Require equal wing widths
+                put_width = puts[1].strike - puts[0].strike
+                call_width = calls[1].strike - calls[0].strike
+                if put_width == call_width:
                     return MatchResult(StrategyType.IRON_BUTTERFLY, tuple(combo_list))
 
     return None
@@ -184,6 +194,117 @@ def match_put_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
             and mid.abs_quantity == 2 * low.abs_quantity
         ):
             return MatchResult(StrategyType.PUT_BUTTERFLY, tuple(combo_list))
+
+    return None
+
+
+def match_iron_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Iron Broken Wing Butterfly: 4 options, same exp, same qty.
+    Short put strike == short call strike but unequal wing widths.
+    """
+    options = [leg for leg in legs if leg.is_option]
+    if len(options) < 4:
+        return None
+
+    for combo in combinations(options, 4):
+        combo_list = list(combo)
+        if not same_expiration(combo_list) or not same_abs_quantity(combo_list):
+            continue
+
+        puts = sorted(
+            [leg for leg in combo_list if leg.is_put],
+            key=lambda x: x.strike or 0,
+        )
+        calls = sorted(
+            [leg for leg in combo_list if leg.is_call],
+            key=lambda x: x.strike or 0,
+        )
+
+        if len(puts) != 2 or len(calls) != 2:
+            continue
+
+        if (
+            puts[0].is_long
+            and puts[1].is_short
+            and calls[0].is_short
+            and calls[1].is_long
+        ):
+            if (
+                puts[0].strike is not None
+                and puts[1].strike is not None
+                and calls[0].strike is not None
+                and calls[1].strike is not None
+                and puts[1].strike == calls[0].strike
+            ):
+                put_width = puts[1].strike - puts[0].strike
+                call_width = calls[1].strike - calls[0].strike
+                # Require UNequal wing widths (equal = regular iron butterfly)
+                if put_width != call_width:
+                    return MatchResult(StrategyType.IRON_BWB, tuple(combo_list))
+
+    return None
+
+
+def match_call_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Broken Wing Call Butterfly: 3 calls, same exp, 1:2:1 ratio, unequal spacing."""
+    options = [leg for leg in legs if leg.is_option and leg.is_call]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = sorted(combo, key=lambda x: x.strike or 0)
+        if not same_expiration(list(combo_list)):
+            continue
+
+        low, mid, high = combo_list
+        if low.strike is None or mid.strike is None or high.strike is None:
+            continue
+
+        # Require unequal spacing (equal = regular butterfly)
+        if mid.strike - low.strike == high.strike - mid.strike:
+            continue
+
+        # Buy 1 low, sell 2 middle, buy 1 high
+        if (
+            low.is_long
+            and mid.is_short
+            and high.is_long
+            and low.abs_quantity == high.abs_quantity
+            and mid.abs_quantity == 2 * low.abs_quantity
+        ):
+            return MatchResult(StrategyType.CALL_BWB, tuple(combo_list))
+
+    return None
+
+
+def match_put_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Broken Wing Put Butterfly: 3 puts, same exp, 1:2:1 ratio, unequal spacing."""
+    options = [leg for leg in legs if leg.is_option and leg.is_put]
+    if len(options) < 3:
+        return None
+
+    for combo in combinations(options, 3):
+        combo_list = sorted(combo, key=lambda x: x.strike or 0)
+        if not same_expiration(list(combo_list)):
+            continue
+
+        low, mid, high = combo_list
+        if low.strike is None or mid.strike is None or high.strike is None:
+            continue
+
+        # Require unequal spacing (equal = regular butterfly)
+        if mid.strike - low.strike == high.strike - mid.strike:
+            continue
+
+        # Buy 1 low, sell 2 middle, buy 1 high
+        if (
+            low.is_long
+            and mid.is_short
+            and high.is_long
+            and low.abs_quantity == high.abs_quantity
+            and mid.abs_quantity == 2 * low.abs_quantity
+        ):
+            return MatchResult(StrategyType.PUT_BWB, tuple(combo_list))
 
     return None
 
@@ -586,13 +707,16 @@ def match_single_leg(leg: ParsedLeg) -> StrategyType:
 # ===== Ordered matcher list =====
 
 MULTI_LEG_MATCHERS: list[Callable[[list[ParsedLeg]], MatchResult | None]] = [
-    # 4+ legs first
+    # 4+ legs first (regular variants before BWB)
     match_iron_condor,
     match_iron_butterfly,
+    match_iron_bwb,
     match_covered_jade_lizard,
     match_big_lizard,
     match_call_butterfly,
     match_put_butterfly,
+    match_call_bwb,
+    match_put_bwb,
     # 3 legs
     match_jade_lizard,
     match_collar,

--- a/src/tastytrade/analytics/strategies/patterns.py
+++ b/src/tastytrade/analytics/strategies/patterns.py
@@ -3,7 +3,7 @@
 Each matcher: match_X(legs: list[ParsedLeg]) -> MatchResult | None
 
 Priority order (greedy -- most legs first):
-1. 4+ legs: Iron Condor, Iron Butterfly, Iron BWB, Covered Jade Lizard, Big Lizard, Butterfly, BWB
+1. 4+ legs: Iron Condor, Iron Butterfly, Iron BWB, Covered Jade Lizard, Big Lizard, Butterfly, Broken Wing Butterfly
 2. 3 legs: Jade Lizard, Collar
 3. 2 legs (with stock): Covered Call, Protective Put
 4. 2 legs (same exp, same type): Vertical spreads, Ratio Spread
@@ -245,66 +245,37 @@ def match_iron_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
     return None
 
 
-def match_call_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
-    """Broken Wing Call Butterfly: 3 calls, same exp, 1:2:1 ratio, unequal spacing."""
-    options = [leg for leg in legs if leg.is_option and leg.is_call]
-    if len(options) < 3:
-        return None
-
-    for combo in combinations(options, 3):
-        combo_list = sorted(combo, key=lambda x: x.strike or 0)
-        if not same_expiration(list(combo_list)):
+def match_broken_wing_butterfly(legs: list[ParsedLeg]) -> MatchResult | None:
+    """Broken Wing Butterfly: 3 options of same type, same exp, 1:2:1 ratio, unequal spacing."""
+    for opt_filter in (lambda x: x.is_call, lambda x: x.is_put):
+        options = [leg for leg in legs if leg.is_option and opt_filter(leg)]
+        if len(options) < 3:
             continue
 
-        low, mid, high = combo_list
-        if low.strike is None or mid.strike is None or high.strike is None:
-            continue
+        for combo in combinations(options, 3):
+            combo_list = sorted(combo, key=lambda x: x.strike or 0)
+            if not same_expiration(list(combo_list)):
+                continue
 
-        # Require unequal spacing (equal = regular butterfly)
-        if mid.strike - low.strike == high.strike - mid.strike:
-            continue
+            low, mid, high = combo_list
+            if low.strike is None or mid.strike is None or high.strike is None:
+                continue
 
-        # Buy 1 low, sell 2 middle, buy 1 high
-        if (
-            low.is_long
-            and mid.is_short
-            and high.is_long
-            and low.abs_quantity == high.abs_quantity
-            and mid.abs_quantity == 2 * low.abs_quantity
-        ):
-            return MatchResult(StrategyType.CALL_BWB, tuple(combo_list))
+            # Require unequal spacing (equal = regular butterfly)
+            if mid.strike - low.strike == high.strike - mid.strike:
+                continue
 
-    return None
-
-
-def match_put_bwb(legs: list[ParsedLeg]) -> MatchResult | None:
-    """Broken Wing Put Butterfly: 3 puts, same exp, 1:2:1 ratio, unequal spacing."""
-    options = [leg for leg in legs if leg.is_option and leg.is_put]
-    if len(options) < 3:
-        return None
-
-    for combo in combinations(options, 3):
-        combo_list = sorted(combo, key=lambda x: x.strike or 0)
-        if not same_expiration(list(combo_list)):
-            continue
-
-        low, mid, high = combo_list
-        if low.strike is None or mid.strike is None or high.strike is None:
-            continue
-
-        # Require unequal spacing (equal = regular butterfly)
-        if mid.strike - low.strike == high.strike - mid.strike:
-            continue
-
-        # Buy 1 low, sell 2 middle, buy 1 high
-        if (
-            low.is_long
-            and mid.is_short
-            and high.is_long
-            and low.abs_quantity == high.abs_quantity
-            and mid.abs_quantity == 2 * low.abs_quantity
-        ):
-            return MatchResult(StrategyType.PUT_BWB, tuple(combo_list))
+            # Buy 1 low, sell 2 middle, buy 1 high
+            if (
+                low.is_long
+                and mid.is_short
+                and high.is_long
+                and low.abs_quantity == high.abs_quantity
+                and mid.abs_quantity == 2 * low.abs_quantity
+            ):
+                return MatchResult(
+                    StrategyType.BROKEN_WING_BUTTERFLY, tuple(combo_list)
+                )
 
     return None
 
@@ -715,8 +686,7 @@ MULTI_LEG_MATCHERS: list[Callable[[list[ParsedLeg]], MatchResult | None]] = [
     match_big_lizard,
     match_call_butterfly,
     match_put_butterfly,
-    match_call_bwb,
-    match_put_bwb,
+    match_broken_wing_butterfly,
     # 3 legs
     match_jade_lizard,
     match_collar,

--- a/unit_tests/analytics/strategies/test_patterns.py
+++ b/unit_tests/analytics/strategies/test_patterns.py
@@ -204,7 +204,7 @@ class TestIronBWB:
         ]
         result = match_iron_bwb(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.IRON_BWB
+        assert result.strategy_type == StrategyType.IRON_BROKEN_FLY
         assert len(result.matched_legs) == 4
 
     def test_match_wider_put_wing(self):
@@ -217,7 +217,7 @@ class TestIronBWB:
         ]
         result = match_iron_bwb(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.IRON_BWB
+        assert result.strategy_type == StrategyType.IRON_BROKEN_FLY
 
     def test_no_match_equal_wings(self):
         """Equal wing widths = regular iron butterfly, not BWB."""
@@ -314,7 +314,7 @@ class TestBrokenWingButterfly:
         ]
         result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
+        assert result.strategy_type == StrategyType.BROKEN_FLY
         assert len(result.matched_legs) == 3
 
     def test_match_puts_real_world(self):
@@ -326,7 +326,7 @@ class TestBrokenWingButterfly:
         ]
         result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
+        assert result.strategy_type == StrategyType.BROKEN_FLY
         assert len(result.matched_legs) == 3
 
     def test_match_wider_lower_wing(self):
@@ -338,7 +338,7 @@ class TestBrokenWingButterfly:
         ]
         result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
+        assert result.strategy_type == StrategyType.BROKEN_FLY
 
     def test_no_match_equal_spacing_calls(self):
         """Equal spacing = regular butterfly, not BWB."""

--- a/unit_tests/analytics/strategies/test_patterns.py
+++ b/unit_tests/analytics/strategies/test_patterns.py
@@ -7,8 +7,8 @@ from tastytrade.accounts.models import InstrumentType
 from tastytrade.analytics.strategies.models import ParsedLeg, StrategyType
 from tastytrade.analytics.strategies.patterns import (
     match_big_lizard,
+    match_broken_wing_butterfly,
     match_call_butterfly,
-    match_call_bwb,
     match_calendar_spread,
     match_collar,
     match_covered_call,
@@ -20,7 +20,6 @@ from tastytrade.analytics.strategies.patterns import (
     match_jade_lizard,
     match_protective_put,
     match_put_butterfly,
-    match_put_bwb,
     match_ratio_spread,
     match_single_leg,
     match_straddle,
@@ -302,66 +301,32 @@ class TestPutButterfly:
         assert result.strategy_type == StrategyType.PUT_BUTTERFLY
 
 
-# ===== Call BWB =====
+# ===== Broken Wing Butterfly =====
 
 
-class TestCallBWB:
-    def test_match(self):
-        """BWB: +1 C@100, -2 C@103, +1 C@105 (3-wide lower, 2-wide upper)."""
+class TestBrokenWingButterfly:
+    def test_match_calls(self):
+        """Call BWB: +1 C@100, -2 C@103, +1 C@105."""
         legs = [
             make_option("C", Decimal("100"), 1),
             make_option("C", Decimal("103"), -2),
             make_option("C", Decimal("105"), 1),
         ]
-        result = match_call_bwb(legs)
+        result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.CALL_BWB
+        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
         assert len(result.matched_legs) == 3
 
-    def test_no_match_equal_spacing(self):
-        """Equal spacing = regular butterfly, not BWB."""
-        legs = [
-            make_option("C", Decimal("290"), 1),
-            make_option("C", Decimal("300"), -2),
-            make_option("C", Decimal("310"), 1),
-        ]
-        result = match_call_bwb(legs)
-        assert result is None
-
-    def test_no_match_wrong_ratio(self):
-        legs = [
-            make_option("C", Decimal("100"), 1),
-            make_option("C", Decimal("103"), -1),
-            make_option("C", Decimal("105"), 1),
-        ]
-        result = match_call_bwb(legs)
-        assert result is None
-
-    def test_no_match_puts(self):
-        """Call BWB only matches calls."""
-        legs = [
-            make_option("P", Decimal("100"), 1),
-            make_option("P", Decimal("103"), -2),
-            make_option("P", Decimal("105"), 1),
-        ]
-        result = match_call_bwb(legs)
-        assert result is None
-
-
-# ===== Put BWB =====
-
-
-class TestPutBWB:
-    def test_match_real_world(self):
+    def test_match_puts_real_world(self):
         """Real-world BWB: +1 P@111, -2 P@114, +1 P@115 (/ZBM6)."""
         legs = [
             make_option("P", Decimal("111"), 1),
             make_option("P", Decimal("114"), -2),
             make_option("P", Decimal("115"), 1),
         ]
-        result = match_put_bwb(legs)
+        result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.PUT_BWB
+        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
         assert len(result.matched_legs) == 3
 
     def test_match_wider_lower_wing(self):
@@ -371,18 +336,37 @@ class TestPutBWB:
             make_option("P", Decimal("295"), -2),
             make_option("P", Decimal("300"), 1),
         ]
-        result = match_put_bwb(legs)
+        result = match_broken_wing_butterfly(legs)
         assert result is not None
-        assert result.strategy_type == StrategyType.PUT_BWB
+        assert result.strategy_type == StrategyType.BROKEN_WING_BUTTERFLY
 
-    def test_no_match_equal_spacing(self):
+    def test_no_match_equal_spacing_calls(self):
+        """Equal spacing = regular butterfly, not BWB."""
+        legs = [
+            make_option("C", Decimal("290"), 1),
+            make_option("C", Decimal("300"), -2),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_broken_wing_butterfly(legs)
+        assert result is None
+
+    def test_no_match_equal_spacing_puts(self):
         """Equal spacing = regular butterfly, not BWB."""
         legs = [
             make_option("P", Decimal("290"), 1),
             make_option("P", Decimal("300"), -2),
             make_option("P", Decimal("310"), 1),
         ]
-        result = match_put_bwb(legs)
+        result = match_broken_wing_butterfly(legs)
+        assert result is None
+
+    def test_no_match_wrong_ratio(self):
+        legs = [
+            make_option("C", Decimal("100"), 1),
+            make_option("C", Decimal("103"), -1),
+            make_option("C", Decimal("105"), 1),
+        ]
+        result = match_broken_wing_butterfly(legs)
         assert result is None
 
     def test_no_match_wrong_direction(self):
@@ -392,17 +376,7 @@ class TestPutBWB:
             make_option("P", Decimal("114"), 2),
             make_option("P", Decimal("115"), -1),
         ]
-        result = match_put_bwb(legs)
-        assert result is None
-
-    def test_no_match_calls(self):
-        """Put BWB only matches puts."""
-        legs = [
-            make_option("C", Decimal("111"), 1),
-            make_option("C", Decimal("114"), -2),
-            make_option("C", Decimal("115"), 1),
-        ]
-        result = match_put_bwb(legs)
+        result = match_broken_wing_butterfly(legs)
         assert result is None
 
 

--- a/unit_tests/analytics/strategies/test_patterns.py
+++ b/unit_tests/analytics/strategies/test_patterns.py
@@ -8,16 +8,19 @@ from tastytrade.analytics.strategies.models import ParsedLeg, StrategyType
 from tastytrade.analytics.strategies.patterns import (
     match_big_lizard,
     match_call_butterfly,
+    match_call_bwb,
     match_calendar_spread,
     match_collar,
     match_covered_call,
     match_covered_jade_lizard,
     match_diagonal_spread,
     match_iron_butterfly,
+    match_iron_bwb,
     match_iron_condor,
     match_jade_lizard,
     match_protective_put,
     match_put_butterfly,
+    match_put_bwb,
     match_ratio_spread,
     match_single_leg,
     match_straddle,
@@ -176,6 +179,79 @@ class TestIronButterfly:
         result = match_iron_butterfly(legs)
         assert result is None
 
+    def test_no_match_unequal_wings(self):
+        """Iron butterfly requires equal wing widths (unequal = iron BWB)."""
+        legs = [
+            make_option("P", Decimal("290"), 1),  # 10-wide put wing
+            make_option("P", Decimal("300"), -1),  # short put at center
+            make_option("C", Decimal("300"), -1),  # short call at center
+            make_option("C", Decimal("315"), 1),  # 15-wide call wing
+        ]
+        result = match_iron_butterfly(legs)
+        assert result is None
+
+
+# ===== Iron BWB =====
+
+
+class TestIronBWB:
+    def test_match_wider_call_wing(self):
+        """Iron BWB with wider call wing."""
+        legs = [
+            make_option("P", Decimal("295"), 1),  # long put (5-wide)
+            make_option("P", Decimal("300"), -1),  # short put at center
+            make_option("C", Decimal("300"), -1),  # short call at center
+            make_option("C", Decimal("308"), 1),  # long call (8-wide)
+        ]
+        result = match_iron_bwb(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.IRON_BWB
+        assert len(result.matched_legs) == 4
+
+    def test_match_wider_put_wing(self):
+        """Iron BWB with wider put wing."""
+        legs = [
+            make_option("P", Decimal("285"), 1),  # long put (15-wide)
+            make_option("P", Decimal("300"), -1),  # short put at center
+            make_option("C", Decimal("300"), -1),  # short call at center
+            make_option("C", Decimal("310"), 1),  # long call (10-wide)
+        ]
+        result = match_iron_bwb(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.IRON_BWB
+
+    def test_no_match_equal_wings(self):
+        """Equal wing widths = regular iron butterfly, not BWB."""
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("300"), -1),
+            make_option("C", Decimal("300"), -1),
+            make_option("C", Decimal("320"), 1),
+        ]
+        result = match_iron_bwb(legs)
+        assert result is None
+
+    def test_no_match_different_center_strikes(self):
+        """Iron BWB requires same center strike."""
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("295"), -1),
+            make_option("C", Decimal("305"), -1),
+            make_option("C", Decimal("320"), 1),
+        ]
+        result = match_iron_bwb(legs)
+        assert result is None
+
+    def test_no_match_different_quantities(self):
+        legs = [
+            make_option("P", Decimal("290"), 1),
+            make_option("P", Decimal("300"), -2),
+            make_option("C", Decimal("300"), -1),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_iron_bwb(legs)
+        assert result is None
+
 
 # ===== Call Butterfly =====
 
@@ -224,6 +300,110 @@ class TestPutButterfly:
         result = match_put_butterfly(legs)
         assert result is not None
         assert result.strategy_type == StrategyType.PUT_BUTTERFLY
+
+
+# ===== Call BWB =====
+
+
+class TestCallBWB:
+    def test_match(self):
+        """BWB: +1 C@100, -2 C@103, +1 C@105 (3-wide lower, 2-wide upper)."""
+        legs = [
+            make_option("C", Decimal("100"), 1),
+            make_option("C", Decimal("103"), -2),
+            make_option("C", Decimal("105"), 1),
+        ]
+        result = match_call_bwb(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.CALL_BWB
+        assert len(result.matched_legs) == 3
+
+    def test_no_match_equal_spacing(self):
+        """Equal spacing = regular butterfly, not BWB."""
+        legs = [
+            make_option("C", Decimal("290"), 1),
+            make_option("C", Decimal("300"), -2),
+            make_option("C", Decimal("310"), 1),
+        ]
+        result = match_call_bwb(legs)
+        assert result is None
+
+    def test_no_match_wrong_ratio(self):
+        legs = [
+            make_option("C", Decimal("100"), 1),
+            make_option("C", Decimal("103"), -1),
+            make_option("C", Decimal("105"), 1),
+        ]
+        result = match_call_bwb(legs)
+        assert result is None
+
+    def test_no_match_puts(self):
+        """Call BWB only matches calls."""
+        legs = [
+            make_option("P", Decimal("100"), 1),
+            make_option("P", Decimal("103"), -2),
+            make_option("P", Decimal("105"), 1),
+        ]
+        result = match_call_bwb(legs)
+        assert result is None
+
+
+# ===== Put BWB =====
+
+
+class TestPutBWB:
+    def test_match_real_world(self):
+        """Real-world BWB: +1 P@111, -2 P@114, +1 P@115 (/ZBM6)."""
+        legs = [
+            make_option("P", Decimal("111"), 1),
+            make_option("P", Decimal("114"), -2),
+            make_option("P", Decimal("115"), 1),
+        ]
+        result = match_put_bwb(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.PUT_BWB
+        assert len(result.matched_legs) == 3
+
+    def test_match_wider_lower_wing(self):
+        """BWB with wider lower wing."""
+        legs = [
+            make_option("P", Decimal("280"), 1),
+            make_option("P", Decimal("295"), -2),
+            make_option("P", Decimal("300"), 1),
+        ]
+        result = match_put_bwb(legs)
+        assert result is not None
+        assert result.strategy_type == StrategyType.PUT_BWB
+
+    def test_no_match_equal_spacing(self):
+        """Equal spacing = regular butterfly, not BWB."""
+        legs = [
+            make_option("P", Decimal("290"), 1),
+            make_option("P", Decimal("300"), -2),
+            make_option("P", Decimal("310"), 1),
+        ]
+        result = match_put_bwb(legs)
+        assert result is None
+
+    def test_no_match_wrong_direction(self):
+        """Wrong direction: sell low, buy middle, sell high."""
+        legs = [
+            make_option("P", Decimal("111"), -1),
+            make_option("P", Decimal("114"), 2),
+            make_option("P", Decimal("115"), -1),
+        ]
+        result = match_put_bwb(legs)
+        assert result is None
+
+    def test_no_match_calls(self):
+        """Put BWB only matches puts."""
+        legs = [
+            make_option("C", Decimal("111"), 1),
+            make_option("C", Decimal("114"), -2),
+            make_option("C", Decimal("115"), 1),
+        ]
+        result = match_put_bwb(legs)
+        assert result is None
 
 
 # ===== Jade Lizard =====


### PR DESCRIPTION
## Summary
- Add `Call BWB`, `Put BWB`, and `Iron BWB` strategy types and pattern matchers for broken wing butterflies (same structure as standard butterflies but with unequal wing spacing)
- Tighten existing `match_iron_butterfly` to require equal wing widths (previously accepted unequal wings)
- BWB matchers placed after regular butterfly matchers in priority order so standard butterflies always match first

## Related Jira Issue
**Jira**: [TT-82](https://mandeng.atlassian.net/browse/TT-82)

## Changes
- `src/tastytrade/analytics/strategies/models.py` — Add `CALL_BWB`, `PUT_BWB`, `IRON_BWB` to `StrategyType` enum
- `src/tastytrade/analytics/strategies/patterns.py` — Add `match_call_bwb`, `match_put_bwb`, `match_iron_bwb`; tighten `match_iron_butterfly` equal-width check
- `unit_tests/analytics/strategies/test_patterns.py` — 23 new tests covering all BWB variants and edge cases

## Test evidence
- 114/114 strategy tests pass (69 pattern tests including 23 new BWB tests)
- pyright: 0 errors, 0 warnings
- ruff: all checks passed
- Real-world case: +1 P@111, -2 P@114, +1 P@115 now matches as Put BWB instead of decomposing into Ratio Spread + Long Put

## Test plan
- [x] All existing butterfly tests still pass (equal spacing)
- [x] Unequal-spacing butterflies match as BWB, not ratio spread + single leg
- [x] Iron BWB matches when center strikes equal but wing widths differ
- [x] Regular iron butterfly still requires equal wing widths
- [x] Type checking and linting clean

[TT-82]: https://mandeng.atlassian.net/browse/TT-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ