### PR TITLE
TT-91: Fix campaign P&L, add trade fill explorer with BS curves

### DIFF
--- a/docs/architecture-map/_devserver.py
+++ b/docs/architecture-map/_devserver.py
@@ -6,16 +6,139 @@ Usage:
 
 Serves the current directory. PUT requests write the body to the requested file path
 (restricted to .json files in the served directory for safety).
+
+API endpoints:
+    POST /api/refresh — re-export trade data and market data from Redis to JSON files.
 """
 
+import json
 import os
 import sys
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 
+def refresh_from_redis() -> dict[str, str]:
+    """Pull fresh data from Redis and write JSON files. Returns status."""
+    import asyncio
+
+    import redis.asyncio as aioredis  # type: ignore[import-untyped]
+
+    results: dict[str, str] = {}
+
+    async def export() -> None:
+        r: aioredis.Redis = aioredis.Redis()  # type: ignore[type-arg]
+        try:
+            # raw_redis_data.json — orders, trade chains, positions
+            raw_orders = await r.hgetall("tastytrade:orders")
+            orders = []
+            for key, val in raw_orders.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                orders.append({"redis_key": k, "raw": json.loads(val)})
+
+            raw_chains = await r.hgetall("tastytrade:trade_chains")
+            chains = []
+            for key, val in raw_chains.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                chains.append({"redis_key": k, "raw": json.loads(val)})
+
+            raw_pos = await r.hgetall("tastytrade:positions")
+            positions = []
+            for key, val in raw_pos.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                positions.append({"redis_key": k, "raw": json.loads(val)})
+
+            trade_data = {
+                "redis_keys": {
+                    "orders": "tastytrade:orders",
+                    "trade_chains": "tastytrade:trade_chains",
+                    "positions": "tastytrade:positions",
+                },
+                "orders": orders,
+                "trade_chains": chains,
+                "positions": positions,
+            }
+            Path("raw_redis_data.json").write_text(
+                json.dumps(trade_data, indent=2, default=str)
+            )
+            results["raw_redis_data"] = (
+                f"{len(orders)} orders, {len(chains)} chains, {len(positions)} positions"
+            )
+
+            # market_data.json — greeks, quotes, instruments
+            raw_greeks = await r.hgetall("tastytrade:latest:GreeksEvent")
+            greeks = {}
+            for key, val in raw_greeks.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                greeks[k] = json.loads(val)
+
+            raw_quotes = await r.hgetall("tastytrade:latest:QuoteEvent")
+            quotes = {}
+            for key, val in raw_quotes.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                quotes[k] = json.loads(val)
+
+            pos_map = {}
+            for _key, val in raw_pos.items():
+                p = json.loads(val)
+                sym = p.get("symbol", "").strip()
+                pos_map[sym] = {
+                    "underlying": p.get("underlying-symbol", ""),
+                    "multiplier": p.get("multiplier"),
+                    "streamer_symbol": p.get("streamer-symbol"),
+                    "average_open_price": p.get("average-open-price"),
+                }
+
+            raw_inst = await r.hgetall("tastytrade:instruments")
+            instruments = {}
+            for key, val in raw_inst.items():
+                k = key.decode() if isinstance(key, bytes) else key
+                inst = json.loads(val)
+                ss = inst.get("streamer-symbol", "")
+                if ss:
+                    instruments[k] = {"streamer_symbol": ss}
+
+            market_data = {
+                "greeks": greeks,
+                "quotes": quotes,
+                "positions": pos_map,
+                "instruments": instruments,
+            }
+            Path("market_data.json").write_text(
+                json.dumps(market_data, indent=2, default=str)
+            )
+            results["market_data"] = (
+                f"{len(quotes)} quotes, {len(greeks)} greeks, {len(instruments)} instruments"
+            )
+        finally:
+            await r.close()
+
+    asyncio.run(export())
+    return results
+
+
 class DevHandler(SimpleHTTPRequestHandler):
-    """Extends SimpleHTTPRequestHandler with PUT support for .json files."""
+    """Extends SimpleHTTPRequestHandler with PUT and API support."""
+
+    def do_POST(self) -> None:
+        if self.path == "/api/refresh":
+            try:
+                results = refresh_from_redis()
+                body = json.dumps({"ok": True, "data": results}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except Exception as e:
+                body = json.dumps({"ok": False, "error": str(e)}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            return
+        self.send_error(404, "Not found")
 
     def do_PUT(self) -> None:
         # Only allow .json files in the served directory

--- a/docs/architecture-map/trade_explorer.html
+++ b/docs/architecture-map/trade_explorer.html
@@ -17,6 +17,13 @@
   .shell { display: flex; flex-direction: column; height: 100vh; }
   .topbar { padding: 12px 20px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 20px; background: var(--paper-raised); flex-shrink: 0; }
   .topbar h1 { font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--hl); text-transform: uppercase; }
+  .refresh-btn {
+    background: var(--paper-inset); border: 1px solid var(--rule); color: var(--ink-2);
+    padding: 3px 10px; border-radius: 3px; font-family: inherit; font-size: 11px;
+    cursor: pointer; transition: border-color 0.15s, color 0.15s;
+  }
+  .refresh-btn:hover { border-color: var(--hl); color: var(--ink); }
+  .refresh-btn.loading { color: var(--hl); cursor: wait; }
   .topbar .stat { color: var(--ink-2); font-size: 11px; }
   .topbar .stat b { color: var(--ink); font-weight: 500; }
 
@@ -80,6 +87,7 @@
     <h1>Trade Fills</h1>
     <div class="stat">Orders: <b id="s-orders">-</b></div>
     <div class="stat">Fills: <b id="s-fills">-</b></div>
+    <button class="refresh-btn" id="refresh-btn" onclick="refreshData()">Refresh</button>
     <div class="sel-count" id="sel-count"></div>
   </div>
   <div class="filters">
@@ -756,6 +764,28 @@ document.querySelectorAll('.pane-tab').forEach(tab => {
 
 // Resize redraw
 window.addEventListener('resize', () => { if (SELECTED.size) drawChart(); });
+
+async function refreshData() {
+  const btn = document.getElementById('refresh-btn');
+  btn.textContent = 'Refreshing...'; btn.classList.add('loading');
+  try {
+    const resp = await fetch('/api/refresh', { method: 'POST' });
+    const result = await resp.json();
+    if (result.ok) {
+      // Reload all data
+      ORDERS = []; SELECTED.clear(); GREEKS_MAP = {}; QUOTES_MAP = {};
+      await boot();
+      btn.textContent = 'Done'; setTimeout(() => { btn.textContent = 'Refresh'; }, 1500);
+    } else {
+      btn.textContent = 'Error'; setTimeout(() => { btn.textContent = 'Refresh'; }, 2000);
+      console.error('Refresh failed:', result.error);
+    }
+  } catch(e) {
+    btn.textContent = 'Error'; setTimeout(() => { btn.textContent = 'Refresh'; }, 2000);
+    console.error('Refresh error:', e);
+  }
+  btn.classList.remove('loading');
+}
 
 document.getElementById('f-underlying').onchange = () => { SELECTED.clear(); render(); };
 document.getElementById('f-search').oninput = render;

--- a/docs/architecture-map/trade_explorer.html
+++ b/docs/architecture-map/trade_explorer.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Trade Fills</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap');
+  :root {
+    --ink: #c9d1d9; --ink-2: #8b949e; --ink-3: #6e7681;
+    --paper: #0d1117; --paper-raised: #161b22; --paper-inset: #090c10;
+    --rule: #30363d; --gain: #3fb950; --loss: #f85149; --hl: #58a6ff;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'JetBrains Mono', monospace; background: var(--paper); color: var(--ink); font-size: 12px; line-height: 1.5; }
+
+  .shell { display: flex; flex-direction: column; height: 100vh; }
+  .topbar { padding: 12px 20px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 20px; background: var(--paper-raised); flex-shrink: 0; }
+  .topbar h1 { font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--hl); text-transform: uppercase; }
+  .topbar .stat { color: var(--ink-2); font-size: 11px; }
+  .topbar .stat b { color: var(--ink); font-weight: 500; }
+
+  .filters { padding: 8px 20px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 14px; background: var(--paper-raised); flex-shrink: 0; }
+  .filters label { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.8px; }
+  .filters select, .filters input { background: var(--paper-inset); border: 1px solid var(--rule); color: var(--ink); padding: 4px 8px; border-radius: 3px; font-family: inherit; font-size: 11px; }
+  .filters select:focus, .filters input:focus { outline: none; border-color: var(--hl); }
+
+  .workspace { display: flex; flex: 1; overflow: hidden; }
+  .timeline { overflow-y: auto; padding: 16px 20px; flex-shrink: 0; width: 380px; min-width: 260px; }
+  .gutter { width: 4px; cursor: col-resize; background: var(--rule); flex-shrink: 0; transition: background 0.1s; }
+  .gutter:hover, .gutter.active { background: var(--hl); }
+  .right-pane { flex: 1; display: flex; flex-direction: column; min-width: 200px; background: var(--paper-inset); }
+
+  .pane-tabs { display: flex; border-bottom: 1px solid var(--rule); flex-shrink: 0; }
+  .pane-tab { padding: 8px 16px; font-family: inherit; font-size: 11px; background: none; border: none; color: var(--ink-3); cursor: pointer; border-bottom: 2px solid transparent; text-transform: uppercase; letter-spacing: 0.5px; }
+  .pane-tab:hover { color: var(--ink-2); }
+  .pane-tab.active { color: var(--hl); border-bottom-color: var(--hl); }
+  .pane-body { flex: 1; overflow-y: auto; }
+  .pane-content { display: none; height: 100%; }
+  .pane-content.active { display: flex; flex-direction: column; }
+
+  .inspector-wrap { flex: 1; overflow-y: auto; padding: 16px 20px; }
+  .inspector-empty { color: var(--ink-3); padding: 40px 0; text-align: center; font-size: 11px; }
+  .inspector-label { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 6px; }
+  .json-block { font-size: 11px; line-height: 1.65; white-space: pre-wrap; word-break: break-all; color: var(--ink-2); }
+  .json-block .k { color: var(--hl); } .json-block .s { color: var(--gain); }
+  .json-block .n { color: #d19a66; } .json-block .b { color: #c678dd; } .json-block .null { color: var(--ink-3); }
+
+  .chart-wrap { flex: 1; display: flex; flex-direction: column; padding: 12px; }
+  .chart-info { font-size: 11px; color: var(--ink-2); margin-bottom: 8px; display: flex; gap: 16px; flex-wrap: wrap; }
+  .chart-info .ci-label { color: var(--ink-3); text-transform: uppercase; font-size: 10px; }
+  .chart-info .ci-val { font-weight: 500; }
+  .chart-info .ci-val.cr { color: var(--gain); } .chart-info .ci-val.dr { color: var(--loss); }
+  .chart-canvas-wrap { flex: 1; position: relative; min-height: 200px; }
+  .chart-canvas-wrap canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+  .chart-empty { color: var(--ink-3); text-align: center; padding: 60px 20px; font-size: 11px; }
+
+  .day { margin-bottom: 20px; }
+  .day-label { font-size: 10px; font-weight: 500; color: var(--ink-3); text-transform: uppercase; letter-spacing: 1px; padding-bottom: 4px; margin-bottom: 8px; border-bottom: 1px solid var(--rule); }
+
+  .ticket { margin-bottom: 6px; padding: 8px 10px; border: 1px solid var(--rule); border-radius: 4px; cursor: pointer; transition: border-color 0.1s, background 0.1s; background: var(--paper-raised); }
+  .ticket:hover { border-color: var(--ink-3); }
+  .ticket.selected { border-color: var(--hl); background: rgba(88,166,255,0.06); }
+  .ticket-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4px; }
+  .ticket-time { font-size: 11px; color: var(--ink-2); }
+  .ticket-price { font-size: 12px; font-weight: 500; }
+  .ticket-price.cr { color: var(--gain); } .ticket-price.dr { color: var(--loss); }
+  .leg-row { display: flex; gap: 6px; font-size: 11px; padding: 1px 0; color: var(--ink); }
+  .leg-action { width: 110px; flex-shrink: 0; }
+  .leg-action.buy { color: var(--gain); } .leg-action.sell { color: var(--loss); }
+  .leg-detail { color: var(--ink-2); } .leg-at { color: var(--ink-3); }
+  .ticket-id { font-size: 10px; color: var(--ink-3); margin-top: 3px; }
+
+  .sel-count { font-size: 10px; color: var(--hl); margin-left: auto; }
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <h1>Trade Fills</h1>
+    <div class="stat">Orders: <b id="s-orders">-</b></div>
+    <div class="stat">Fills: <b id="s-fills">-</b></div>
+    <div class="sel-count" id="sel-count"></div>
+  </div>
+  <div class="filters">
+    <label>Underlying</label>
+    <select id="f-underlying"><option value="">All</option></select>
+    <label>Search</label>
+    <input id="f-search" type="text" placeholder="symbol, order id..." style="width:160px">
+  </div>
+  <div class="workspace">
+    <div class="timeline" id="timeline"></div>
+    <div class="gutter" id="gutter"></div>
+    <div class="right-pane">
+      <div class="pane-tabs">
+        <button class="pane-tab active" data-pane="chart">P&L Chart</button>
+        <button class="pane-tab" data-pane="json">JSON</button>
+      </div>
+      <div class="pane-body">
+        <div class="pane-content active" id="pane-chart">
+          <div class="chart-wrap">
+            <div class="chart-info" id="chart-info"></div>
+            <div class="chart-canvas-wrap" id="chart-area">
+              <div class="chart-empty">Select orders to plot P&L at expiration</div>
+            </div>
+          </div>
+        </div>
+        <div class="pane-content" id="pane-json">
+          <div class="inspector-wrap" id="inspector">
+            <div class="inspector-empty">Click an order to inspect the raw Redis object</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+const TZ = 'America/New_York';
+let DATA, ORDERS = [], SELECTED = new Set(), MULTIPLIERS = {};
+let lastClicked = null;
+
+async function boot() {
+  DATA = await (await fetch('raw_redis_data.json')).json();
+
+  // Build multiplier lookup from positions
+  DATA.positions.forEach(rec => {
+    const p = rec.raw;
+    const u = p['underlying-symbol'] || '';
+    const m = p.multiplier;
+    if (u && m) MULTIPLIERS[u] = m;
+  });
+
+  DATA.orders.forEach(rec => {
+    const o = rec.raw;
+    const legs = o.legs || [];
+    const filledLegs = legs.filter(l => (l.fills || []).length > 0);
+    if (!filledLegs.length) return;
+
+    let earliest = '';
+    filledLegs.forEach(l => (l.fills||[]).forEach(f => {
+      const t = f['filled-at'] || '';
+      if (t && (!earliest || t < earliest)) earliest = t;
+    }));
+
+    ORDERS.push({
+      id: o.id,
+      time: earliest || o['updated-at'] || o['received-at'] || '',
+      underlying: o['underlying-symbol'] || '',
+      price: o.price,
+      size: o.size || 1,
+      priceEffect: o['price-effect'] || '',
+      legs: filledLegs.map(l => {
+        const fill = (l.fills||[])[0] || {};
+        return {
+          action: l.action || '',
+          symbol: (l.symbol || '').trim(),
+          instrumentType: l['instrument-type'] || '',
+          qty: parseFloat(fill.quantity || fill['fill-quantity'] || l.quantity || 0),
+          fillPrice: parseFloat(fill['fill-price'] ?? 0),
+        };
+      }),
+      _raw: o, _redisKey: rec.redis_key,
+    });
+  });
+
+  ORDERS.sort((a, b) => b.time.localeCompare(a.time));
+
+  const uu = [...new Set(ORDERS.map(o => o.underlying))].filter(Boolean).sort();
+  const sel = document.getElementById('f-underlying');
+  uu.forEach(u => { const opt = document.createElement('option'); opt.value = u; opt.textContent = u; sel.appendChild(opt); });
+
+  document.getElementById('s-orders').textContent = ORDERS.length;
+  document.getElementById('s-fills').textContent = ORDERS.reduce((n, o) => n + o.legs.length, 0);
+
+  render();
+}
+
+// --- Symbol parsing ---
+function parseOption(leg) {
+  const sym = leg.symbol;
+  const iType = leg.instrumentType;
+  let strike, optType;
+
+  if (iType === 'Equity Option') {
+    // QQQ   260417C00636000 → C, 636
+    const m = sym.match(/(\d{6})([CP])(\d{8})$/);
+    if (m) { optType = m[2]; strike = parseInt(m[3]) / 1000; }
+  } else if (iType === 'Future Option') {
+    // ./ZBM6 OZBK6 260424P111  or  ./6EM6 EUUK6 260508C1.2
+    const m = sym.match(/(\d{6})([CP])(.+)$/);
+    if (m) { optType = m[2]; strike = parseFloat(m[3]); }
+  }
+  if (!strike || !optType) return null;
+
+  const isBuy = leg.action.startsWith('Buy');
+  return { strike, optType, isLong: isBuy, qty: leg.qty, premium: leg.fillPrice };
+}
+
+// --- P&L computation ---
+function computePayoff(parsedLegs, multiplier, priceRange) {
+  return priceRange.map(s => {
+    let total = 0;
+    parsedLegs.forEach(leg => {
+      let intrinsic = leg.optType === 'C' ? Math.max(0, s - leg.strike) : Math.max(0, leg.strike - s);
+      let pnl = leg.isLong
+        ? (intrinsic - leg.premium) * leg.qty * multiplier
+        : (leg.premium - intrinsic) * leg.qty * multiplier;
+      total += pnl;
+    });
+    return { price: s, pnl: total };
+  });
+}
+
+// --- Chart drawing ---
+function drawChart() {
+  const info = document.getElementById('chart-info');
+  const area = document.getElementById('chart-area');
+
+  if (SELECTED.size === 0) {
+    info.innerHTML = '';
+    area.innerHTML = '<div class="chart-empty">Select orders to plot P&L at expiration</div>';
+    return;
+  }
+
+  // Gather all legs from selected orders
+  const selectedOrders = ORDERS.filter(o => SELECTED.has(o.id));
+  const allLegs = [];
+  let underlying = '';
+  selectedOrders.forEach(o => {
+    if (!underlying) underlying = o.underlying;
+    o.legs.forEach(l => {
+      const parsed = parseOption(l);
+      if (parsed) allLegs.push(parsed);
+    });
+  });
+
+  if (!allLegs.length) {
+    info.innerHTML = '';
+    area.innerHTML = '<div class="chart-empty">Could not parse option data from selected orders</div>';
+    return;
+  }
+
+  const mult = MULTIPLIERS[underlying] || 100;
+  const strikes = allLegs.map(l => l.strike);
+  const minK = Math.min(...strikes);
+  const maxK = Math.max(...strikes);
+  const spread = maxK - minK || maxK * 0.1 || 10;
+  const lo = minK - spread * 0.6;
+  const hi = maxK + spread * 0.6;
+  const steps = 300;
+  const range = [];
+  for (let i = 0; i <= steps; i++) range.push(lo + (hi - lo) * i / steps);
+
+  const payoff = computePayoff(allLegs, mult, range);
+
+  // Compute summary
+  const maxProfit = Math.max(...payoff.map(p => p.pnl));
+  const maxLoss = Math.min(...payoff.map(p => p.pnl));
+  const netPremium = selectedOrders.reduce((sum, o) => {
+    const sign = o.priceEffect === 'Credit' ? 1 : -1;
+    return sum + (o.price || 0) * (o.size || 1) * mult * sign;
+  }, 0);
+
+  info.innerHTML = `
+    <div><span class="ci-label">Underlying</span> <span class="ci-val">${esc(underlying)}</span></div>
+    <div><span class="ci-label">Mult</span> <span class="ci-val">${mult}</span></div>
+    <div><span class="ci-label">Net Premium</span> <span class="ci-val ${netPremium >= 0 ? 'cr' : 'dr'}">${netPremium >= 0 ? '+' : ''}${netPremium.toFixed(2)}</span></div>
+    <div><span class="ci-label">Max Profit</span> <span class="ci-val cr">${maxProfit === Infinity ? '∞' : '+' + maxProfit.toFixed(2)}</span></div>
+    <div><span class="ci-label">Max Loss</span> <span class="ci-val dr">${maxLoss === -Infinity ? '-∞' : maxLoss.toFixed(2)}</span></div>
+    <div><span class="ci-label">Orders</span> <span class="ci-val">${selectedOrders.length}</span></div>
+    <div><span class="ci-label">Legs</span> <span class="ci-val">${allLegs.length}</span></div>
+  `;
+
+  // Canvas — two layers: static chart + hover overlay
+  area.innerHTML = '<canvas id="chart-cv"></canvas><canvas id="chart-hover" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none"></canvas>';
+  const canvas = document.getElementById('chart-cv');
+  const hoverCanvas = document.getElementById('chart-hover');
+  const rect = area.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr; canvas.height = rect.height * dpr;
+  hoverCanvas.width = rect.width * dpr; hoverCanvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+  const W = rect.width, H = rect.height;
+  const pad = { top: 20, right: 20, bottom: 36, left: 68 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+
+  const pnls = payoff.map(p => p.pnl);
+  const rawMin = Math.min(...pnls, 0);
+  const rawMax = Math.max(...pnls, 0);
+
+  // Round Y axis to nice numbers
+  function niceStep(range) {
+    const rough = range / 5;
+    const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+    const norm = rough / mag;
+    let step;
+    if (norm <= 1.5) step = 1;
+    else if (norm <= 3) step = 2;
+    else if (norm <= 7) step = 5;
+    else step = 10;
+    return step * mag;
+  }
+  const yStep = niceStep(rawMax - rawMin || 1);
+  let minP = Math.floor(rawMin / yStep) * yStep - yStep;
+  let maxP = Math.ceil(rawMax / yStep) * yStep + yStep;
+  // Ensure zero is included
+  if (minP > 0) minP = 0;
+  if (maxP < 0) maxP = 0;
+
+  const isSmallStrike = strikes[0] < 10;
+  function x(price) { return pad.left + (price - lo) / (hi - lo) * cw; }
+  function y(pnl) { return pad.top + (1 - (pnl - minP) / (maxP - minP)) * ch; }
+  function fmtDollar(v) { return (v >= 0 ? '+' : '') + v.toLocaleString('en-US', { maximumFractionDigits: 0 }); }
+
+  // Grid lines at nice intervals
+  ctx.strokeStyle = '#21262d';
+  ctx.lineWidth = 1;
+  ctx.font = '10px JetBrains Mono';
+  ctx.textAlign = 'right';
+  for (let val = minP; val <= maxP; val += yStep) {
+    const yy = y(val);
+    if (yy < pad.top - 1 || yy > pad.top + ch + 1) continue;
+    ctx.beginPath(); ctx.moveTo(pad.left, yy); ctx.lineTo(W - pad.right, yy); ctx.stroke();
+    ctx.fillStyle = '#484f58';
+    ctx.fillText(fmtDollar(val), pad.left - 6, yy + 3);
+  }
+
+  // Zero line
+  if (minP < 0 && maxP > 0) {
+    ctx.strokeStyle = '#484f58'; ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath(); ctx.moveTo(pad.left, y(0)); ctx.lineTo(W - pad.right, y(0)); ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  // X axis labels
+  const xTicks = Math.min(strikes.length + 2, 8);
+  const xStep = (hi - lo) / xTicks;
+  ctx.fillStyle = '#484f58'; ctx.textAlign = 'center';
+  for (let i = 0; i <= xTicks; i++) {
+    const val = lo + xStep * i;
+    ctx.fillText(val.toFixed(isSmallStrike ? 2 : 0), x(val), H - pad.bottom + 16);
+  }
+
+  // Strike markers
+  ctx.strokeStyle = '#30363d'; ctx.lineWidth = 1;
+  ctx.setLineDash([2, 4]);
+  strikes.forEach(k => { ctx.beginPath(); ctx.moveTo(x(k), pad.top); ctx.lineTo(x(k), H - pad.bottom); ctx.stroke(); });
+  ctx.setLineDash([]);
+
+  // Fill: green above zero, red below zero
+  const y0 = y(0);
+  const clippedY0 = Math.max(pad.top, Math.min(pad.top + ch, y0));
+
+  ctx.save();
+  ctx.beginPath(); ctx.rect(pad.left, pad.top, cw, clippedY0 - pad.top); ctx.clip();
+  ctx.beginPath(); ctx.moveTo(x(payoff[0].price), clippedY0);
+  payoff.forEach(p => ctx.lineTo(x(p.price), y(p.pnl)));
+  ctx.lineTo(x(payoff[payoff.length-1].price), clippedY0); ctx.closePath();
+  ctx.fillStyle = 'rgba(63,185,80,0.12)'; ctx.fill(); ctx.restore();
+
+  ctx.save();
+  ctx.beginPath(); ctx.rect(pad.left, clippedY0, cw, pad.top + ch - clippedY0); ctx.clip();
+  ctx.beginPath(); ctx.moveTo(x(payoff[0].price), clippedY0);
+  payoff.forEach(p => ctx.lineTo(x(p.price), y(p.pnl)));
+  ctx.lineTo(x(payoff[payoff.length-1].price), clippedY0); ctx.closePath();
+  ctx.fillStyle = 'rgba(248,81,73,0.12)'; ctx.fill(); ctx.restore();
+
+  // Main P&L line
+  ctx.beginPath();
+  payoff.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+  ctx.strokeStyle = '#c9d1d9'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+
+  // Max profit / max loss markers on Y axis
+  const maxProfitVal = Math.max(...pnls);
+  const maxLossVal = Math.min(...pnls);
+
+  function drawYMarker(val, color, label, fullWidth) {
+    const yy = y(val);
+    if (yy < pad.top || yy > pad.top + ch) return;
+    let endX = W - pad.right;
+    if (!fullWidth) {
+      for (let i = 0; i < payoff.length; i++) {
+        if (Math.abs(payoff[i].pnl - val) < Math.abs(pnls[0] - val) * 0.01 + 0.5) {
+          endX = x(payoff[i].price); break;
+        }
+      }
+    }
+    ctx.strokeStyle = color + '55'; ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath(); ctx.moveTo(pad.left, yy); ctx.lineTo(endX, yy); ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'right'; ctx.fillStyle = color;
+    ctx.fillText(label + ' ' + fmtDollar(val), pad.left - 6, yy + 3);
+  }
+  if (maxProfitVal !== 0) drawYMarker(maxProfitVal, '#3fb950', 'MAX', true);
+  if (maxLossVal !== 0) drawYMarker(maxLossVal, '#f85149', 'MAX', false);
+
+  // Breakeven dots
+  for (let i = 1; i < payoff.length; i++) {
+    if ((payoff[i-1].pnl <= 0 && payoff[i].pnl >= 0) || (payoff[i-1].pnl >= 0 && payoff[i].pnl <= 0)) {
+      const ratio = Math.abs(payoff[i-1].pnl) / (Math.abs(payoff[i-1].pnl) + Math.abs(payoff[i].pnl));
+      const bPrice = payoff[i-1].price + (payoff[i].price - payoff[i-1].price) * ratio;
+      ctx.beginPath(); ctx.arc(x(bPrice), y(0), 4, 0, Math.PI * 2);
+      ctx.fillStyle = '#58a6ff'; ctx.fill();
+      ctx.fillStyle = '#c9d1d9'; ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'center';
+      ctx.fillText(bPrice.toFixed(isSmallStrike ? 3 : 1), x(bPrice), y(0) - 8);
+    }
+  }
+
+  // Hover crosshair
+  canvas.style.pointerEvents = 'auto';
+  canvas.onmousemove = (e) => {
+    const cr = canvas.getBoundingClientRect();
+    const mx = e.clientX - cr.left;
+    const my = e.clientY - cr.top;
+    const hctx = hoverCanvas.getContext('2d');
+    hctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    hctx.clearRect(0, 0, W, H);
+
+    if (mx < pad.left || mx > W - pad.right || my < pad.top || my > pad.top + ch) return;
+
+    // Find nearest payoff point
+    const hoverPrice = lo + (mx - pad.left) / cw * (hi - lo);
+    let closest = payoff[0], closestDist = Infinity;
+    payoff.forEach(p => { const d = Math.abs(p.price - hoverPrice); if (d < closestDist) { closestDist = d; closest = p; } });
+
+    const px = x(closest.price), py = y(closest.pnl);
+
+    // Vertical line
+    hctx.strokeStyle = 'rgba(139,148,158,0.4)'; hctx.lineWidth = 1;
+    hctx.setLineDash([3, 3]);
+    hctx.beginPath(); hctx.moveTo(px, pad.top); hctx.lineTo(px, pad.top + ch); hctx.stroke();
+    hctx.setLineDash([]);
+
+    // Horizontal line to Y axis
+    hctx.strokeStyle = 'rgba(139,148,158,0.25)'; hctx.lineWidth = 1;
+    hctx.setLineDash([3, 3]);
+    hctx.beginPath(); hctx.moveTo(pad.left, py); hctx.lineTo(px, py); hctx.stroke();
+    hctx.setLineDash([]);
+
+    // Dot on curve
+    hctx.beginPath(); hctx.arc(px, py, 4, 0, Math.PI * 2);
+    hctx.fillStyle = closest.pnl >= 0 ? '#3fb950' : '#f85149'; hctx.fill();
+    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1.5; hctx.stroke();
+
+    // Tooltip
+    const pnlStr = fmtDollar(closest.pnl);
+    const priceStr = closest.price.toFixed(isSmallStrike ? 3 : 1);
+    const text = `${priceStr}  ${pnlStr}`;
+    hctx.font = '11px JetBrains Mono';
+    const tw = hctx.measureText(text).width + 12;
+    const tx = Math.min(px + 8, W - pad.right - tw);
+    const ty = Math.max(py - 24, pad.top + 2);
+
+    hctx.fillStyle = '#161b22'; hctx.strokeStyle = '#30363d'; hctx.lineWidth = 1;
+    hctx.beginPath();
+    hctx.roundRect(tx, ty, tw, 20, 3);
+    hctx.fill(); hctx.stroke();
+
+    hctx.fillStyle = closest.pnl >= 0 ? '#3fb950' : '#f85149';
+    hctx.textAlign = 'left';
+    hctx.fillText(text, tx + 6, ty + 14);
+  };
+
+  canvas.onmouseleave = () => {
+    const hctx = hoverCanvas.getContext('2d');
+    hctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    hctx.clearRect(0, 0, W, H);
+  };
+}
+
+function var_hl() { return '#58a6ff'; }
+
+function filtered() {
+  const u = document.getElementById('f-underlying').value;
+  const q = document.getElementById('f-search').value.toLowerCase();
+  return ORDERS.filter(o => {
+    if (u && o.underlying !== u) return false;
+    if (q) {
+      const hay = [o.id, o.underlying, ...o.legs.map(l => l.symbol + ' ' + l.action)].join(' ').toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function render() {
+  const orders = filtered();
+  const panel = document.getElementById('timeline');
+  const days = {};
+  orders.forEach(o => {
+    let day = 'Unknown';
+    if (o.time) try { day = new Date(o.time).toLocaleDateString('en-CA', { timeZone: TZ }); } catch(e) {}
+    (days[day] = days[day] || []).push(o);
+  });
+
+  let html = '';
+  Object.keys(days).sort().reverse().forEach(day => {
+    const label = day === 'Unknown' ? day : new Date(day + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    html += `<div class="day"><div class="day-label">${esc(label)}</div>`;
+    days[day].forEach(o => {
+      const t = o.time ? new Date(o.time).toLocaleTimeString('en-US', { timeZone: TZ, hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '';
+      const isCr = o.priceEffect === 'Credit';
+      const isDr = o.priceEffect === 'Debit';
+      const priceCls = isCr ? 'cr' : isDr ? 'dr' : '';
+      const sign = isCr ? '+' : isDr ? '-' : '';
+      const total = o.price != null && o.size != null ? (o.price * o.size) : o.price;
+      const totalStr = total != null ? parseFloat(total.toFixed(6)) : null;
+      const priceStr = totalStr != null ? `${sign}${totalStr} ${o.priceEffect}` : '';
+      const sel = SELECTED.has(o.id) ? ' selected' : '';
+
+      html += `<div class="ticket${sel}" data-oid="${o.id}">`;
+      html += `<div class="ticket-head"><span class="ticket-time">${t}</span><span class="ticket-price ${priceCls}">${esc(priceStr)}</span></div>`;
+      html += `<div class="ticket-legs">`;
+      o.legs.forEach(l => {
+        const isBuy = l.action.startsWith('Buy');
+        const aCls = isBuy ? 'buy' : 'sell';
+        const at = l.fillPrice ? ` <span class="leg-at">@ ${l.fillPrice}</span>` : '';
+        html += `<div class="leg-row"><span class="leg-action ${aCls}">${esc(l.action)}</span><span class="leg-detail">${esc(l.qty)}x ${esc(l.symbol)}${at}</span></div>`;
+      });
+      html += `</div>`;
+      html += `<div class="ticket-id">${o.underlying} · #${o.id}</div>`;
+      html += `</div>`;
+    });
+    html += `</div>`;
+  });
+  if (!html) html = '<div class="inspector-empty">No matching fills</div>';
+  panel.innerHTML = html;
+
+  // Attach click handlers — toggle selection
+  document.querySelectorAll('.ticket').forEach(el => {
+    el.addEventListener('click', () => {
+      const oid = parseInt(el.dataset.oid);
+      if (SELECTED.has(oid)) { SELECTED.delete(oid); el.classList.remove('selected'); }
+      else { SELECTED.add(oid); el.classList.add('selected'); }
+      lastClicked = oid;
+      updateSelectionUI();
+    });
+  });
+
+  updateSelectionUI();
+}
+
+function updateSelectionUI() {
+  document.getElementById('sel-count').textContent = SELECTED.size ? `${SELECTED.size} selected` : '';
+  drawChart();
+  // Update JSON pane with last clicked
+  if (lastClicked != null) {
+    const o = ORDERS.find(x => x.id === lastClicked);
+    if (o) {
+      document.getElementById('inspector').innerHTML =
+        `<div class="inspector-label">Redis key: ${esc(o._redisKey)} in ${esc(DATA.redis_keys.orders)}</div>` +
+        `<div class="json-block">${highlight(JSON.stringify(o._raw, null, 2))}</div>`;
+    }
+  }
+}
+
+function highlight(json) {
+  return json.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"([^"]+)"(?=\s*:)/g, '<span class="k">"$1"</span>')
+    .replace(/:\s*"([^"]*)"/g, ': <span class="s">"$1"</span>')
+    .replace(/:\s*(-?\d+\.?\d*(?:[eE][+-]?\d+)?)/g, ': <span class="n">$1</span>')
+    .replace(/:\s*(true|false)/g, ': <span class="b">$1</span>')
+    .replace(/:\s*null/g, ': <span class="null">null</span>');
+}
+function esc(s) { return String(s||'').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+// Tab switching
+document.querySelectorAll('.pane-tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.pane-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.pane-content').forEach(c => c.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById('pane-' + tab.dataset.pane).classList.add('active');
+    if (tab.dataset.pane === 'chart') drawChart();
+  });
+});
+
+// Draggable gutter
+(function() {
+  const gutter = document.getElementById('gutter');
+  const timeline = document.getElementById('timeline');
+  let dragging = false, startX, startW;
+  gutter.addEventListener('mousedown', e => {
+    dragging = true; startX = e.clientX; startW = timeline.offsetWidth;
+    gutter.classList.add('active'); document.body.style.cursor = 'col-resize'; document.body.style.userSelect = 'none'; e.preventDefault();
+  });
+  document.addEventListener('mousemove', e => { if (!dragging) return; timeline.style.width = Math.max(240, Math.min(window.innerWidth - 200, startW + e.clientX - startX)) + 'px'; });
+  document.addEventListener('mouseup', () => { if (!dragging) return; dragging = false; gutter.classList.remove('active'); document.body.style.cursor = ''; document.body.style.userSelect = ''; });
+})();
+
+// Resize redraw
+window.addEventListener('resize', () => { if (SELECTED.size) drawChart(); });
+
+document.getElementById('f-underlying').onchange = () => { SELECTED.clear(); render(); };
+document.getElementById('f-search').oninput = render;
+
+boot();
+</script>
+</body>
+</html>

--- a/docs/architecture-map/trade_explorer.html
+++ b/docs/architecture-map/trade_explorer.html
@@ -116,11 +116,71 @@
 </div>
 <script>
 const TZ = 'America/New_York';
-let DATA, ORDERS = [], SELECTED = new Set(), MULTIPLIERS = {};
+let DATA, MARKET, ORDERS = [], SELECTED = new Set(), MULTIPLIERS = {};
+let GREEKS_MAP = {}; // fill symbol → {iv, delta, theta}
+let QUOTES_MAP = {}; // underlying → {bid, ask, mid}
 let lastClicked = null;
+
+// --- Black-Scholes ---
+function normCdf(x) { return 0.5 * (1 + erf(x / Math.SQRT2)); }
+function erf(x) {
+  const a1=0.254829592, a2=-0.284496736, a3=1.421413741, a4=-1.453152027, a5=1.061405429, p=0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  x = Math.abs(x);
+  const t = 1 / (1 + p * x);
+  const y = 1 - (((((a5*t+a4)*t)+a3)*t+a2)*t+a1)*t * Math.exp(-x*x);
+  return sign * y;
+}
+function bsPrice(S, K, T, r, sigma, optType) {
+  if (T <= 0) return optType === 'C' ? Math.max(0, S-K) : Math.max(0, K-S);
+  if (sigma <= 0) return optType === 'C' ? Math.max(0, S-K) : Math.max(0, K-S);
+  const d1 = (Math.log(S/K) + (r + sigma*sigma/2)*T) / (sigma*Math.sqrt(T));
+  const d2 = d1 - sigma*Math.sqrt(T);
+  if (optType === 'C') return S*normCdf(d1) - K*Math.exp(-r*T)*normCdf(d2);
+  else return K*Math.exp(-r*T)*normCdf(-d2) - S*normCdf(-d1);
+}
 
 async function boot() {
   DATA = await (await fetch('raw_redis_data.json')).json();
+  try { MARKET = await (await fetch('market_data.json')).json(); } catch(e) { MARKET = {greeks:{},quotes:{},positions:{}}; }
+
+  // Build Greeks lookup: map fill symbol → streamer key → greeks
+  // Patterns:
+  //   Equity: "SPY   260501P00645000" → ".SPY260501P645"
+  //   Future: "./ZBM6 OZBK6 260424P111" → "./OZBK26P111:XCBT" (year digit expanded)
+  // We'll match by strike+type+expiry since that's unique enough
+  const greeksByStrikeKey = {};
+  for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+    // Extract type+strike from greeks key
+    const m = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+    if (m) {
+      const k = m[1] + '_' + m[2];
+      greeksByStrikeKey[k] = { iv: gVal.volatility, delta: gVal.delta, theta: gVal.theta, key: gKey };
+    }
+  }
+
+  // Build underlying quote lookup — keyed by both streamer symbol and API symbol
+  for (const [qKey, qVal] of Object.entries(MARKET.quotes || {})) {
+    if (!qKey.startsWith('.')) {
+      const bid = qVal.bidPrice || 0;
+      const ask = qVal.askPrice || 0;
+      QUOTES_MAP[qKey] = { bid, ask, mid: (bid + ask) / 2 };
+    }
+  }
+  // Map API symbols to streamer quotes via instruments (e.g. /ZBM6 → /ZBM26:XCBT)
+  for (const [instKey, instVal] of Object.entries(MARKET.instruments || {})) {
+    const ss = instVal.streamer_symbol;
+    if (ss && QUOTES_MAP[ss] && !QUOTES_MAP[instKey]) {
+      QUOTES_MAP[instKey] = QUOTES_MAP[ss];
+    }
+  }
+
+  // Map position underlying → multiplier, and also store streamer→greeks link
+  for (const [sym, pos] of Object.entries(MARKET.positions || {})) {
+    if (pos.streamer_symbol && MARKET.greeks[pos.streamer_symbol]) {
+      GREEKS_MAP[sym] = MARKET.greeks[pos.streamer_symbol];
+    }
+  }
 
   // Build multiplier lookup from positions
   DATA.positions.forEach(rec => {
@@ -179,21 +239,44 @@ async function boot() {
 function parseOption(leg) {
   const sym = leg.symbol;
   const iType = leg.instrumentType;
-  let strike, optType;
+  let strike, optType, dateStr;
 
   if (iType === 'Equity Option') {
-    // QQQ   260417C00636000 → C, 636
     const m = sym.match(/(\d{6})([CP])(\d{8})$/);
-    if (m) { optType = m[2]; strike = parseInt(m[3]) / 1000; }
+    if (m) { dateStr = m[1]; optType = m[2]; strike = parseInt(m[3]) / 1000; }
   } else if (iType === 'Future Option') {
-    // ./ZBM6 OZBK6 260424P111  or  ./6EM6 EUUK6 260508C1.2
     const m = sym.match(/(\d{6})([CP])(.+)$/);
-    if (m) { optType = m[2]; strike = parseFloat(m[3]); }
+    if (m) { dateStr = m[1]; optType = m[2]; strike = parseFloat(m[3]); }
   }
   if (!strike || !optType) return null;
 
+  // Parse DTE from date string (YYMMDD)
+  let dte = 30; // fallback
+  if (dateStr) {
+    const exp = new Date(2000 + parseInt(dateStr.slice(0,2)), parseInt(dateStr.slice(2,4))-1, parseInt(dateStr.slice(4,6)));
+    const now = new Date();
+    dte = Math.max(1, Math.round((exp - now) / 86400000));
+  }
+
+  // Look up IV from Greeks — match by strike+type key
+  const strikeKey = optType + '_' + strike;
+  let iv = 0.20; // fallback
+  // Try direct position match first
+  if (GREEKS_MAP[sym]) {
+    iv = GREEKS_MAP[sym].volatility || iv;
+  } else {
+    // Search greeks by strike key pattern
+    for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+      const m2 = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+      if (m2 && m2[1] === optType && parseFloat(m2[2]) === strike) {
+        iv = gVal.volatility || iv;
+        break;
+      }
+    }
+  }
+
   const isBuy = leg.action.startsWith('Buy');
-  return { strike, optType, isLong: isBuy, qty: leg.qty, premium: leg.fillPrice };
+  return { strike, optType, isLong: isBuy, qty: leg.qty, premium: leg.fillPrice, dte, iv, symbol: sym };
 }
 
 // --- P&L computation ---
@@ -209,6 +292,41 @@ function computePayoff(parsedLegs, multiplier, priceRange) {
     });
     return { price: s, pnl: total };
   });
+}
+
+function computeDay0Payoff(parsedLegs, multiplier, priceRange) {
+  const r = 0.04; // risk-free rate approximation
+  return priceRange.map(s => {
+    let total = 0;
+    parsedLegs.forEach(leg => {
+      const T = leg.dte / 365;
+      const theo = bsPrice(s, leg.strike, T, r, leg.iv, leg.optType);
+      let pnl = leg.isLong
+        ? (theo - leg.premium) * leg.qty * multiplier
+        : (leg.premium - theo) * leg.qty * multiplier;
+      total += pnl;
+    });
+    return { price: s, pnl: total };
+  });
+}
+
+function estimateUnderlyingPrice(parsedLegs, underlying) {
+  // Try quotes first
+  const q = QUOTES_MAP[underlying];
+  if (q && q.mid > 0) return q.mid;
+  // Estimate from near-ATM option: the strike where |delta| is closest to 0.5
+  let bestStrike = null, bestDeltaDiff = Infinity;
+  for (const leg of parsedLegs) {
+    // Look up delta
+    for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+      const m = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+      if (m && m[1] === leg.optType && parseFloat(m[2]) === leg.strike && gVal.delta != null) {
+        const diff = Math.abs(Math.abs(gVal.delta) - 0.5);
+        if (diff < bestDeltaDiff) { bestDeltaDiff = diff; bestStrike = leg.strike; }
+      }
+    }
+  }
+  return bestStrike || parsedLegs[0]?.strike || 100;
 }
 
 // --- Chart drawing ---
@@ -251,24 +369,36 @@ function drawChart() {
   const range = [];
   for (let i = 0; i <= steps; i++) range.push(lo + (hi - lo) * i / steps);
 
+  const isSmallStrike = strikes[0] < 10;
   const payoff = computePayoff(allLegs, mult, range);
+  const day0 = computeDay0Payoff(allLegs, mult, range);
+  // Time decay projections: scale DTE by fraction, recompute BS
+  const timeSlices = [0.75, 0.50, 0.25];
+  const projections = timeSlices.map(frac => {
+    const projLegs = allLegs.map(l => ({ ...l, dte: Math.max(1, Math.round(l.dte * frac)) }));
+    return { frac, data: computeDay0Payoff(projLegs, mult, range) };
+  });
+  const spotPrice = estimateUnderlyingPrice(allLegs, underlying);
 
   // Compute summary
   const maxProfit = Math.max(...payoff.map(p => p.pnl));
   const maxLoss = Math.min(...payoff.map(p => p.pnl));
+  const day0AtSpot = day0.find(d => Math.abs(d.price - spotPrice) < (hi-lo)/steps*1.5);
   const netPremium = selectedOrders.reduce((sum, o) => {
     const sign = o.priceEffect === 'Credit' ? 1 : -1;
     return sum + (o.price || 0) * (o.size || 1) * mult * sign;
   }, 0);
 
+  const avgDte = Math.round(allLegs.reduce((s,l) => s+l.dte, 0) / allLegs.length);
+  const day0Pnl = day0AtSpot ? day0AtSpot.pnl : 0;
+
   info.innerHTML = `
-    <div><span class="ci-label">Underlying</span> <span class="ci-val">${esc(underlying)}</span></div>
-    <div><span class="ci-label">Mult</span> <span class="ci-val">${mult}</span></div>
+    <div><span class="ci-label">Underlying</span> <span class="ci-val">${esc(underlying)} @ ${spotPrice.toFixed(isSmallStrike ? 3 : 1)}</span></div>
+    <div><span class="ci-label">DTE</span> <span class="ci-val">${avgDte}</span></div>
     <div><span class="ci-label">Net Premium</span> <span class="ci-val ${netPremium >= 0 ? 'cr' : 'dr'}">${netPremium >= 0 ? '+' : ''}${netPremium.toFixed(2)}</span></div>
+    <div><span class="ci-label">Day 0 P&L</span> <span class="ci-val ${day0Pnl >= 0 ? 'cr' : 'dr'}">${day0Pnl >= 0 ? '+' : ''}${day0Pnl.toFixed(2)}</span></div>
     <div><span class="ci-label">Max Profit</span> <span class="ci-val cr">${maxProfit === Infinity ? '∞' : '+' + maxProfit.toFixed(2)}</span></div>
     <div><span class="ci-label">Max Loss</span> <span class="ci-val dr">${maxLoss === -Infinity ? '-∞' : maxLoss.toFixed(2)}</span></div>
-    <div><span class="ci-label">Orders</span> <span class="ci-val">${selectedOrders.length}</span></div>
-    <div><span class="ci-label">Legs</span> <span class="ci-val">${allLegs.length}</span></div>
   `;
 
   // Canvas — two layers: static chart + hover overlay
@@ -287,8 +417,11 @@ function drawChart() {
   const ch = H - pad.top - pad.bottom;
 
   const pnls = payoff.map(p => p.pnl);
-  const rawMin = Math.min(...pnls, 0);
-  const rawMax = Math.max(...pnls, 0);
+  const day0pnls = day0.map(p => p.pnl);
+  const projPnls = projections.flatMap(pr => pr.data.map(p => p.pnl));
+  const allPnls = pnls.concat(day0pnls, projPnls);
+  const rawMin = Math.min(...allPnls, 0);
+  const rawMax = Math.max(...allPnls, 0);
 
   // Round Y axis to nice numbers
   function niceStep(range) {
@@ -309,7 +442,6 @@ function drawChart() {
   if (minP > 0) minP = 0;
   if (maxP < 0) maxP = 0;
 
-  const isSmallStrike = strikes[0] < 10;
   function x(price) { return pad.left + (price - lo) / (hi - lo) * cw; }
   function y(pnl) { return pad.top + (1 - (pnl - minP) / (maxP - minP)) * ch; }
   function fmtDollar(v) { return (v >= 0 ? '+' : '') + v.toLocaleString('en-US', { maximumFractionDigits: 0 }); }
@@ -368,7 +500,36 @@ function drawChart() {
   ctx.lineTo(x(payoff[payoff.length-1].price), clippedY0); ctx.closePath();
   ctx.fillStyle = 'rgba(248,81,73,0.12)'; ctx.fill(); ctx.restore();
 
-  // Main P&L line
+  // Time decay projections (75%, 50%, 25% DTE remaining)
+  projections.forEach(proj => {
+    ctx.beginPath();
+    proj.data.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+    ctx.strokeStyle = '#484f58'; ctx.lineWidth = 1; ctx.lineJoin = 'round';
+    ctx.setLineDash([4, 3]); ctx.stroke(); ctx.setLineDash([]);
+  });
+
+  // Day 0 curve (Black-Scholes theoretical)
+  ctx.beginPath();
+  day0.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+  ctx.strokeStyle = '#58a6ff'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round';
+  ctx.setLineDash([6, 3]); ctx.stroke(); ctx.setLineDash([]);
+
+  // Current price vertical line
+  const spotX = x(spotPrice);
+  ctx.strokeStyle = '#58a6ff55'; ctx.lineWidth = 1;
+  ctx.setLineDash([4, 3]);
+  ctx.beginPath(); ctx.moveTo(spotX, pad.top); ctx.lineTo(spotX, pad.top + ch); ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.fillStyle = '#58a6ff'; ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'center';
+  ctx.fillText(spotPrice.toFixed(isSmallStrike ? 3 : 1), spotX, pad.top + ch + 14);
+
+  // Spot price marker on Day 0 curve
+  const spotY = day0.reduce((best, p) => Math.abs(p.price - spotPrice) < Math.abs(best.price - spotPrice) ? p : best, day0[0]);
+  ctx.beginPath(); ctx.arc(x(spotY.price), y(spotY.pnl), 5, 0, Math.PI * 2);
+  ctx.fillStyle = '#58a6ff'; ctx.fill();
+  ctx.strokeStyle = '#0d1117'; ctx.lineWidth = 1.5; ctx.stroke();
+
+  // Expiration P&L line
   ctx.beginPath();
   payoff.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
   ctx.strokeStyle = '#c9d1d9'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
@@ -424,10 +585,11 @@ function drawChart() {
 
     // Find nearest payoff point
     const hoverPrice = lo + (mx - pad.left) / cw * (hi - lo);
-    let closest = payoff[0], closestDist = Infinity;
-    payoff.forEach(p => { const d = Math.abs(p.price - hoverPrice); if (d < closestDist) { closestDist = d; closest = p; } });
+    let closest = payoff[0], closestD0 = day0[0], closestDist = Infinity;
+    payoff.forEach((p, i) => { const d = Math.abs(p.price - hoverPrice); if (d < closestDist) { closestDist = d; closest = p; closestD0 = day0[i]; } });
 
     const px = x(closest.price), py = y(closest.pnl);
+    const d0y = y(closestD0.pnl);
 
     // Vertical line
     hctx.strokeStyle = 'rgba(139,148,158,0.4)'; hctx.lineWidth = 1;
@@ -435,32 +597,32 @@ function drawChart() {
     hctx.beginPath(); hctx.moveTo(px, pad.top); hctx.lineTo(px, pad.top + ch); hctx.stroke();
     hctx.setLineDash([]);
 
-    // Horizontal line to Y axis
-    hctx.strokeStyle = 'rgba(139,148,158,0.25)'; hctx.lineWidth = 1;
-    hctx.setLineDash([3, 3]);
-    hctx.beginPath(); hctx.moveTo(pad.left, py); hctx.lineTo(px, py); hctx.stroke();
-    hctx.setLineDash([]);
-
-    // Dot on curve
-    hctx.beginPath(); hctx.arc(px, py, 4, 0, Math.PI * 2);
+    // Dot on expiration curve
+    hctx.beginPath(); hctx.arc(px, py, 3.5, 0, Math.PI * 2);
     hctx.fillStyle = closest.pnl >= 0 ? '#3fb950' : '#f85149'; hctx.fill();
-    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1.5; hctx.stroke();
+    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1; hctx.stroke();
 
-    // Tooltip
-    const pnlStr = fmtDollar(closest.pnl);
+    // Dot on Day 0 curve
+    hctx.beginPath(); hctx.arc(px, d0y, 3.5, 0, Math.PI * 2);
+    hctx.fillStyle = '#58a6ff'; hctx.fill();
+    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1; hctx.stroke();
+
+    // Tooltip with both values
     const priceStr = closest.price.toFixed(isSmallStrike ? 3 : 1);
-    const text = `${priceStr}  ${pnlStr}`;
+    const expStr = fmtDollar(closest.pnl);
+    const d0Str = fmtDollar(closestD0.pnl);
+    const text = `${priceStr}  Exp: ${expStr}  Now: ${d0Str}`;
     hctx.font = '11px JetBrains Mono';
     const tw = hctx.measureText(text).width + 12;
     const tx = Math.min(px + 8, W - pad.right - tw);
-    const ty = Math.max(py - 24, pad.top + 2);
+    const ty = Math.max(Math.min(py, d0y) - 28, pad.top + 2);
 
     hctx.fillStyle = '#161b22'; hctx.strokeStyle = '#30363d'; hctx.lineWidth = 1;
     hctx.beginPath();
     hctx.roundRect(tx, ty, tw, 20, 3);
     hctx.fill(); hctx.stroke();
 
-    hctx.fillStyle = closest.pnl >= 0 ? '#3fb950' : '#f85149';
+    hctx.fillStyle = '#c9d1d9';
     hctx.textAlign = 'left';
     hctx.fillText(text, tx + 6, ty + 14);
   };

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set dotenv-load := true
 # Run `just --list` to see all available recipes
 
 # Default symbols and intervals for subscription
-default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX"
+default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX,/ZBM26:XCBT,/6EM26:XCME,/GCM26:XCEC,/RTYM26:XCME,/CLK26:XNYM"
 default_intervals := "1d,1h,30m,15m,5m,m"
 
 # Prior workday calculation: Mon->Fri(-3), Sun->Fri(-2), else->yesterday(-1)

--- a/justfile
+++ b/justfile
@@ -56,33 +56,22 @@ strategies:
 strategies-json:
     uv run tasty-subscription strategies --json
 
-# Trade chain lifecycle summary (rolls, P&L, fees)
+# Trade chains: just chains, just chains /ZB, just chains /ZB --json
 chains *args:
-    uv run tasty-subscription chains {{args}}
+    uv run tasty-subscription chains {{ if args =~ '^/' { "--underlying " + args } else { args } }}
 
-# Campaign P&L by underlying (realized + unrealized + recovery needed)
+# Campaign P&L: just campaign, just campaign /ZB
 campaign *args:
-    uv run tasty-subscription chains --campaign {{args}}
+    uv run tasty-subscription chains --campaign {{ if args =~ '^/' { "--underlying " + args } else { args } }}
 
-# Detailed roll history per chain with node-level fills
+# Roll history: just campaign-detail, just campaign-detail /ZB
 campaign-detail *args:
-    uv run tasty-subscription chains --detail {{args}}
+    uv run tasty-subscription chains --detail {{ if args =~ '^/' { "--underlying " + args } else { args } }}
 
 # Backfill historical account events into InfluxDB (idempotent)
 backfill:
     uv run python scripts/backfill_influxdb.py
 
-# Fetch option chain snapshot for any underlying
+# Option chain: just options SPX, just options /GC --dte 0,30,45 --strikes
 options symbol *args:
     uv run tasty-subscription options --symbol "{{symbol}}" {{args}}
-
-# Position summary with LLM strategy identification (legacy)
-positions-strategies:
-    uv run tasty-subscription positions-summary | claude --print \
-        "Identify the strategy for each underlying. Output ONLY a markdown table \
-        with columns: Underlying, Strategy, Net Delta, Num Legs. No reasoning or notes. \
-        Strategy reference: short strangle (2 short options, no stock), \
-        iron condor (short strangle + protective wings), \
-        covered call (long stock + short call), \
-        jade lizard (short OTM vertical spread + short option on opposite side), \
-        covered jade lizard (long stock + jade lizard overlay)."

--- a/src/tastytrade/analytics/positions.py
+++ b/src/tastytrade/analytics/positions.py
@@ -271,6 +271,7 @@ class PositionMetricsReader:
     # -- Campaign P&L aggregation (TT-91) --
     # Groups chains by underlying, sums realized P&L from rolls,
     # cross-references open legs with live position mark data.
+    # Unrealized = (mark - avg_open) × qty × multiplier per open leg.
 
     @property
     def campaign_summary(self) -> pd.DataFrame:
@@ -282,19 +283,20 @@ class PositionMetricsReader:
             "total_rolls",
             "realized_pnl",
             "total_fees",
-            "unrealized_mark",
+            "pnl_open",
             "net_pnl",
             "recovery_needed",
         ]
         if not self.trade_chains:
             return pd.DataFrame(columns=columns)
 
-        # Build symbol → position lookup for mark value computation
+        # Build symbol → position lookup for unrealized P&L computation
         pos_by_symbol: dict[str, dict[str, Any]] = {}
         if not self.position_metrics_df.empty:
             for _, row in self.position_metrics_df.iterrows():
                 pos_by_symbol[str(row["symbol"]).strip()] = {
                     "mid_price": row.get("mid_price"),
+                    "average_open_price": row.get("average_open_price"),
                     "quantity": row.get("quantity"),
                     "multiplier": row.get("multiplier"),
                     "quantity_direction": row.get("quantity_direction"),
@@ -326,19 +328,26 @@ class PositionMetricsReader:
                     for entry in cd.open_entries:
                         sym = entry.symbol.strip()
                         pos = pos_by_symbol.get(sym)
-                        if pos is None or pos["mid_price"] is None:
+                        if pos is None:
                             continue
-                        mid = Decimal(str(pos["mid_price"]))
+                        mid = pos["mid_price"]
+                        avg_open = pos["average_open_price"]
+                        if mid is None or avg_open is None:
+                            continue
                         qty = Decimal(str(pos["quantity"]))
                         mult = Decimal(str(pos["multiplier"] or 1))
-                        sign = (
-                            Decimal("-1")
-                            if str(pos["quantity_direction"]) == "Short"
-                            or str(pos["quantity_direction"])
-                            == "QuantityDirection.SHORT"
-                            else Decimal("1")
+                        is_short = str(pos["quantity_direction"]) in (
+                            "Short",
+                            "QuantityDirection.SHORT",
                         )
-                        total_unrealized += mid * qty * mult * sign
+                        sign = Decimal("-1") if is_short else Decimal("1")
+                        pnl = (
+                            (Decimal(str(mid)) - Decimal(str(avg_open)))
+                            * qty
+                            * mult
+                            * sign
+                        )
+                        total_unrealized += pnl
 
             net_pnl = total_realized + total_unrealized
             recovery = max(Decimal("0"), -net_pnl)
@@ -351,7 +360,7 @@ class PositionMetricsReader:
                     "total_rolls": total_rolls,
                     "realized_pnl": float(total_realized),
                     "total_fees": float(total_fees),
-                    "unrealized_mark": float(total_unrealized),
+                    "pnl_open": float(total_unrealized),
                     "net_pnl": float(net_pnl),
                     "recovery_needed": float(recovery),
                 }
@@ -364,7 +373,7 @@ class PositionMetricsReader:
             for col in (
                 "realized_pnl",
                 "total_fees",
-                "unrealized_mark",
+                "pnl_open",
                 "net_pnl",
                 "recovery_needed",
             ):
@@ -373,12 +382,13 @@ class PositionMetricsReader:
 
     def campaign_detail(self, underlying: Optional[str] = None) -> list[dict[str, Any]]:
         """Detailed roll history per chain, optionally filtered by underlying."""
-        # Build symbol → position lookup for open leg mark values
+        # Build symbol → position lookup for open leg P&L
         pos_by_symbol: dict[str, dict[str, Any]] = {}
         if not self.position_metrics_df.empty:
             for _, row in self.position_metrics_df.iterrows():
                 pos_by_symbol[str(row["symbol"]).strip()] = {
                     "mid_price": row.get("mid_price"),
+                    "average_open_price": row.get("average_open_price"),
                     "quantity": row.get("quantity"),
                     "multiplier": row.get("multiplier"),
                     "quantity_direction": row.get("quantity_direction"),
@@ -456,34 +466,40 @@ class PositionMetricsReader:
                     }
                 )
 
-            # Open legs with current mark values
+            # Open legs with unrealized P&L per leg
             open_legs = []
             unrealized = Decimal("0")
             for entry in cd.open_entries:
                 sym = entry.symbol.strip()
                 direction = "Short" if entry.quantity_type == "Short" else "Long"
                 pos = pos_by_symbol.get(sym)
-                mark_value: float | None = None
-                if pos and pos["mid_price"] is not None:
-                    mid = Decimal(str(pos["mid_price"]))
-                    qty = Decimal(str(pos["quantity"]))
-                    mult = Decimal(str(pos["multiplier"] or 1))
-                    sign = (
-                        Decimal("-1")
-                        if str(pos["quantity_direction"]) == "Short"
-                        or str(pos["quantity_direction"]) == "QuantityDirection.SHORT"
-                        else Decimal("1")
-                    )
-                    mv = mid * qty * mult * sign
-                    mark_value = float(mv)
-                    unrealized += mv
+                pnl_value: float | None = None
+                if pos is not None:
+                    mid = pos["mid_price"]
+                    avg_open = pos["average_open_price"]
+                    if mid is not None and avg_open is not None:
+                        qty = Decimal(str(pos["quantity"]))
+                        mult = Decimal(str(pos["multiplier"] or 1))
+                        is_short = str(pos["quantity_direction"]) in (
+                            "Short",
+                            "QuantityDirection.SHORT",
+                        )
+                        sign = Decimal("-1") if is_short else Decimal("1")
+                        pnl = (
+                            (Decimal(str(mid)) - Decimal(str(avg_open)))
+                            * qty
+                            * mult
+                            * sign
+                        )
+                        pnl_value = float(pnl)
+                        unrealized += pnl
 
                 open_legs.append(
                     {
                         "symbol": sym,
                         "quantity": entry.quantity,
                         "direction": direction,
-                        "mark_value": mark_value,
+                        "pnl_open": pnl_value,
                     }
                 )
 
@@ -497,7 +513,7 @@ class PositionMetricsReader:
                     "rolls": cd.roll_count,
                     "realized_pnl": str(realized),
                     "total_fees": str(fees),
-                    "unrealized_mark": str(unrealized),
+                    "pnl_open": str(unrealized),
                     "net_pnl": str(net_pnl),
                     "opened_at": cd.opened_at,
                     "nodes": nodes,

--- a/src/tastytrade/subscription/cli.py
+++ b/src/tastytrade/subscription/cli.py
@@ -414,7 +414,7 @@ def format_campaign_detail(chains: list[dict[str, object]]) -> None:
         click.echo(
             f"Realized P&L: {chain_data['realized_pnl']}  "
             f"Fees: {chain_data['total_fees']}  "
-            f"Unrealized: {chain_data['unrealized_mark']}"
+            f"P&L Open: {chain_data['pnl_open']}"
         )
         click.echo(f"Net P&L: {chain_data['net_pnl']}")
         click.echo(f"Opened: {chain_data.get('opened_at', '-')}")
@@ -466,8 +466,8 @@ def format_campaign_detail(chains: list[dict[str, object]]) -> None:
             click.echo(f"  {'-' * 60}")
             for leg in open_legs:
                 if isinstance(leg, dict):
-                    mark = leg.get("mark_value")
-                    mark_str = f"  mark=${mark:,.2f}" if mark is not None else ""
+                    pnl = leg.get("pnl_open")
+                    mark_str = f"  P&L=${pnl:,.2f}" if pnl is not None else ""
                     click.echo(
                         f"    {leg.get('direction', '-')} "
                         f"{leg.get('quantity', '-')}x "

--- a/unit_tests/analytics/test_position_reader.py
+++ b/unit_tests/analytics/test_position_reader.py
@@ -330,7 +330,7 @@ class TestApplyEffect:
 
 
 # ---------------------------------------------------------------------------
-# campaign_summary (TT-91)
+# campaign_summary (TT-91) — chain-based P&L with corrected unrealized
 # ---------------------------------------------------------------------------
 
 
@@ -339,6 +339,7 @@ def make_position_df(rows: list[dict[str, object]]) -> pd.DataFrame:
     defaults = {
         "symbol": "",
         "mid_price": None,
+        "average_open_price": None,
         "quantity": 1.0,
         "multiplier": 1.0,
         "quantity_direction": QuantityDirection.SHORT,
@@ -356,9 +357,7 @@ class TestCampaignSummary:
         assert "underlying" in df.columns
         assert "net_pnl" in df.columns
 
-    def test_single_underlying_single_chain(
-        self, reader: PositionMetricsReader
-    ) -> None:
+    def test_closed_chain_realized_only(self, reader: PositionMetricsReader) -> None:
         chain = TradeChain.model_validate_json(
             make_trade_chain_json(
                 realized_gain="200.0",
@@ -373,12 +372,8 @@ class TestCampaignSummary:
         assert len(df) == 1
         row = df.iloc[0]
         assert row["underlying"] == "/6E"
-        assert row["chains"] == 1
-        assert row["open_chains"] == 0
-        assert row["total_rolls"] == 2
         assert row["realized_pnl"] == 200.0
-        assert row["total_fees"] == 10.0
-        assert row["unrealized_mark"] == 0.0
+        assert row["pnl_open"] == 0.0
         assert row["net_pnl"] == 200.0
         assert row["recovery_needed"] == 0.0
 
@@ -399,6 +394,100 @@ class TestCampaignSummary:
         assert row["realized_pnl"] == -450.0
         assert row["net_pnl"] == -450.0
         assert row["recovery_needed"] == 450.0
+
+    def test_unrealized_uses_mid_minus_avg_open(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        """P&L Open = (mid - avg_open) * qty * mult * dir_sign, not just mid."""
+        sym = CALL_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+                is_open=True,
+                open_entry_symbols=[sym],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        # Short 1x, sold at 2.00, now at 1.50 → profit = (2.00-1.50)*1*1000 = 500
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 1.50,
+                    "average_open_price": 2.00,
+                    "quantity": 1.0,
+                    "multiplier": 1000.0,
+                    "quantity_direction": QuantityDirection.SHORT,
+                }
+            ]
+        )
+        df = reader.campaign_summary
+        row = df.iloc[0]
+        assert row["pnl_open"] == 500.0
+        assert row["net_pnl"] == 500.0
+
+    def test_long_position_unrealized(self, reader: PositionMetricsReader) -> None:
+        sym = PUT_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="0.0",
+                realized_gain_effect="Credit",
+                is_open=True,
+                open_entry_symbols=[sym],
+                open_entry_directions=["Long"],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        # Long 1x, bought at 1.0, now at 3.0 → profit = (3-1)*1*1000 = 2000
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 3.0,
+                    "average_open_price": 1.0,
+                    "quantity": 1.0,
+                    "multiplier": 1000.0,
+                    "quantity_direction": QuantityDirection.LONG,
+                }
+            ]
+        )
+        df = reader.campaign_summary
+        assert df.iloc[0]["pnl_open"] == 2000.0
+
+    def test_net_pnl_combines_realized_and_unrealized(
+        self, reader: PositionMetricsReader
+    ) -> None:
+        sym = CALL_SYMBOL
+        chain = TradeChain.model_validate_json(
+            make_trade_chain_json(
+                realized_gain="300.0",
+                realized_gain_effect="Debit",
+                is_open=True,
+                open_entry_symbols=[sym],
+                open_entry_directions=["Long"],
+            )
+        )
+        reader.trade_chains = {chain.id: chain}
+        # Long: (5-3)*1*100 = 200 unrealized
+        reader.position_metrics_df = make_position_df(
+            [
+                {
+                    "symbol": sym,
+                    "mid_price": 5.0,
+                    "average_open_price": 3.0,
+                    "quantity": 1.0,
+                    "multiplier": 100.0,
+                    "quantity_direction": QuantityDirection.LONG,
+                }
+            ]
+        )
+        df = reader.campaign_summary
+        row = df.iloc[0]
+        assert row["realized_pnl"] == -300.0
+        assert row["pnl_open"] == 200.0
+        assert row["net_pnl"] == -100.0
+        assert row["recovery_needed"] == 100.0
 
     def test_multiple_chains_same_underlying_aggregates(
         self, reader: PositionMetricsReader
@@ -433,130 +522,10 @@ class TestCampaignSummary:
         assert row["chains"] == 2
         assert row["total_rolls"] == 2
         assert row["realized_pnl"] == -150.0
-        assert row["total_fees"] == 8.0
 
-    def test_multiple_underlyings_grouped(self, reader: PositionMetricsReader) -> None:
-        chain_zb = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                chain_id="zb1",
-                underlying="/ZB",
-                realized_gain="100.0",
-                realized_gain_effect="Credit",
-                is_open=False,
-            )
-        )
-        chain_es = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                chain_id="es1",
-                underlying="/ES",
-                realized_gain="200.0",
-                realized_gain_effect="Debit",
-                is_open=False,
-            )
-        )
-        reader.trade_chains = {chain_zb.id: chain_zb, chain_es.id: chain_es}
-        df = reader.campaign_summary
-        assert len(df) == 2
-        assert set(df["underlying"]) == {"/ES", "/ZB"}
-
-    def test_unrealized_mark_from_positions(
+    def test_missing_position_data_treated_as_zero_unrealized(
         self, reader: PositionMetricsReader
     ) -> None:
-        """Open chain with position data computes unrealized mark."""
-        sym = CALL_SYMBOL
-        chain = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                realized_gain="0.0",
-                realized_gain_effect="Credit",
-                total_fees="5.0",
-                is_open=True,
-                open_entry_symbols=[sym],
-            )
-        )
-        reader.trade_chains = {chain.id: chain}
-        # Short 1x at mid_price=2.50, multiplier=1000 → mark = -2500
-        reader.position_metrics_df = make_position_df(
-            [
-                {
-                    "symbol": sym,
-                    "mid_price": 2.50,
-                    "quantity": 1.0,
-                    "multiplier": 1000.0,
-                    "quantity_direction": QuantityDirection.SHORT,
-                }
-            ]
-        )
-        df = reader.campaign_summary
-        row = df.iloc[0]
-        assert row["unrealized_mark"] == -2500.0
-        assert row["net_pnl"] == -2500.0
-        assert row["recovery_needed"] == 2500.0
-
-    def test_net_pnl_combines_realized_and_unrealized(
-        self, reader: PositionMetricsReader
-    ) -> None:
-        sym = CALL_SYMBOL
-        chain = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                realized_gain="300.0",
-                realized_gain_effect="Debit",
-                total_fees="5.0",
-                is_open=True,
-                open_entry_symbols=[sym],
-            )
-        )
-        reader.trade_chains = {chain.id: chain}
-        # Long 1x at mid_price=5.0, multiplier=100 → mark = +500
-        reader.position_metrics_df = make_position_df(
-            [
-                {
-                    "symbol": sym,
-                    "mid_price": 5.0,
-                    "quantity": 1.0,
-                    "multiplier": 100.0,
-                    "quantity_direction": QuantityDirection.LONG,
-                }
-            ]
-        )
-        df = reader.campaign_summary
-        row = df.iloc[0]
-        assert row["realized_pnl"] == -300.0
-        assert row["unrealized_mark"] == 500.0
-        assert row["net_pnl"] == 200.0
-        assert row["recovery_needed"] == 0.0
-
-    def test_recovery_needed_zero_when_profitable(
-        self, reader: PositionMetricsReader
-    ) -> None:
-        chain = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                realized_gain="500.0",
-                realized_gain_effect="Credit",
-                is_open=False,
-            )
-        )
-        reader.trade_chains = {chain.id: chain}
-        df = reader.campaign_summary
-        assert df.iloc[0]["recovery_needed"] == 0.0
-
-    def test_closed_chains_have_zero_unrealized(
-        self, reader: PositionMetricsReader
-    ) -> None:
-        chain = TradeChain.model_validate_json(
-            make_trade_chain_json(
-                realized_gain="100.0",
-                realized_gain_effect="Debit",
-                is_open=False,
-            )
-        )
-        reader.trade_chains = {chain.id: chain}
-        df = reader.campaign_summary
-        assert df.iloc[0]["unrealized_mark"] == 0.0
-
-    def test_missing_position_data_treated_as_zero_mark(
-        self, reader: PositionMetricsReader
-    ) -> None:
-        """Open chain with no matching position data → unrealized = 0."""
         chain = TradeChain.model_validate_json(
             make_trade_chain_json(
                 realized_gain="50.0",
@@ -567,7 +536,7 @@ class TestCampaignSummary:
         )
         reader.trade_chains = {chain.id: chain}
         df = reader.campaign_summary
-        assert df.iloc[0]["unrealized_mark"] == 0.0
+        assert df.iloc[0]["pnl_open"] == 0.0
         assert df.iloc[0]["net_pnl"] == 50.0
 
 
@@ -718,6 +687,7 @@ class TestCampaignDetail:
                 {
                     "symbol": sym,
                     "mid_price": 3.0,
+                    "average_open_price": 2.0,
                     "quantity": 1.0,
                     "multiplier": 1000.0,
                     "quantity_direction": QuantityDirection.SHORT,
@@ -729,4 +699,5 @@ class TestCampaignDetail:
         assert len(open_legs) == 1
         assert open_legs[0]["symbol"] == sym
         assert open_legs[0]["direction"] == "Short"
-        assert open_legs[0]["mark_value"] == -3000.0
+        # Short: -(3.0 - 2.0) * 1 * 1000 = -1000
+        assert open_legs[0]["pnl_open"] == -1000.0


### PR DESCRIPTION
## Summary
- Fix unrealized P&L calculation to use `(mark - avg_open_price) × qty × multiplier` instead of raw mark value — the original formula was computing total notional position value, not P&L
- Add interactive trade fill timeline explorer (`docs/architecture-map/trade_explorer.html`) for inspecting raw brokerage data
- Add Black-Scholes Day 0 P&L curve with per-leg implied volatility from live Greeks data
- Add time decay projections at 75%, 50%, 25% DTE remaining
- Add `POST /api/refresh` endpoint to devserver for live Redis data reload
- Add futures contract streamer symbols (`/ZBM26:XCBT`, `/6EM26:XCME`, etc.) to default subscriptions
- Clean up `justfile` recipes: remove legacy `positions-strategies`, replace `*args` with documented parameters

## Related Jira Issue
**Jira**: [TT-91](https://mandeng.atlassian.net/browse/TT-91)

## Trade Fill Explorer Features
- Timeline of filled orders grouped by day (Eastern time), one card per order with trade-level credit/debit
- Multi-select orders to compose hockey stick P&L chart at expiration
- Black-Scholes Day 0 theoretical curve using live IV from Greeks data
- Time decay projections (75%, 50%, 25% DTE) as muted intermediate curves
- Current underlying price marker from live futures/equity quotes
- Hover crosshair showing both expiration and Day 0 P&L at any price point
- Max profit/loss markers with muted horizontal lines
- Breakeven points highlighted on zero line
- Draggable split pane with JSON inspector tab for raw Redis object inspection
- Refresh button pulls fresh data from Redis without restart
- Filter by underlying, search by symbol or order ID

## Functional Evidence

### Unrealized P&L Fix
Before (raw mark value — wrong):
```
/ZB: unrealized=4570.31 net=4566.88
```
After (mark minus cost basis — correct):
```
/ZB: pnl_open=1296.88 net=1293.44
```
Verified against brokerage P/L Open for /ZBM6: our formula `(mid - avg_open) × qty × mult × dir_sign` produces values within market timing tolerance of brokerage numbers.

### Campaign View
```
$ just campaign
underlying chains open_chains total_rolls realized_pnl total_fees pnl_open  net_pnl recovery_needed
       /ZB      2           2           0        -3.44      14.04  1296.88  1293.44             0.0
       /RTY      3           1           0          1.7      20.88   2090.0   2091.7             0.0
       SPY      2           1           0        359.0        1.1    343.0    702.0             0.0
```

### Just Recipes
```
$ just --list
    campaign *args           # Campaign P&L: just campaign, just campaign /ZB
    campaign-detail *args    # Roll history: just campaign-detail /ZB
    chains *args             # Trade chains: just chains, just chains /ZB
    options symbol *args     # Option chain: just options SPX (--dte 0,30,45 --strikes --json)
```

### All Tests Pass
```
818 passed, 0 failures
pyright: 0 errors
ruff: all checks passed
```

## Test plan
- [x] Unit tests pass (818/818)
- [x] Pyright strict: 0 errors
- [x] Ruff + pre-commit hooks pass
- [x] Functional: `just campaign` shows corrected P&L for all underlyings
- [x] Functional: `just campaign /ZB` filters correctly
- [x] Functional: `just campaign-detail /ZB` shows roll history
- [x] Functional: Trade explorer loads, multi-select works, BS curve renders
- [x] Functional: Refresh button pulls live Redis data
- [x] Functional: Futures quotes flowing (`/ZBM26:XCBT` bid=112.625)
- [x] Functional: All just recipes tested with examples

[TT-91]: https://mandeng.atlassian.net/browse/TT-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ