### PR TITLE
TT-98: Replace Redis Commander with RedisInsight

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ VS Code will build and start the development container, which includes:
 - Telegraf
 - Kafka
 - Redis
-- Redis-Commander
+- RedisInsight
 - All required Python packages
 - Pre-configured development tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,18 @@ services:
     networks:
       - internal_net
 
+  redisinsight:
+    image: redis/redisinsight:latest
+    container_name: redisinsight
+    labels:
+      - "traefik.enable=false"
+    ports:
+      - "5540:5540"
+    depends_on:
+      - redis
+    networks:
+      - internal_net
+
   grafana:
     image: grafana/grafana:latest
     container_name: grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,22 +60,6 @@ services:
       timeout: 5s
       retries: 3
 
-  redis-commander:
-    image: rediscommander/redis-commander:latest
-    container_name: redis-commander
-    labels:
-      - "traefik.enable=false"
-    environment:
-      - REDIS_HOSTS=local:redis:6379
-      - HTTP_USER=admin
-      - HTTP_PASSWORD=adminpassword
-    ports:
-      - "8081:8081"
-    depends_on:
-      - redis
-    networks:
-      - internal_net
-
   redisinsight:
     image: redis/redisinsight:latest
     container_name: redisinsight


### PR DESCRIPTION
## Summary

Replaces Redis Commander with RedisInsight in the Docker Compose stack. RedisInsight is Redis's official GUI tool and covers all Redis Commander functionality while adding pub/sub monitoring, built-in CLI, memory analysis, and slowlog analysis. This is an infrastructure-only change affecting docker-compose.yml and README.

## Related Jira Issue

**Jira**: [TT-98](https://mandeng.atlassian.net/browse/TT-98)

## Acceptance Criteria - Functional Evidence

### AC1: RedisInsight container added to Docker Compose stack

The redisinsight service is defined in docker-compose.yml using the official redis/redisinsight:latest image. It connects to Redis via Docker DNS on the internal_net network, exposes port 5540, and depends on the redis service.

```yaml
redisinsight:
  image: redis/redisinsight:latest
  container_name: redisinsight
  labels:
    - "traefik.enable=false"
  ports:
    - "5540:5540"
  depends_on:
    - redis
  networks:
    - internal_net
```

**Results:**
- Container uses official Redis image (redis/redisinsight:latest)
- Accessible on host port 5540
- Connected to internal_net Docker network for Redis DNS resolution
- No hardcoded credentials required (RedisInsight handles connection setup via its UI)

---

### AC2: Redis Commander removed from Docker Compose stack

The redis-commander service block has been fully removed from docker-compose.yml, including its image reference, environment variables (REDIS_HOSTS, HTTP_USER, HTTP_PASSWORD), port mapping (8081), and network configuration.

**Results:**
- redis-commander service definition completely removed
- No references to rediscommander/redis-commander image remain
- Hardcoded credentials (HTTP_USER=admin, HTTP_PASSWORD=adminpassword) eliminated
- Port 8081 freed up

---

### AC3: README updated to reference RedisInsight

The README dev container service list now references RedisInsight instead of Redis-Commander, keeping documentation in sync with the actual stack.

**Results:**
- README.md line updated from `- Redis-Commander` to `- RedisInsight`
- Documentation accurately reflects the running services

---

## Test Evidence

- This is an infrastructure-only change (docker-compose.yml + README.md) -- no Python code was modified
- No unit tests, type checking, or linting are affected
- Verification: `docker compose config` validates the compose file syntax
- Post-merge verification: `docker compose up -d redisinsight` and access at `http://localhost:5540`

## Changes Made

- **docker-compose.yml**: Replaced redis-commander service with redisinsight service (redis/redisinsight:latest on port 5540, no hardcoded credentials)
- **README.md**: Updated dev container service list to reference RedisInsight instead of Redis-Commander

[TT-98]: https://mandeng.atlassian.net/browse/TT-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ