### PR TITLE
TT-97: Fix Redis connection health status after reconnection

### DIFF
--- a/src/tastytrade/accounts/orchestrator.py
+++ b/src/tastytrade/accounts/orchestrator.py
@@ -66,6 +66,10 @@ async def update_account_connection_status(
         status["error"] = reason
     await redis_client.hset("tastytrade:account_connection", mapping=status)  # type: ignore[arg-type]
 
+    # Clear stale error field when connection is healthy
+    if not reason:
+        await redis_client.hdel("tastytrade:account_connection", "error")
+
 
 async def consume_positions(
     queue: asyncio.Queue,  # type: ignore[type-arg]

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -74,6 +74,10 @@ async def update_redis_connection_status(
 
     await store.redis.hset("tastytrade:connection", mapping=status)  # type: ignore[arg-type]
 
+    # Clear stale error field when connection is healthy
+    if not reason:
+        await store.redis.hdel("tastytrade:connection", "error")
+
 
 def log_health_status(
     dxlink: DXLinkManager,
@@ -407,6 +411,10 @@ async def _run_subscription_once(
 
         # Get subscription store for Redis status updates
         subscription_store = dxlink.subscription_store
+
+        # Publish healthy connection status to Redis
+        if isinstance(subscription_store, RedisSubscriptionStore):
+            await update_redis_connection_status(subscription_store, state="connected")
 
         # Start failure trigger listener if Redis is available
         failure_listener_task: asyncio.Task | None = None

--- a/unit_tests/accounts/test_account_orchestrator.py
+++ b/unit_tests/accounts/test_account_orchestrator.py
@@ -82,6 +82,24 @@ class TestUpdateAccountConnectionStatus:
         assert mapping["state"] == "disconnected"
         assert "error" not in mapping
 
+    @pytest.mark.asyncio
+    async def test_connected_clears_stale_error_field(self) -> None:
+        """Connected status removes the stale error field from Redis."""
+        mock_redis = AsyncMock()
+        await update_account_connection_status(mock_redis, state="connected")
+        mock_redis.hdel.assert_awaited_once_with(
+            "tastytrade:account_connection", "error"
+        )
+
+    @pytest.mark.asyncio
+    async def test_error_status_does_not_clear_error_field(self) -> None:
+        """Error status preserves the error field."""
+        mock_redis = AsyncMock()
+        await update_account_connection_status(
+            mock_redis, state="error", reason="connection_dropped"
+        )
+        mock_redis.hdel.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # consume_positions

--- a/unit_tests/subscription/test_connection_status.py
+++ b/unit_tests/subscription/test_connection_status.py
@@ -1,0 +1,60 @@
+"""Tests for Redis connection health status updates."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tastytrade.subscription.orchestrator import update_redis_connection_status
+
+
+@pytest.fixture()
+def mock_store() -> MagicMock:
+    store = MagicMock()
+    store.redis = AsyncMock()
+    store.redis.hset = AsyncMock()
+    store.redis.hdel = AsyncMock()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_connected_status_sets_state_and_timestamp(mock_store: MagicMock) -> None:
+    """Setting connected status writes state and timestamp."""
+    await update_redis_connection_status(mock_store, state="connected")
+
+    mock_store.redis.hset.assert_called_once()
+    call_kwargs = mock_store.redis.hset.call_args
+    mapping = call_kwargs.kwargs.get("mapping") or call_kwargs[1]["mapping"]
+    assert mapping["state"] == "connected"
+    assert "timestamp" in mapping
+    assert "error" not in mapping
+
+
+@pytest.mark.asyncio
+async def test_connected_status_clears_error_field(mock_store: MagicMock) -> None:
+    """Setting connected status removes the stale error field from Redis."""
+    await update_redis_connection_status(mock_store, state="connected")
+
+    mock_store.redis.hdel.assert_called_once_with("tastytrade:connection", "error")
+
+
+@pytest.mark.asyncio
+async def test_error_status_sets_error_field(mock_store: MagicMock) -> None:
+    """Setting error status includes the error reason."""
+    await update_redis_connection_status(
+        mock_store, state="error", reason="connection_dropped"
+    )
+
+    call_kwargs = mock_store.redis.hset.call_args
+    mapping = call_kwargs.kwargs.get("mapping") or call_kwargs[1]["mapping"]
+    assert mapping["state"] == "error"
+    assert mapping["error"] == "connection_dropped"
+
+
+@pytest.mark.asyncio
+async def test_error_status_does_not_clear_error_field(mock_store: MagicMock) -> None:
+    """Setting error status does not call hdel since reason is provided."""
+    await update_redis_connection_status(
+        mock_store, state="error", reason="auth_expired"
+    )
+
+    mock_store.redis.hdel.assert_not_called()


### PR DESCRIPTION
## Summary
- Fix `update_redis_connection_status()` to clear the stale `error` field from the `tastytrade:connection` HSET when the connection is healthy
- Publish `state: connected` to Redis after the subscription orchestrator successfully establishes or re-establishes a connection
- Add 4 unit tests covering connected/error status transitions and error field lifecycle

## Bug
After a successful reconnection, `tastytrade:connection` remained stuck at `state: error` indefinitely because:
1. `update_redis_connection_status()` was only called to set `error` state on connection drop — never called with `connected` after recovery
2. `hset(mapping=...)` only sets fields, never removes them — so the old `error` field persisted even if `state` was updated

**Jira:** [TT-97](https://mandeng.atlassian.net/browse/TT-97)

## Functional Evidence

**Before fix:** Connection drops at 09:26 UTC → orchestrator reconnects at 09:26:29 → Redis HSET stays `state: error` for 12+ hours while data actively flows on all channels (76 messages in 3 seconds confirmed via `market:*` pub/sub).

**After fix:** `update_redis_connection_status(store, state="connected")` is called immediately after the subscription goes active. The `hdel` call removes any stale `error` field. On next connection drop, `state: error` is set as before.

## Test plan
- [x] 4 new tests in `test_connection_status.py` (connected status write, error field cleanup, error status write, error field persistence)
- [x] All 80 subscription tests pass
- [x] pyright clean (0 errors)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

[TT-97]: https://mandeng.atlassian.net/browse/TT-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ