### PR TITLE
TT-91: Add campaign P&L view to chains CLI with roll history

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,12 +57,16 @@ strategies-json:
     uv run tasty-subscription strategies --json
 
 # Trade chain lifecycle summary (rolls, P&L, fees)
-chains:
-    uv run tasty-subscription chains
+chains *args:
+    uv run tasty-subscription chains {{args}}
 
-# Trade chain lifecycle summary in JSON format
-chains-json:
-    uv run tasty-subscription chains --json
+# Campaign P&L by underlying (realized + unrealized + recovery needed)
+campaign *args:
+    uv run tasty-subscription chains --campaign {{args}}
+
+# Detailed roll history per chain with node-level fills
+campaign-detail *args:
+    uv run tasty-subscription chains --detail {{args}}
 
 # Backfill historical account events into InfluxDB (idempotent)
 backfill:

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -29,6 +29,20 @@ from tastytrade.messaging.models.events import GreeksEvent, QuoteEvent
 logger = logging.getLogger(__name__)
 
 
+def apply_effect(amount: Optional[str], effect: Optional[str]) -> Decimal:
+    """Convert TastyTrade unsigned amount + effect string to signed Decimal.
+
+    TastyTrade encodes sign via a separate effect field:
+    'Credit' = positive (money received), 'Debit' = negative (money paid).
+    """
+    if amount is None:
+        return Decimal("0")
+    val = Decimal(amount)
+    if effect == "Debit":
+        return -val
+    return val
+
+
 class PositionMetricsReader:
     """Reads position metrics from Redis. Pure consumer -- no connections."""
 
@@ -253,6 +267,245 @@ class PositionMetricsReader:
         if not df.empty:
             df["rolls"] = df["rolls"].astype("Int64")
         return df
+
+    # -- Campaign P&L aggregation (TT-91) --
+    # Groups chains by underlying, sums realized P&L from rolls,
+    # cross-references open legs with live position mark data.
+
+    @property
+    def campaign_summary(self) -> pd.DataFrame:
+        """Campaign P&L by underlying — aggregates chains and open mark values."""
+        columns = [
+            "underlying",
+            "chains",
+            "open_chains",
+            "total_rolls",
+            "realized_pnl",
+            "total_fees",
+            "unrealized_mark",
+            "net_pnl",
+            "recovery_needed",
+        ]
+        if not self.trade_chains:
+            return pd.DataFrame(columns=columns)
+
+        # Build symbol → position lookup for mark value computation
+        pos_by_symbol: dict[str, dict[str, Any]] = {}
+        if not self.position_metrics_df.empty:
+            for _, row in self.position_metrics_df.iterrows():
+                pos_by_symbol[str(row["symbol"]).strip()] = {
+                    "mid_price": row.get("mid_price"),
+                    "quantity": row.get("quantity"),
+                    "multiplier": row.get("multiplier"),
+                    "quantity_direction": row.get("quantity_direction"),
+                }
+
+        # Group chains by underlying
+        by_underlying: dict[str, list[TradeChain]] = {}
+        for chain in self.trade_chains.values():
+            by_underlying.setdefault(chain.underlying_symbol, []).append(chain)
+
+        rows = []
+        for underlying, chains in sorted(by_underlying.items()):
+            total_realized = Decimal("0")
+            total_fees = Decimal("0")
+            total_rolls = 0
+            open_chains = 0
+            total_unrealized = Decimal("0")
+
+            for chain in chains:
+                cd = chain.computed_data
+                total_realized += apply_effect(
+                    cd.realized_gain, cd.realized_gain_effect
+                )
+                total_fees += Decimal(cd.total_fees) if cd.total_fees else Decimal("0")
+                total_rolls += cd.roll_count
+
+                if cd.open:
+                    open_chains += 1
+                    for entry in cd.open_entries:
+                        sym = entry.symbol.strip()
+                        pos = pos_by_symbol.get(sym)
+                        if pos is None or pos["mid_price"] is None:
+                            continue
+                        mid = Decimal(str(pos["mid_price"]))
+                        qty = Decimal(str(pos["quantity"]))
+                        mult = Decimal(str(pos["multiplier"] or 1))
+                        sign = (
+                            Decimal("-1")
+                            if str(pos["quantity_direction"]) == "Short"
+                            or str(pos["quantity_direction"])
+                            == "QuantityDirection.SHORT"
+                            else Decimal("1")
+                        )
+                        total_unrealized += mid * qty * mult * sign
+
+            net_pnl = total_realized + total_unrealized
+            recovery = max(Decimal("0"), -net_pnl)
+
+            rows.append(
+                {
+                    "underlying": underlying,
+                    "chains": len(chains),
+                    "open_chains": open_chains,
+                    "total_rolls": total_rolls,
+                    "realized_pnl": float(total_realized),
+                    "total_fees": float(total_fees),
+                    "unrealized_mark": float(total_unrealized),
+                    "net_pnl": float(net_pnl),
+                    "recovery_needed": float(recovery),
+                }
+            )
+
+        df = pd.DataFrame(rows)
+        if not df.empty:
+            for col in ("chains", "open_chains", "total_rolls"):
+                df[col] = df[col].astype("Int64")
+            for col in (
+                "realized_pnl",
+                "total_fees",
+                "unrealized_mark",
+                "net_pnl",
+                "recovery_needed",
+            ):
+                df[col] = df[col].round(2)
+        return df
+
+    def campaign_detail(self, underlying: Optional[str] = None) -> list[dict[str, Any]]:
+        """Detailed roll history per chain, optionally filtered by underlying."""
+        # Build symbol → position lookup for open leg mark values
+        pos_by_symbol: dict[str, dict[str, Any]] = {}
+        if not self.position_metrics_df.empty:
+            for _, row in self.position_metrics_df.iterrows():
+                pos_by_symbol[str(row["symbol"]).strip()] = {
+                    "mid_price": row.get("mid_price"),
+                    "quantity": row.get("quantity"),
+                    "multiplier": row.get("multiplier"),
+                    "quantity_direction": row.get("quantity_direction"),
+                }
+
+        results: list[dict[str, Any]] = []
+        for chain in self.trade_chains.values():
+            if underlying and chain.underlying_symbol != underlying:
+                continue
+
+            cd = chain.computed_data
+            realized = apply_effect(cd.realized_gain, cd.realized_gain_effect)
+            fees = Decimal(cd.total_fees) if cd.total_fees else Decimal("0")
+
+            # Expand lite_nodes into readable history
+            nodes = []
+            for node in chain.lite_nodes:
+                fill_cost = apply_effect(
+                    node.total_fill_cost, node.total_fill_cost_effect
+                )
+                node_fees = (
+                    Decimal(node.total_fees) if node.total_fees else Decimal("0")
+                )
+
+                legs = []
+                for leg in node.legs:
+                    legs.append(
+                        {
+                            "symbol": leg.symbol,
+                            "action": leg.action,
+                            "fill_quantity": leg.fill_quantity,
+                        }
+                    )
+
+                entries = []
+                for entry in node.entries:
+                    direction = "Short" if entry.quantity_type == "Short" else "Long"
+                    entries.append(
+                        {
+                            "symbol": entry.symbol.strip(),
+                            "quantity": entry.quantity,
+                            "direction": direction,
+                        }
+                    )
+
+                snapshot: dict[str, Any] | None = None
+                if node.market_state_snapshot:
+                    ms = node.market_state_snapshot
+                    snapshot = {
+                        "total_delta": ms.total_delta,
+                        "total_theta": ms.total_theta,
+                        "instruments": [
+                            {
+                                "symbol": md.symbol,
+                                "bid": md.bid,
+                                "ask": md.ask,
+                                "delta": md.delta,
+                                "theta": md.theta,
+                            }
+                            for md in ms.market_datas
+                        ],
+                    }
+
+                nodes.append(
+                    {
+                        "node_type": node.node_type,
+                        "description": node.description,
+                        "occurred_at": node.occurred_at,
+                        "fill_cost": str(fill_cost),
+                        "total_fees": str(node_fees),
+                        "roll": node.roll or False,
+                        "legs": legs,
+                        "entries": entries,
+                        "market_snapshot": snapshot,
+                    }
+                )
+
+            # Open legs with current mark values
+            open_legs = []
+            unrealized = Decimal("0")
+            for entry in cd.open_entries:
+                sym = entry.symbol.strip()
+                direction = "Short" if entry.quantity_type == "Short" else "Long"
+                pos = pos_by_symbol.get(sym)
+                mark_value: float | None = None
+                if pos and pos["mid_price"] is not None:
+                    mid = Decimal(str(pos["mid_price"]))
+                    qty = Decimal(str(pos["quantity"]))
+                    mult = Decimal(str(pos["multiplier"] or 1))
+                    sign = (
+                        Decimal("-1")
+                        if str(pos["quantity_direction"]) == "Short"
+                        or str(pos["quantity_direction"]) == "QuantityDirection.SHORT"
+                        else Decimal("1")
+                    )
+                    mv = mid * qty * mult * sign
+                    mark_value = float(mv)
+                    unrealized += mv
+
+                open_legs.append(
+                    {
+                        "symbol": sym,
+                        "quantity": entry.quantity,
+                        "direction": direction,
+                        "mark_value": mark_value,
+                    }
+                )
+
+            net_pnl = realized + unrealized
+            results.append(
+                {
+                    "chain_id": chain.id,
+                    "description": chain.description,
+                    "underlying": chain.underlying_symbol,
+                    "status": "open" if cd.open else "closed",
+                    "rolls": cd.roll_count,
+                    "realized_pnl": str(realized),
+                    "total_fees": str(fees),
+                    "unrealized_mark": str(unrealized),
+                    "net_pnl": str(net_pnl),
+                    "opened_at": cd.opened_at,
+                    "nodes": nodes,
+                    "open_legs": open_legs,
+                }
+            )
+
+        return results
 
     # -- end TradeChain enrichment block --
 

--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -401,6 +401,81 @@ def strategies_cmd(as_json: bool) -> None:
     asyncio.run(_run())
 
 
+def format_campaign_detail(chains: list[dict[str, object]]) -> None:
+    """Print human-readable detail of chain roll history."""
+    for chain_data in chains:
+        click.echo(f"{'=' * 70}")
+        click.echo(f"Chain: {chain_data['chain_id']}  {chain_data['description']}")
+        click.echo(
+            f"Underlying: {chain_data['underlying']}  "
+            f"Status: {chain_data['status']}  "
+            f"Rolls: {chain_data['rolls']}"
+        )
+        click.echo(
+            f"Realized P&L: {chain_data['realized_pnl']}  "
+            f"Fees: {chain_data['total_fees']}  "
+            f"Unrealized: {chain_data['unrealized_mark']}"
+        )
+        click.echo(f"Net P&L: {chain_data['net_pnl']}")
+        click.echo(f"Opened: {chain_data.get('opened_at', '-')}")
+
+        nodes = chain_data.get("nodes")
+        if isinstance(nodes, list):
+            click.echo(f"\n  {'Roll History':}")
+            click.echo(f"  {'-' * 60}")
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                roll_marker = " [ROLL]" if node.get("roll") else ""
+                click.echo(
+                    f"  {node.get('occurred_at', '-')}  "
+                    f"{node.get('description', '-')}{roll_marker}"
+                )
+                click.echo(
+                    f"    Fill cost: {node.get('fill_cost', '-')}  "
+                    f"Fees: {node.get('total_fees', '-')}"
+                )
+                legs = node.get("legs")
+                if isinstance(legs, list):
+                    for leg in legs:
+                        if isinstance(leg, dict):
+                            click.echo(
+                                f"      {leg.get('action', '-')} "
+                                f"{leg.get('fill_quantity', '-')}x "
+                                f"{leg.get('symbol', '-')}"
+                            )
+                entries = node.get("entries")
+                if isinstance(entries, list) and entries:
+                    for entry in entries:
+                        if isinstance(entry, dict):
+                            click.echo(
+                                f"      => {entry.get('direction', '-')} "
+                                f"{entry.get('quantity', '-')}x "
+                                f"{entry.get('symbol', '-')}"
+                            )
+                snapshot = node.get("market_snapshot")
+                if isinstance(snapshot, dict):
+                    click.echo(
+                        f"    Market: delta={snapshot.get('total_delta', '-')} "
+                        f"theta={snapshot.get('total_theta', '-')}"
+                    )
+
+        open_legs = chain_data.get("open_legs")
+        if isinstance(open_legs, list) and open_legs:
+            click.echo(f"\n  {'Open Legs':}")
+            click.echo(f"  {'-' * 60}")
+            for leg in open_legs:
+                if isinstance(leg, dict):
+                    mark = leg.get("mark_value")
+                    mark_str = f"  mark=${mark:,.2f}" if mark is not None else ""
+                    click.echo(
+                        f"    {leg.get('direction', '-')} "
+                        f"{leg.get('quantity', '-')}x "
+                        f"{leg.get('symbol', '-')}{mark_str}"
+                    )
+        click.echo()
+
+
 @cli.command(name="chains")
 @click.option(
     "--json",
@@ -409,7 +484,29 @@ def strategies_cmd(as_json: bool) -> None:
     default=False,
     help="Output in JSON format for machine consumption.",
 )
-def chains_cmd(as_json: bool) -> None:
+@click.option(
+    "--campaign",
+    is_flag=True,
+    default=False,
+    help="Group by underlying with campaign P&L aggregation.",
+)
+@click.option(
+    "--underlying",
+    default=None,
+    help="Filter to specific underlying (e.g., /ZB, /ES, SPY).",
+)
+@click.option(
+    "--detail",
+    is_flag=True,
+    default=False,
+    help="Show full roll history per chain with node-level fills.",
+)
+def chains_cmd(
+    as_json: bool,
+    campaign: bool,
+    underlying: str | None,
+    detail: bool,
+) -> None:
     """Show trade chain lifecycle summary from Redis.
 
     Displays one row per OrderChain with strategy name, rolls,
@@ -417,25 +514,70 @@ def chains_cmd(as_json: bool) -> None:
     to be running.
 
     \b
-    Example:
+    Modes:
+      (default)     One row per chain
+      --campaign    Aggregate by underlying with campaign P&L
+      --detail      Full roll history per chain with node-level fills
+
+    \b
+    Examples:
       tasty-subscription chains
+      tasty-subscription chains --campaign
+      tasty-subscription chains --campaign --underlying /ZB
+      tasty-subscription chains --detail --underlying /ZB
       tasty-subscription chains --json
     """
 
     async def _run() -> None:
+        import json as json_mod
+
         from tastytrade.analytics.positions import PositionMetricsReader
 
         reader = PositionMetricsReader()
         try:
             await reader.read()
-            df = reader.chain_summary
-            if df.empty:
-                click.echo("No trade chains found in Redis. Is account-stream running?")
-                return
-            if as_json:
-                click.echo(df.to_json(orient="records", indent=2))
+
+            if detail:
+                data = reader.campaign_detail(underlying=underlying)
+                if not data:
+                    click.echo("No matching chains found.")
+                    return
+                if as_json:
+                    click.echo(json_mod.dumps(data, indent=2, default=str))
+                else:
+                    format_campaign_detail(data)
+            elif campaign:
+                df = reader.campaign_summary
+                if df.empty:
+                    click.echo(
+                        "No trade chains found in Redis. Is account-stream running?"
+                    )
+                    return
+                if underlying:
+                    df = df[df["underlying"] == underlying]
+                    if df.empty:
+                        click.echo(f"No chains found for underlying: {underlying}")
+                        return
+                if as_json:
+                    click.echo(df.to_json(orient="records", indent=2))
+                else:
+                    click.echo(df.astype(object).fillna("").to_string(index=False))
             else:
-                click.echo(df.astype(object).fillna("").to_string(index=False))
+                df = reader.chain_summary
+                if df.empty:
+                    click.echo(
+                        "No trade chains found in Redis. Is account-stream running?"
+                    )
+                    return
+                if underlying:
+                    df = df[df["underlying"] == underlying]
+                    if df.empty:
+                        click.echo(f"No chains found for underlying: {underlying}")
+                        return
+                if as_json:
+                    click.echo(df.to_json(orient="records", indent=2))
+                else:
+                    click.echo(df.astype(object).fillna("").to_string(index=False))
         finally:
             await reader.close()
 

--- a/unit_tests/analytics/test_position_reader.py
+++ b/unit_tests/analytics/test_position_reader.py
@@ -1,13 +1,14 @@
 """Tests for PositionMetricsReader -- pure Redis consumer."""
 
 import json
+from decimal import Decimal
 from unittest.mock import AsyncMock
 
 import pandas as pd
 import pytest
 
-from tastytrade.accounts.models import TradeChain
-from tastytrade.analytics.positions import PositionMetricsReader
+from tastytrade.accounts.models import QuantityDirection, TradeChain
+from tastytrade.analytics.positions import PositionMetricsReader, apply_effect
 
 
 def make_position_json(
@@ -63,35 +64,49 @@ def make_trade_chain_json(
     roll_count: int = 1,
     realized_gain_with_fees: str = "7.68",
     total_fees: str = "7.68",
+    total_fees_effect: str = "Debit",
+    realized_gain: str | None = None,
+    realized_gain_effect: str | None = None,
     opened_at: str = "2026-03-07T15:30:00.000+0000",
     open_entry_symbols: list[str] | None = None,
+    open_entry_directions: list[str] | None = None,
+    lite_nodes: list[dict[str, object]] | None = None,
 ) -> str:
     """Build a trade chain JSON payload for Redis mock."""
+    directions = open_entry_directions or []
     entries = []
-    for sym in open_entry_symbols or []:
+    for i, sym in enumerate(open_entry_symbols or []):
+        direction = directions[i] if i < len(directions) else "Short"
+        sign = "-1" if direction == "Short" else "1"
         entries.append(
             {
                 "symbol": sym,
                 "instrument-type": "Future Option",
                 "quantity": "1",
-                "quantity-type": "Short",
-                "quantity-numeric": "-1",
+                "quantity-type": direction,
+                "quantity-numeric": sign,
             }
         )
+    computed: dict[str, object] = {
+        "open": is_open,
+        "roll-count": roll_count,
+        "realized-gain-with-fees": realized_gain_with_fees,
+        "total-fees": total_fees,
+        "total-fees-effect": total_fees_effect,
+        "opened-at": opened_at,
+        "open-entries": entries,
+    }
+    if realized_gain is not None:
+        computed["realized-gain"] = realized_gain
+    if realized_gain_effect is not None:
+        computed["realized-gain-effect"] = realized_gain_effect
     return json.dumps(
         {
             "id": chain_id,
             "description": description,
             "underlying-symbol": underlying,
-            "computed-data": {
-                "open": is_open,
-                "roll-count": roll_count,
-                "realized-gain-with-fees": realized_gain_with_fees,
-                "total-fees": total_fees,
-                "opened-at": opened_at,
-                "open-entries": entries,
-            },
-            "lite-nodes": [],
+            "computed-data": computed,
+            "lite-nodes": lite_nodes or [],
         }
     )
 
@@ -290,3 +305,428 @@ class TestChainSummary:
         df = reader.chain_summary
         assert len(df) == 1
         assert df.iloc[0]["chain_id"] == "12345"
+
+
+# ---------------------------------------------------------------------------
+# apply_effect utility (TT-91)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEffect:
+    def test_credit_is_positive(self) -> None:
+        assert apply_effect("100.50", "Credit") == Decimal("100.50")
+
+    def test_debit_is_negative(self) -> None:
+        assert apply_effect("75.00", "Debit") == Decimal("-75.00")
+
+    def test_none_amount_returns_zero(self) -> None:
+        assert apply_effect(None, "Credit") == Decimal("0")
+
+    def test_none_effect_treated_as_positive(self) -> None:
+        assert apply_effect("50.0", None) == Decimal("50.0")
+
+    def test_zero_amount(self) -> None:
+        assert apply_effect("0.0", "Debit") == Decimal("0.0")
+
+
+# ---------------------------------------------------------------------------
+# campaign_summary (TT-91)
+# ---------------------------------------------------------------------------
+
+
+def make_position_df(rows: list[dict[str, object]]) -> pd.DataFrame:
+    """Build a minimal position DataFrame for campaign tests."""
+    defaults = {
+        "symbol": "",
+        "mid_price": None,
+        "quantity": 1.0,
+        "multiplier": 1.0,
+        "quantity_direction": QuantityDirection.SHORT,
+    }
+    full_rows = [{**defaults, **r} for r in rows]
+    return pd.DataFrame(full_rows)
+
+
+class TestCampaignSummary:
+    def test_empty_when_no_chains(self, reader: PositionMetricsReader) -> None:
+        reader.trade_chains = {}
+        df = reader.campaign_summary
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 0
+        assert "underlying" in df.columns
+        assert "net_pnl" in df.columns
+
+    def test_single_underlying_single_chain(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="200.0",
+                realized_gain_effect="Credit",
+                total_fees="10.0",
+                roll_count=2,
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        df = reader.campaign_summary
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["underlying"] == "/6E"
+        assert row["chains"] == 1
+        assert row["open_chains"] == 0
+        assert row["total_rolls"] == 2
+        assert row["realized_pnl"] == 200.0
+        assert row["total_fees"] == 10.0
+        assert row["unrealized_mark"] == 0.0
+        assert row["net_pnl"] == 200.0
+        assert row["recovery_needed"] == 0.0
+
+    def test_debit_effect_makes_realized_negative(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="450.0",
+                realized_gain_effect="Debit",
+                total_fees="12.0",
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        df = reader.campaign_summary
+        row = df.iloc[0]
+        assert row["realized_pnl"] == -450.0
+        assert row["net_pnl"] == -450.0
+        assert row["recovery_needed"] == 450.0
+
+    def test_multiple_chains_same_underlying_aggregates(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        chain_a = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="aaa",
+                underlying="/ZB",
+                realized_gain="100.0",
+                realized_gain_effect="Debit",
+                total_fees="5.0",
+                roll_count=1,
+                is_open=False,
+            )
+        )
+        chain_b = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="bbb",
+                underlying="/ZB",
+                realized_gain="50.0",
+                realized_gain_effect="Debit",
+                total_fees="3.0",
+                roll_count=1,
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain_a.id: chain_a, chain_b.id: chain_b}
+        df = reader.campaign_summary
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["underlying"] == "/ZB"
+        assert row["chains"] == 2
+        assert row["total_rolls"] == 2
+        assert row["realized_pnl"] == -150.0
+        assert row["total_fees"] == 8.0
+
+    def test_multiple_underlyings_grouped(self, reader: PositionMetricsReader) -> None:
+        chain_zb = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="zb1",
+                underlying="/ZB",
+                realized_gain="100.0",
+                realized_gain_effect="Credit",
+                is_open=False,
+            )
+        )
+        chain_es = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="es1",
+                underlying="/ES",
+                realized_gain="200.0",
+                realized_gain_effect="Debit",
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain_zb.id: chain_zb, chain_es.id: chain_es}
+        df = reader.campaign_summary
+        assert len(df) == 2
+        assert set(df["underlying"]) == {"/ES", "/ZB"}
+
+    def test_unrealized_mark_from_positions(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        """Open chain with position data computes unrealized mark."""
+        sym = CALL_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+                total_fees="5.0",
+                is_open=True,
+                open_entry_symbols=[sym],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        # Short 1x at mid_price=2.50, multiplier=1000 → mark = -2500
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 2.50,
+                    "quantity": 1.0,
+                    "multiplier": 1000.0,
+                    "quantity_direction": QuantityDirection.SHORT,
+                }
+            ]
+        )
+        df = reader.campaign_summary
+        row = df.iloc[0]
+        assert row["unrealized_mark"] == -2500.0
+        assert row["net_pnl"] == -2500.0
+        assert row["recovery_needed"] == 2500.0
+
+    def test_net_pnl_combines_realized_and_unrealized(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        sym = CALL_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="300.0",
+                realized_gain_effect="Debit",
+                total_fees="5.0",
+                is_open=True,
+                open_entry_symbols=[sym],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        # Long 1x at mid_price=5.0, multiplier=100 → mark = +500
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 5.0,
+                    "quantity": 1.0,
+                    "multiplier": 100.0,
+                    "quantity_direction": QuantityDirection.LONG,
+                }
+            ]
+        )
+        df = reader.campaign_summary
+        row = df.iloc[0]
+        assert row["realized_pnl"] == -300.0
+        assert row["unrealized_mark"] == 500.0
+        assert row["net_pnl"] == 200.0
+        assert row["recovery_needed"] == 0.0
+
+    def test_recovery_needed_zero_when_profitable(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="500.0",
+                realized_gain_effect="Credit",
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        df = reader.campaign_summary
+        assert df.iloc[0]["recovery_needed"] == 0.0
+
+    def test_closed_chains_have_zero_unrealized(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="100.0",
+                realized_gain_effect="Debit",
+                is_open=False,
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        df = reader.campaign_summary
+        assert df.iloc[0]["unrealized_mark"] == 0.0
+
+    def test_missing_position_data_treated_as_zero_mark(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        """Open chain with no matching position data → unrealized = 0."""
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="50.0",
+                realized_gain_effect="Credit",
+                is_open=True,
+                open_entry_symbols=["UNKNOWN_SYMBOL"],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        df = reader.campaign_summary
+        assert df.iloc[0]["unrealized_mark"] == 0.0
+        assert df.iloc[0]["net_pnl"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# campaign_detail (TT-91)
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignDetail:
+    def test_empty_when_no_chains(self, reader: PositionMetricsReader) -> None:
+        reader.trade_chains = {}
+        result = reader.campaign_detail()
+        assert result == []
+
+    def test_detail_returns_chain_metadata(self, reader: PositionMetricsReader) -> None:
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="100.0",
+                realized_gain_effect="Debit",
+                total_fees="5.0",
+                roll_count=2,
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        result = reader.campaign_detail()
+        assert len(result) == 1
+        item = result[0]
+        assert item["chain_id"] == "12345"
+        assert item["description"] == "Strangle w/ a roll"
+        assert item["underlying"] == "/6E"
+        assert item["status"] == "open"
+        assert item["rolls"] == 2
+        assert item["realized_pnl"] == "-100.0"
+
+    def test_detail_filtered_by_underlying(self, reader: PositionMetricsReader) -> None:
+        chain_zb = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="zb1",
+                underlying="/ZB",
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+            )
+        )
+        chain_es = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                chain_id="es1",
+                underlying="/ES",
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+            )
+        )
+        reader.trade_chains = {chain_zb.id: chain_zb, chain_es.id: chain_es}
+        result = reader.campaign_detail(underlying="/ZB")
+        assert len(result) == 1
+        assert result[0]["underlying"] == "/ZB"
+
+    def test_detail_includes_roll_flag_in_nodes(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        nodes = [
+            {
+                "node-type": "order",
+                "id": "node1",
+                "description": "Strangle",
+                "occurred-at": "2026-03-07T15:30:00.000+0000",
+                "total-fill-cost": "500.0",
+                "total-fill-cost-effect": "Credit",
+                "total-fees": "3.50",
+                "roll": False,
+                "legs": [
+                    {
+                        "symbol": CALL_SYMBOL,
+                        "instrument-type": "Future Option",
+                        "action": "Sell to Open",
+                        "fill-quantity": "1",
+                        "order-quantity": "1",
+                    }
+                ],
+                "entries": [],
+            },
+            {
+                "node-type": "order",
+                "id": "node2",
+                "description": "Rolling",
+                "occurred-at": "2026-03-10T10:00:00.000+0000",
+                "total-fill-cost": "50.0",
+                "total-fill-cost-effect": "Debit",
+                "total-fees": "3.50",
+                "roll": True,
+                "legs": [
+                    {
+                        "symbol": CALL_SYMBOL,
+                        "instrument-type": "Future Option",
+                        "action": "Buy to Close",
+                        "fill-quantity": "1",
+                        "order-quantity": "1",
+                    },
+                    {
+                        "symbol": PUT_SYMBOL,
+                        "instrument-type": "Future Option",
+                        "action": "Sell to Open",
+                        "fill-quantity": "1",
+                        "order-quantity": "1",
+                    },
+                ],
+                "entries": [],
+            },
+        ]
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="50.0",
+                realized_gain_effect="Debit",
+                total_fees="7.0",
+                roll_count=1,
+                lite_nodes=nodes,
+                open_entry_symbols=[PUT_SYMBOL],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        result = reader.campaign_detail()
+        detail_nodes = result[0]["nodes"]
+        assert len(detail_nodes) == 2
+        assert detail_nodes[0]["roll"] is False
+        assert detail_nodes[0]["description"] == "Strangle"
+        assert detail_nodes[0]["fill_cost"] == "500.0"
+        assert detail_nodes[1]["roll"] is True
+        assert detail_nodes[1]["description"] == "Rolling"
+        assert detail_nodes[1]["fill_cost"] == "-50.0"
+        # Check legs
+        assert len(detail_nodes[1]["legs"]) == 2
+        assert detail_nodes[1]["legs"][0]["action"] == "Buy to Close"
+
+    def test_detail_open_legs_with_mark_values(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        sym = PUT_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+                is_open=True,
+                open_entry_symbols=[sym],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 3.0,
+                    "quantity": 1.0,
+                    "multiplier": 1000.0,
+                    "quantity_direction": QuantityDirection.SHORT,
+                }
+            ]
+        )
+        result = reader.campaign_detail()
+        open_legs = result[0]["open_legs"]
+        assert len(open_legs) == 1
+        assert open_legs[0]["symbol"] == sym
+        assert open_legs[0]["direction"] == "Short"
+        assert open_legs[0]["mark_value"] == -3000.0


### PR DESCRIPTION
## Summary
- Add `--campaign` flag to `tasty-subscription chains` for underlying-level P&L aggregation showing realized P&L, unrealized mark value, net campaign P&L, and recovery needed
- Add `--detail` flag for full roll history per chain with node-level fills, market snapshots, and open leg mark values
- Add `--underlying` filter applicable to all modes (default, campaign, detail)
- Introduce `apply_effect()` utility for correct sign handling of TastyTrade amount+effect pairs (fixes the `realized_gain_with_fees` confusion documented in TODO)

## Related Jira Issue
**Jira**: [TT-91](https://mandeng.atlassian.net/browse/TT-91)

## Functional Evidence

### AC1: Default campaign view with all underlyings
```
$ tasty-subscription chains --campaign
underlying chains open_chains total_rolls realized_pnl total_fees unrealized_mark  net_pnl recovery_needed
       /6E      2           1           1          0.0      26.88          -687.5   -687.5           687.5
       /CL      1           1           0          0.0       7.28          -130.0   -130.0           130.0
       /GC      4           3           0          3.6      35.46          -985.0   -981.4           981.4
      /RTY      3           1           0          1.7      20.88          -675.0   -673.3           673.3
       /ZB      2           2           0        -3.44      14.04          4062.5  4059.06             0.0
       QQQ      2           1           0        302.0        1.1          -348.0    -46.0            46.0
       SPY      2           1           0        359.0        1.1          -507.0   -148.0           148.0
```

### AC2: Underlying filter
```
$ tasty-subscription chains --campaign --underlying /ZB
underlying chains open_chains total_rolls realized_pnl total_fees unrealized_mark  net_pnl recovery_needed
       /ZB      2           2           0        -3.44      14.04         4054.69  4051.25             0.0
```

### AC3: Detail view with roll history
```
$ tasty-subscription chains --detail --underlying /ZB
======================================================================
Chain: 150315735  Butterfly
Underlying: /ZB  Status: open  Rolls: 0
Realized P&L: 0.0  Fees: 4.68  Unrealized: 4062.500000
Net P&L: 4062.500000

  Roll History
  ------------------------------------------------------------
  None  Open Pos
      => Long 1.0x ./ZBM6 OZBK6 260424P111
      => Long 1.0x ./ZBM6 OZBK6 260424P115
      => Short 2.0x ./ZBM6 OZBK6 260424P114
  2026-03-10T04:06:12.942Z  Butterfly
      Buy to Open 1x ./ZBM6 OZBK6 260424P115
      Buy to Open 1x ./ZBM6 OZBK6 260424P111
      Sell to Open 2x ./ZBM6 OZBK6 260424P114

  Open Legs
  ------------------------------------------------------------
    Long 1.0x ./ZBM6 OZBK6 260424P111  mark=$1,062.50
    Long 1.0x ./ZBM6 OZBK6 260424P115  mark=$3,000.00
    Short 2.0x ./ZBM6 OZBK6 260424P114

======================================================================
Chain: fa6a49fc-...  Butterfly w/ a roll
Underlying: /ZB  Status: open  Rolls: 0
Realized P&L: -3.4375  Fees: 9.36
Net P&L: -3.4375

  Roll History
  ------------------------------------------------------------
  2026-03-20T15:47:46.099Z  Roll [ROLL]
      Buy to Close 2x ./ZBM6 OZBK6 260424P114
      Sell to Open 2x ./ZBM6 OZBK6 260424P113
    Market: delta=-0.191 theta=0.003
  2026-03-10T12:08:15.381Z  Butterfly
      Buy to Open 1x ./ZBM6 OZBK6 260424P115
      Buy to Open 1x ./ZBM6 OZBK6 260424P111
      Sell to Open 2x ./ZBM6 OZBK6 260424P114
```

### AC4-5: Net P&L and recovery calculation
- /ZB: realized=-3.44 + unrealized=4054.69 = net +4051.25, recovery=0 (profitable)
- /GC: realized=3.60 + unrealized=-985.00 = net -981.40, recovery=981.40

### AC6: Existing chains command preserved
```
$ tasty-subscription chains --underlying /ZB
(original per-chain view works unchanged with new filter)
```

### AC7: Tests
- 29 tests in test_position_reader.py (was 10) — all pass
- 818 total tests pass, 0 failures
- New test classes: TestApplyEffect, TestCampaignSummary (11 tests), TestCampaignDetail (5 tests)

### AC8: Works with futures and equity options
Evidence shows /ZB, /GC, /ES (futures options), SPY, QQQ (equity options) all in campaign view.

## Test Evidence

- All tests passing (818/818, `just test`)
- Pyright strict: 0 errors
- Ruff: all checks passed
- Pre-commit hooks pass

## Test plan
- [x] Unit tests pass (818/818)
- [x] Pyright strict: 0 errors
- [x] Ruff: all checks passed
- [x] Pre-commit hooks pass
- [x] Functional test: `chains --campaign` with live Redis data
- [x] Functional test: `chains --campaign --underlying /ZB`
- [x] Functional test: `chains --detail --underlying /ZB`
- [x] Functional test: `chains --underlying /ZB` (backward compat)
- [x] Functional test: `chains --campaign --json` (JSON output)

[TT-91]: https://mandeng.atlassian.net/browse/TT-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ