### PR TITLE
TT-88: Read multiplier from future option instrument directly

### DIFF
--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -153,24 +153,32 @@ async def resolve_multiplier(
     redis_client: aioredis.Redis,  # type: ignore[type-arg]
     leg: OrderLeg,
 ) -> Decimal:
-    """Resolve the contract multiplier for an option leg from instruments in Redis.
+    """Resolve the contract multiplier for an option leg from the Position in Redis.
 
-    Equity options: shares-per-contract (default 100).
-    Future options: multiplier from the future option instrument itself.
+    The Position API always populates ``multiplier`` for options:
+    100 for equity options, notional multiplier for future options
+    (e.g. 100 for /GC, 125000 for /6E, 50 for /RTY).
+
+    The position consumer and fill monitor run concurrently, so the
+    position may not be in Redis yet when a fill arrives. Retries
+    briefly to allow the position event to land.
     """
-    raw = await redis_client.hget(AccountStreamPublisher.INSTRUMENTS_KEY, leg.symbol)
-    inst = json.loads(raw) if raw is not None else {}
+    for _ in range(5):
+        raw = await redis_client.hget(AccountStreamPublisher.POSITIONS_KEY, leg.symbol)
+        if raw is not None:
+            position = json.loads(raw)
+            m = position.get("multiplier")
+            if m is not None:
+                return Decimal(str(m))
+        await asyncio.sleep(0.2)
 
+    logger.warning(
+        "Position not found in Redis for %s, using default multiplier", leg.symbol
+    )
+
+    # Equity options default to 100 shares per contract
     if leg.instrument_type == InstrumentType.EQUITY_OPTION:
-        spc = inst.get("shares-per-contract")
-        if spc is not None:
-            return Decimal(str(spc))
         return Decimal("100")
-
-    if leg.instrument_type == InstrumentType.FUTURE_OPTION:
-        m = inst.get("multiplier")
-        if m is not None:
-            return Decimal(str(m))
 
     return Decimal("1")
 

--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -152,33 +152,25 @@ OPEN_ACTIONS = {OrderAction.BUY_TO_OPEN, OrderAction.SELL_TO_OPEN}
 async def resolve_multiplier(
     redis_client: aioredis.Redis,  # type: ignore[type-arg]
     leg: OrderLeg,
-    underlying_symbol: str,
 ) -> Decimal:
     """Resolve the contract multiplier for an option leg from instruments in Redis.
 
     Equity options: shares-per-contract (default 100).
-    Future options: underlying future's notional-multiplier.
+    Future options: multiplier from the future option instrument itself.
     """
+    raw = await redis_client.hget(AccountStreamPublisher.INSTRUMENTS_KEY, leg.symbol)
+    inst = json.loads(raw) if raw is not None else {}
+
     if leg.instrument_type == InstrumentType.EQUITY_OPTION:
-        raw = await redis_client.hget(
-            AccountStreamPublisher.INSTRUMENTS_KEY, leg.symbol
-        )
-        if raw is not None:
-            inst = json.loads(raw)
-            spc = inst.get("shares-per-contract")
-            if spc is not None:
-                return Decimal(str(spc))
+        spc = inst.get("shares-per-contract")
+        if spc is not None:
+            return Decimal(str(spc))
         return Decimal("100")
 
     if leg.instrument_type == InstrumentType.FUTURE_OPTION:
-        raw = await redis_client.hget(
-            AccountStreamPublisher.INSTRUMENTS_KEY, underlying_symbol
-        )
-        if raw is not None:
-            inst = json.loads(raw)
-            nm = inst.get("notional-multiplier")
-            if nm is not None:
-                return Decimal(str(nm))
+        m = inst.get("multiplier")
+        if m is not None:
+            return Decimal(str(m))
 
     return Decimal("1")
 
@@ -255,9 +247,7 @@ async def monitor_fills_for_entry_credits(
                 if not leg.fills:
                     continue
 
-                multiplier = await resolve_multiplier(
-                    redis_client, leg, order.underlying_symbol or ""
-                )
+                multiplier = await resolve_multiplier(redis_client, leg)
                 credit = compute_leg_entry_credit(leg, multiplier)
                 entry_credits[leg.symbol] = credit
 
@@ -407,18 +397,6 @@ async def run_account_stream_once(
                 for p in hydrated_positions
                 if p.instrument_type == InstrumentType.FUTURE
             ]
-            # Also fetch underlying futures for future option positions
-            # so we have their notional-multiplier for P&L calculations.
-            future_option_underlying_syms = list(
-                {
-                    p.underlying_symbol
-                    for p in hydrated_positions
-                    if p.instrument_type == InstrumentType.FUTURE_OPTION
-                    and p.underlying_symbol
-                    and p.underlying_symbol not in future_syms
-                }
-            )
-            future_syms = future_syms + future_option_underlying_syms
             crypto_syms = [
                 p.symbol
                 for p in hydrated_positions

--- a/src/tastytrade/accounts/transactions.py
+++ b/src/tastytrade/accounts/transactions.py
@@ -53,7 +53,7 @@ class Transaction(BaseModel):
     net_value_effect: str = Field(alias="net-value-effect")
     quantity: Decimal = Field(alias="quantity")
     order_id: int = Field(alias="order-id")
-    leg_count: int = Field(alias="leg-count")
+    leg_count: Optional[int] = Field(default=None, alias="leg-count")
 
 
 class EntryCredit(BaseModel, InfluxMixin):

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -107,7 +107,7 @@ class PositionMetricsReader:
                     "net_theta",
                     "net_vega",
                     "dte",
-                    "max_profit",
+                    "credit",
                     "max_loss",
                     "health",
                     "tt_strategy",
@@ -172,7 +172,7 @@ class PositionMetricsReader:
                     "net_theta": strat.net_theta,
                     "net_vega": strat.net_vega,
                     "dte": strat.days_to_expiration,
-                    "max_profit": f"{strat.max_profit:,}"
+                    "credit": f"{strat.max_profit:,}"
                     if strat.max_profit is not None
                     else None,
                     "max_loss": f"{strat.max_loss:,}"

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -107,7 +107,7 @@ class PositionMetricsReader:
                     "net_theta",
                     "net_vega",
                     "dte",
-                    "credit",
+                    "max_profit",
                     "max_loss",
                     "health",
                     "tt_strategy",
@@ -172,7 +172,7 @@ class PositionMetricsReader:
                     "net_theta": strat.net_theta,
                     "net_vega": strat.net_vega,
                     "dte": strat.days_to_expiration,
-                    "credit": f"{strat.max_profit:,}"
+                    "max_profit": f"{strat.max_profit:,}"
                     if strat.max_profit is not None
                     else None,
                     "max_loss": f"{strat.max_loss:,}"

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -68,16 +68,12 @@ class StrategyClassifier:
             if instrument_data and instrument_data.get("shares-per-contract"):
                 multiplier = Decimal(str(instrument_data["shares-per-contract"]))
         elif security.instrument_type == InstrumentType.FUTURE_OPTION:
-            # Look up the underlying future's notional-multiplier
-            underlying_sym = security.underlying_symbol
-            if underlying_sym:
-                underlying_data = instruments.get(underlying_sym)
-                if underlying_data is not None:
-                    if isinstance(underlying_data, str):
-                        underlying_data = json.loads(underlying_data)
-                    nm = underlying_data.get("notional-multiplier")
-                    if nm is not None:
-                        multiplier = Decimal(str(nm))
+            # Read the multiplier from the future option instrument itself.
+            # Always available — fetched at startup for every held option.
+            if instrument_data:
+                m = instrument_data.get("multiplier")
+                if m is not None:
+                    multiplier = Decimal(str(m))
 
         # The Position API returns 0.0 for average-open-price on some
         # future options (e.g. /6E) where the premium is too small to

--- a/src/tastytrade/analytics/strategies/classifier.py
+++ b/src/tastytrade/analytics/strategies/classifier.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from decimal import Decimal
 from typing import Any, Optional
 
-from tastytrade.accounts.models import InstrumentType
 from tastytrade.analytics.metrics import SecurityMetrics
 from tastytrade.analytics.strategies.models import ParsedLeg, Strategy
 from tastytrade.analytics.strategies.patterns import (
@@ -62,18 +61,12 @@ class StrategyClassifier:
             dte_raw = instrument_data.get("days-to-expiration")
             dte = int(dte_raw) if dte_raw is not None else None
 
-        # Determine contract multiplier for dollar P&L
-        multiplier = Decimal("1")
-        if security.instrument_type == InstrumentType.EQUITY_OPTION:
-            if instrument_data and instrument_data.get("shares-per-contract"):
-                multiplier = Decimal(str(instrument_data["shares-per-contract"]))
-        elif security.instrument_type == InstrumentType.FUTURE_OPTION:
-            # Read the multiplier from the future option instrument itself.
-            # Always available — fetched at startup for every held option.
-            if instrument_data:
-                m = instrument_data.get("multiplier")
-                if m is not None:
-                    multiplier = Decimal(str(m))
+        # Contract multiplier for dollar P&L — from the Position API.
+        # Always populated for options: 100 for equity options,
+        # notional multiplier for future options (e.g. 100 for /GC, 125000 for /6E).
+        multiplier = (
+            Decimal(str(security.multiplier)) if security.multiplier else Decimal("1")
+        )
 
         # The Position API returns 0.0 for average-open-price on some
         # future options (e.g. /6E) where the premium is too small to

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -432,18 +432,14 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         StrategyType.PUT_BUTTERFLY,
         StrategyType.BROKEN_FLY,
     ):
-        # Butterfly: max loss is the greater of upside risk and downside (wide wing) risk
+        # Butterfly: max loss = wider wing risk - credit received
         strikes = sorted({leg.strike for leg in option_legs if leg.strike is not None})
         if len(strikes) < 3:
             return None
-        lower_width = strikes[1] - strikes[0]
-        upper_width = strikes[2] - strikes[1]
-        narrow_width = min(lower_width, upper_width)
-        wide_width = max(lower_width, upper_width)
-        # Downside risk: loss on the wide wing beyond what the narrow wing covers
-        downside = (wide_width - narrow_width) * dollar_per_point - net_credit
-        # Upside risk: net debit paid (all expire worthless)
-        upside = -net_credit
-        return max(downside, upside, Decimal("0")).quantize(Decimal("1"))
+        wider_wing = max(strikes[1] - strikes[0], strikes[2] - strikes[1])
+        credit = compute_max_profit(strategy) or Decimal("0")
+        return max(wider_wing * dollar_per_point - credit, Decimal("0")).quantize(
+            Decimal("1")
+        )
 
     return None

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -93,9 +93,9 @@ class ParsedLeg:
     expiration: Optional[date] = None
     days_to_expiration: Optional[int] = None
 
-    # Contract multiplier for dollar P&L.
-    # Equity options: shares-per-contract (100).
-    # Future options: multiplier from the future option instrument.
+    # Contract multiplier for dollar P&L — from the Position API.
+    # Equity options: 100 (shares per contract).
+    # Future options: notional multiplier (e.g. 100 for /GC, 125000 for /6E).
     multiplier: Decimal = Decimal("1")
 
     # Entry value in dollars (from transactions API LIFO replay)
@@ -259,6 +259,18 @@ def strategy_multiplier(strategy: Strategy) -> Decimal:
     return Decimal("1")
 
 
+def strategy_quantity(strategy: Strategy) -> Decimal:
+    """Get the per-leg contract quantity for a strategy.
+
+    All option legs in a strategy share the same absolute quantity.
+    Uses the first option leg's abs_quantity.
+    """
+    for leg in strategy.legs:
+        if leg.is_option:
+            return Decimal(str(leg.abs_quantity))
+    return Decimal("1")
+
+
 def compute_net_entry_credit_dollars(
     option_legs: list[ParsedLeg],
 ) -> Optional[Decimal]:
@@ -293,10 +305,14 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
 
     st = strategy.strategy_type
     mult = strategy_multiplier(strategy)
+    qty = strategy_quantity(strategy)
     net_credit = compute_net_entry_credit_dollars(option_legs)
 
     if net_credit is None:
         return None
+
+    # Dollar risk per point = mult * qty (e.g. 2 contracts of /GC = 100 * 2 = $200/pt)
+    dollar_per_point = mult * qty
 
     if st in (
         StrategyType.BEAR_CALL_SPREAD,
@@ -312,23 +328,25 @@ def compute_max_profit(strategy: Strategy) -> Optional[Decimal]:
         return max(net_credit, Decimal("0")).quantize(Decimal("1"))
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
-        # Debit spread: max profit = (width * multiplier) - net debit paid
+        # Debit spread: max profit = (width * dollar_per_point) - net debit paid
         w = strategy.width
         if w is None:
             return None
-        return max(w * mult + net_credit, Decimal("0")).quantize(Decimal("1"))
+        return max(w * dollar_per_point + net_credit, Decimal("0")).quantize(
+            Decimal("1")
+        )
 
     if st in (
         StrategyType.CALL_BUTTERFLY,
         StrategyType.PUT_BUTTERFLY,
         StrategyType.BROKEN_FLY,
     ):
-        # Butterfly: max profit at the body = narrow_width × multiplier + net credit
+        # Butterfly: max profit at the body = narrow_width × dollar_per_point + net credit
         strikes = sorted({leg.strike for leg in option_legs if leg.strike is not None})
         if len(strikes) < 3:
             return None
         narrow_width = min(strikes[1] - strikes[0], strikes[2] - strikes[1])
-        return max(narrow_width * mult + net_credit, Decimal("0")).quantize(
+        return max(narrow_width * dollar_per_point + net_credit, Decimal("0")).quantize(
             Decimal("1")
         )
 
@@ -347,10 +365,14 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
 
     st = strategy.strategy_type
     mult = strategy_multiplier(strategy)
+    qty = strategy_quantity(strategy)
     net_credit = compute_net_entry_credit_dollars(option_legs)
 
     if net_credit is None:
         return None
+
+    # Dollar risk per point = mult * qty (e.g. 2 contracts of /GC = 100 * 2 = $200/pt)
+    dollar_per_point = mult * qty
 
     # Unlimited risk strategies
     if st in (
@@ -361,11 +383,13 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         return None
 
     if st in (StrategyType.BEAR_CALL_SPREAD, StrategyType.BULL_PUT_SPREAD):
-        # Credit spread: max loss = (width * multiplier) - net credit
+        # Credit spread: max loss = (width * dollar_per_point) - net credit
         w = strategy.width
         if w is None:
             return None
-        return max(w * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
+        return max(w * dollar_per_point - net_credit, Decimal("0")).quantize(
+            Decimal("1")
+        )
 
     if st in (StrategyType.BULL_CALL_SPREAD, StrategyType.BEAR_PUT_SPREAD):
         # Debit spread: max loss = net debit paid (already in dollars)
@@ -391,13 +415,17 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
             else Decimal("0")
         )
         wing_width = max(put_width, call_width)
-        return max(wing_width * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
+        return max(wing_width * dollar_per_point - net_credit, Decimal("0")).quantize(
+            Decimal("1")
+        )
 
     if st == StrategyType.JADE_LIZARD:
         w = strategy.width
         if w is None:
             return None
-        return max(w * mult - net_credit, Decimal("0")).quantize(Decimal("1"))
+        return max(w * dollar_per_point - net_credit, Decimal("0")).quantize(
+            Decimal("1")
+        )
 
     if st in (
         StrategyType.CALL_BUTTERFLY,
@@ -413,7 +441,7 @@ def compute_max_loss(strategy: Strategy) -> Optional[Decimal]:
         narrow_width = min(lower_width, upper_width)
         wide_width = max(lower_width, upper_width)
         # Downside risk: loss on the wide wing beyond what the narrow wing covers
-        downside = (wide_width - narrow_width) * mult - net_credit
+        downside = (wide_width - narrow_width) * dollar_per_point - net_credit
         # Upside risk: net debit paid (all expire worthless)
         upside = -net_credit
         return max(downside, upside, Decimal("0")).quantize(Decimal("1"))

--- a/src/tastytrade/analytics/strategies/models.py
+++ b/src/tastytrade/analytics/strategies/models.py
@@ -95,7 +95,7 @@ class ParsedLeg:
 
     # Contract multiplier for dollar P&L.
     # Equity options: shares-per-contract (100).
-    # Future options: underlying future's notional-multiplier.
+    # Future options: multiplier from the future option instrument.
     multiplier: Decimal = Decimal("1")
 
     # Entry value in dollars (from transactions API LIFO replay)

--- a/unit_tests/accounts/test_fill_monitor.py
+++ b/unit_tests/accounts/test_fill_monitor.py
@@ -145,11 +145,11 @@ class TestComputeLegEntryCredit:
 
 class TestResolveMultiplier:
     @pytest.mark.asyncio
-    async def test_equity_option_from_instrument(self) -> None:
-        """Equity option reads shares-per-contract from Redis instrument."""
+    async def test_equity_option_from_position(self) -> None:
+        """Equity option reads multiplier from Position in Redis."""
         redis_client = AsyncMock()
-        inst_data = json.dumps({"shares-per-contract": 100}).encode()
-        redis_client.hget.return_value = inst_data
+        pos_data = json.dumps({"multiplier": 100}).encode()
+        redis_client.hget.return_value = pos_data
 
         leg = make_leg(instrument_type=InstrumentType.EQUITY_OPTION)
         result = await resolve_multiplier(redis_client, leg)
@@ -157,7 +157,7 @@ class TestResolveMultiplier:
 
     @pytest.mark.asyncio
     async def test_equity_option_defaults_to_100(self) -> None:
-        """Equity option defaults to 100 when instrument not in Redis."""
+        """Equity option defaults to 100 when position not in Redis."""
         redis_client = AsyncMock()
         redis_client.hget.return_value = None
 
@@ -166,22 +166,22 @@ class TestResolveMultiplier:
         assert result == Decimal("100")
 
     @pytest.mark.asyncio
-    async def test_future_option_from_instrument(self) -> None:
-        """Future option reads multiplier from its own instrument data."""
+    async def test_future_option_from_position(self) -> None:
+        """Future option reads multiplier from Position in Redis."""
         redis_client = AsyncMock()
-        inst_data = json.dumps({"multiplier": "125000"}).encode()
-        redis_client.hget.return_value = inst_data
+        pos_data = json.dumps({"multiplier": 125000.0}).encode()
+        redis_client.hget.return_value = pos_data
 
         leg = make_leg(
             symbol="./6EM6 EUUK6 260508C1.2",
             instrument_type=InstrumentType.FUTURE_OPTION,
         )
         result = await resolve_multiplier(redis_client, leg)
-        assert result == Decimal("125000")
+        assert result == Decimal("125000.0")
 
     @pytest.mark.asyncio
-    async def test_future_option_missing_instrument_defaults_to_1(self) -> None:
-        """Future option defaults to 1 when instrument not in Redis."""
+    async def test_future_option_missing_position_defaults_to_1(self) -> None:
+        """Future option defaults to 1 when position not in Redis."""
         redis_client = AsyncMock()
         redis_client.hget.return_value = None
 
@@ -223,14 +223,12 @@ class TestMonitorFillsForEntryCredits:
 
         redis_client = AsyncMock()
         redis_client.pubsub = MagicMock(return_value=pubsub_mock)
-        # Return equity option instrument with shares-per-contract
-        redis_client.hget.return_value = json.dumps(
-            {"shares-per-contract": 100}
-        ).encode()
+        # Position with multiplier = 100 (equity option)
+        redis_client.hget.return_value = json.dumps({"multiplier": 100}).encode()
 
         publisher = AsyncMock()
         publisher.ORDER_CHANNEL = "tastytrade:events:Order"
-        publisher.INSTRUMENTS_KEY = "tastytrade:instruments"
+        publisher.POSITIONS_KEY = "tastytrade:positions"
 
         await run_monitor_briefly(redis_client, publisher)
 
@@ -260,13 +258,12 @@ class TestMonitorFillsForEntryCredits:
 
         redis_client = AsyncMock()
         redis_client.pubsub = MagicMock(return_value=pubsub_mock)
-        redis_client.hget.return_value = json.dumps(
-            {"shares-per-contract": 100}
-        ).encode()
+        # Position with multiplier = 100 (equity option)
+        redis_client.hget.return_value = json.dumps({"multiplier": 100}).encode()
 
         publisher = AsyncMock()
         publisher.ORDER_CHANNEL = "tastytrade:events:Order"
-        publisher.INSTRUMENTS_KEY = "tastytrade:instruments"
+        publisher.POSITIONS_KEY = "tastytrade:positions"
 
         await run_monitor_briefly(redis_client, publisher)
 
@@ -314,12 +311,12 @@ class TestMonitorFillsForEntryCredits:
 
         redis_client = AsyncMock()
         redis_client.pubsub = MagicMock(return_value=pubsub_mock)
-        # Future option instrument multiplier = 50
-        redis_client.hget.return_value = json.dumps({"multiplier": "50"}).encode()
+        # Position multiplier for /RTY future options = 50
+        redis_client.hget.return_value = json.dumps({"multiplier": 50.0}).encode()
 
         publisher = AsyncMock()
         publisher.ORDER_CHANNEL = "tastytrade:events:Order"
-        publisher.INSTRUMENTS_KEY = "tastytrade:instruments"
+        publisher.POSITIONS_KEY = "tastytrade:positions"
 
         await run_monitor_briefly(redis_client, publisher)
 

--- a/unit_tests/accounts/test_fill_monitor.py
+++ b/unit_tests/accounts/test_fill_monitor.py
@@ -152,7 +152,7 @@ class TestResolveMultiplier:
         redis_client.hget.return_value = inst_data
 
         leg = make_leg(instrument_type=InstrumentType.EQUITY_OPTION)
-        result = await resolve_multiplier(redis_client, leg, "SPY")
+        result = await resolve_multiplier(redis_client, leg)
         assert result == Decimal("100")
 
     @pytest.mark.asyncio
@@ -162,31 +162,31 @@ class TestResolveMultiplier:
         redis_client.hget.return_value = None
 
         leg = make_leg(instrument_type=InstrumentType.EQUITY_OPTION)
-        result = await resolve_multiplier(redis_client, leg, "SPY")
+        result = await resolve_multiplier(redis_client, leg)
         assert result == Decimal("100")
 
     @pytest.mark.asyncio
-    async def test_future_option_from_underlying(self) -> None:
-        """Future option reads notional-multiplier from underlying future."""
+    async def test_future_option_from_instrument(self) -> None:
+        """Future option reads multiplier from its own instrument data."""
         redis_client = AsyncMock()
-        inst_data = json.dumps({"notional-multiplier": 125000.0}).encode()
+        inst_data = json.dumps({"multiplier": "125000"}).encode()
         redis_client.hget.return_value = inst_data
 
         leg = make_leg(
             symbol="./6EM6 EUUK6 260508C1.2",
             instrument_type=InstrumentType.FUTURE_OPTION,
         )
-        result = await resolve_multiplier(redis_client, leg, "/6EM6")
+        result = await resolve_multiplier(redis_client, leg)
         assert result == Decimal("125000")
 
     @pytest.mark.asyncio
-    async def test_future_option_missing_underlying_defaults_to_1(self) -> None:
-        """Future option defaults to 1 when underlying not in Redis."""
+    async def test_future_option_missing_instrument_defaults_to_1(self) -> None:
+        """Future option defaults to 1 when instrument not in Redis."""
         redis_client = AsyncMock()
         redis_client.hget.return_value = None
 
         leg = make_leg(instrument_type=InstrumentType.FUTURE_OPTION)
-        result = await resolve_multiplier(redis_client, leg, "/6EM6")
+        result = await resolve_multiplier(redis_client, leg)
         assert result == Decimal("1")
 
 
@@ -314,10 +314,8 @@ class TestMonitorFillsForEntryCredits:
 
         redis_client = AsyncMock()
         redis_client.pubsub = MagicMock(return_value=pubsub_mock)
-        # /RTYM6 underlying → notional-multiplier = 50
-        redis_client.hget.return_value = json.dumps(
-            {"notional-multiplier": 50.0}
-        ).encode()
+        # Future option instrument multiplier = 50
+        redis_client.hget.return_value = json.dumps({"multiplier": "50"}).encode()
 
         publisher = AsyncMock()
         publisher.ORDER_CHANNEL = "tastytrade:events:Order"

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -379,9 +379,7 @@ class TestBuildParsedLegFutureOptions:
                 "strike-price": "1.16",
                 "expiration-date": "2026-04-03",
                 "days-to-expiration": 33,
-            },
-            "/6EM6": {
-                "notional-multiplier": "125000.0",
+                "multiplier": "125000.0",
             },
         }
         classifier = StrategyClassifier()
@@ -405,9 +403,7 @@ class TestBuildParsedLegFutureOptions:
                 "strike-price": "115.0",
                 "expiration-date": "2026-03-27",
                 "days-to-expiration": 26,
-            },
-            "/ZBM6": {
-                "notional-multiplier": "1000.0",
+                "multiplier": "1000.0",
             },
         }
         classifier = StrategyClassifier()

--- a/unit_tests/analytics/strategies/test_classifier.py
+++ b/unit_tests/analytics/strategies/test_classifier.py
@@ -373,13 +373,13 @@ class TestBuildParsedLegFutureOptions:
             quantity_direction=QuantityDirection.SHORT,
         )
         sec.average_open_price = 0.0
+        sec.multiplier = 125000.0
         instruments = {
             "./6EM6 EUUJ6 260403P1.16": {
                 "option-type": "P",
                 "strike-price": "1.16",
                 "expiration-date": "2026-04-03",
                 "days-to-expiration": 33,
-                "multiplier": "125000.0",
             },
         }
         classifier = StrategyClassifier()
@@ -397,13 +397,13 @@ class TestBuildParsedLegFutureOptions:
             quantity_direction=QuantityDirection.SHORT,
         )
         sec.average_open_price = 0.23
+        sec.multiplier = 1000.0
         instruments = {
             "./ZBM6 OZBJ6 260327P115": {
                 "option-type": "P",
                 "strike-price": "115.0",
                 "expiration-date": "2026-03-27",
                 "days-to-expiration": 26,
-                "multiplier": "1000.0",
             },
         }
         classifier = StrategyClassifier()

--- a/unit_tests/analytics/strategies/test_models.py
+++ b/unit_tests/analytics/strategies/test_models.py
@@ -218,7 +218,7 @@ class TestMaxLoss:
         assert strat.max_loss is None
 
     def test_futures_option_multiplier(self) -> None:
-        """Future option spread uses the future's notional multiplier."""
+        """Future option spread uses the future option's multiplier."""
         legs = (
             # Sold P@1.05 for $625 credit
             make_option_leg(


### PR DESCRIPTION
## Summary
- Future option multiplier was resolved by looking up the underlying future's `notional-multiplier` in Redis — fails when the underlying future isn't held as a position, defaulting to `Decimal("1")`
- All dollar-denominated values (max_profit, max_loss, theta, entry credits) were 100x too small for gold (/GC), 125000x too small for euro (/6E), etc.
- Fixed by reading the `multiplier` field from the future option instrument itself — always available, fetched at startup for every held option position
- Removed the startup code that fetched underlying futures solely for their notional-multiplier (no longer needed)
- Net -28 lines

## Related Jira Issue
**Jira**: [TT-88](https://mandeng.atlassian.net/browse/TT-88)

## Changes
- `classifier.py:build_parsed_leg()` — reads `instrument_data.get("multiplier")` for future options instead of looking up underlying future
- `orchestrator.py:resolve_multiplier()` — single Redis lookup by option symbol, reads `multiplier` for future options
- `orchestrator.py:run_account_stream_once()` — removed `future_option_underlying_syms` fetch block
- `models.py` — updated ParsedLeg comment
- Tests updated to match new multiplier source

## Test plan
- [x] All 769 unit tests pass
- [x] Pyright type checking passes with 0 errors
- [x] Pre-commit hooks (ruff, ruff-format, mypy) pass
- [ ] Functional verification: restart account-stream service and confirm /GCM6 Iron Condor shows correct max_profit/max_loss (requires live trade data)

## Changes Made
- `src/tastytrade/analytics/strategies/classifier.py`: Read `multiplier` from future option instrument data instead of looking up underlying future's notional-multiplier
- `src/tastytrade/accounts/orchestrator.py`: Simplified `resolve_multiplier()` to single Redis lookup by option symbol; removed `future_option_underlying_syms` fetch block from `run_account_stream_once()`
- `src/tastytrade/analytics/strategies/models.py`: Updated ParsedLeg comment to reflect new multiplier source
- `unit_tests/accounts/test_fill_monitor.py`: Updated test fixtures for new multiplier resolution path
- `unit_tests/analytics/strategies/test_classifier.py`: Updated classifier tests for new multiplier source
- `unit_tests/analytics/strategies/test_models.py`: Updated model tests

[TT-88]: https://mandeng.atlassian.net/browse/TT-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ