### PR TITLE
TT-94: Add live charting module with TOS-style interactive charts

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,3 +75,17 @@ backfill:
 # Option chain: just options SPX, just options /GC --dte 0,30,45 --strikes
 options symbol *args:
     uv run tasty-subscription options --symbol "{{symbol}}" {{args}}
+
+# --- Charting ---
+
+# Live chart: just chart, just chart SPY, just chart BTC/USD:CXTALP 8092
+chart symbol="SPX" port="8091" interval="m":
+    uv run tasty-chart --symbol "{{symbol}}" --interval {{interval}} --port {{port}}
+
+# List running chart servers
+chart-list:
+    @lsof -iTCP -sTCP:LISTEN -P 2>/dev/null | grep tasty-cha | awk '{split($9,a,":"); print "  port=" a[2] "  pid=" $2}' || echo "  No chart servers running"
+
+# Kill chart server on a port: just chart-kill 8091
+chart-kill port:
+    @kill $(lsof -t -i :{{port}} 2>/dev/null) 2>/dev/null && echo "Stopped chart server on :{{port}}" || echo "No process on :{{port}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ api = "tastytrade.api.main:start"
 tasty-subscription = "tastytrade.subscription.cli:main"
 tasty-signal = "tastytrade.signal.cli:main"
 tasty-backtest = "tastytrade.backtest.cli:main"
+tasty-chart = "tastytrade.charting.cli:main"
 
 # Note: 'uv sync' includes dev group by default. Use 'uv sync --no-dev' for production-only installs.
 [dependency-groups]
@@ -65,6 +66,7 @@ dev = [
     "jupyterlab>=4.4.5",
     "mypy>=1.17.0",
     "pandas-stubs>=2.3.0.250703",
+    "playwright>=1.58.0",
     "pre-commit>=4.2.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.1.0",

--- a/src/tastytrade/charting/__init__.py
+++ b/src/tastytrade/charting/__init__.py
@@ -1,0 +1,16 @@
+"""Live charting module — TOS-style interactive charts with real-time updates.
+
+Standalone component that composes existing SDK infrastructure:
+- InfluxDB for historical candle data (MarketDataProvider)
+- Redis pub/sub for live candle + annotation events
+- Hull MA and MACD indicator computation
+
+Usage:
+    # CLI
+    tasty-chart --symbol SPX --interval 5m
+
+    # Library
+    from tastytrade.charting.server import ChartServer
+    server = ChartServer(symbol="SPX", interval="1m")
+    await server.start(port=8080)
+"""

--- a/src/tastytrade/charting/cli.py
+++ b/src/tastytrade/charting/cli.py
@@ -1,0 +1,42 @@
+"""CLI entry point for tasty-chart.
+
+Thin wrapper over ChartServer — parses args and starts the server.
+"""
+
+import asyncio
+import logging
+
+import click
+
+from tastytrade.common.logging import setup_logging
+
+
+@click.command()
+@click.option("--symbol", default="SPX", help="Market symbol (e.g., SPX, AAPL, /ESM5)")
+@click.option("--interval", default="m", help="Candle interval (m, 5m, 15m, 1h)")
+@click.option("--port", default=8080, type=int, help="Server port")
+@click.option("--debug", is_flag=True, help="Enable debug logging")
+def main(
+    symbol: str,
+    interval: str,
+    port: int,
+    debug: bool,
+) -> None:
+    """Start a live chart server for a market symbol."""
+    setup_logging(level=logging.DEBUG if debug else logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    logger.info("Starting tasty-chart: %s %s on port %d", symbol, interval, port)
+
+    from tastytrade.charting.server import ChartServer
+
+    server = ChartServer(
+        symbol=symbol,
+        interval=interval,
+        port=port,
+    )
+    asyncio.run(server.start())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tastytrade/charting/cli.py
+++ b/src/tastytrade/charting/cli.py
@@ -26,9 +26,11 @@ def main(
     setup_logging(level=logging.DEBUG if debug else logging.INFO)
     logger = logging.getLogger(__name__)
 
-    logger.info("Starting tasty-chart: %s %s on port %d", symbol, interval, port)
-
     from tastytrade.charting.server import ChartServer
+
+    url = f"http://localhost:{port}/?symbol={symbol}&interval={interval}"
+    logger.info("Starting tasty-chart: %s %s on port %d", symbol, interval, port)
+    click.echo(f"\n  tasty-chart → {url}\n")
 
     server = ChartServer(
         symbol=symbol,

--- a/src/tastytrade/charting/feed.py
+++ b/src/tastytrade/charting/feed.py
@@ -1,0 +1,75 @@
+"""Redis pub/sub feed for the charting module.
+
+Subscribes to candle events and horizontal line annotations,
+yielding typed events via async iteration.
+"""
+
+import json
+import logging
+from collections.abc import AsyncIterator
+
+import redis.asyncio as aioredis
+from redis.asyncio.client import PubSub
+
+from tastytrade.config.manager import ConfigurationManager
+
+logger = logging.getLogger(__name__)
+
+
+class ChartFeed:
+    """Subscribes to Redis channels for live chart data.
+
+    Channels:
+        market:CandleEvent:{candle_symbol}   — live candle updates
+        market:HorizontalLine:{symbol}       — level annotations as they lock in
+    """
+
+    def __init__(self, config: ConfigurationManager) -> None:
+        redis_url = config.get("REDIS_URL", "redis://localhost:6379")
+        self.redis = aioredis.from_url(redis_url, decode_responses=True)
+        self.pubsub: PubSub | None = None
+
+    async def listen(
+        self, symbol: str, candle_symbol: str
+    ) -> AsyncIterator[tuple[str, dict]]:
+        """Subscribe and yield (event_type, data) tuples.
+
+        event_type is either "candle" or "level".
+        """
+        candle_channel = f"market:CandleEvent:{candle_symbol}"
+        level_channel = f"market:HorizontalLine:{symbol}"
+
+        ps = self.redis.pubsub()
+        self.pubsub = ps
+        await ps.subscribe(candle_channel, level_channel)
+
+        logger.info("Subscribed to Redis: %s, %s", candle_channel, level_channel)
+
+        async for message in ps.listen():
+            if message["type"] != "message":
+                continue
+
+            channel = message["channel"]
+            try:
+                data = json.loads(message["data"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Invalid JSON on channel %s", channel)
+                continue
+
+            if channel == candle_channel:
+                yield ("candle", data)
+            elif channel == level_channel:
+                yield ("level", data)
+
+    async def close(self) -> None:
+        """Unsubscribe and close Redis connection."""
+        if self.pubsub:
+            try:
+                await self.pubsub.unsubscribe()
+                await self.pubsub.close()
+            except Exception:
+                pass
+        try:
+            await self.redis.close()
+        except Exception:
+            pass

--- a/src/tastytrade/charting/indicators.py
+++ b/src/tastytrade/charting/indicators.py
@@ -1,0 +1,284 @@
+"""Streaming-aware indicator wrappers for Hull MA and MACD.
+
+Wraps the batch functions in analytics/indicators/momentum.py with
+incremental state so each new candle produces one new indicator point
+without recomputing the entire series.
+
+The batch functions are used to seed initial state from historical data.
+After that, each candle update calls the streaming methods.
+"""
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import numpy as np
+import polars as pl
+
+from tastytrade.analytics.indicators.momentum import (
+    ema_with_seed,
+    hull,
+    macd,
+    padded_wma,
+)
+
+
+@dataclass
+class HullState:
+    """Rolling state for incremental Hull Moving Average computation."""
+
+    length: int = 20
+    half_length: int = 0
+    sqrt_length: int = 0
+    pad_value: float = 0.0
+
+    # Rolling windows for the three WMAs
+    wma_half_window: list[float] = field(default_factory=list)
+    wma_full_window: list[float] = field(default_factory=list)
+    wma_sqrt_window: list[float] = field(default_factory=list)
+
+    prev_hma: float | None = None
+
+    def __post_init__(self) -> None:
+        self.half_length = round(self.length / 2)
+        self.sqrt_length = round(math.sqrt(self.length))
+
+
+@dataclass
+class MacdState:
+    """Rolling state for incremental MACD computation."""
+
+    fast_length: int = 12
+    slow_length: int = 26
+    macd_length: int = 9
+
+    fast_ema: float = 0.0
+    slow_ema: float = 0.0
+    signal_ema: float = 0.0
+    prev_histogram: float = 0.0
+
+
+def compute_wma(window: list[float], period: int) -> float:
+    """Compute weighted moving average for a single window."""
+    weights = np.arange(1, period + 1, dtype=float)
+    arr = np.array(window[-period:], dtype=float)
+    if len(arr) < period:
+        pad = np.full(period - len(arr), window[0] if window else 0.0)
+        arr = np.concatenate((pad, arr))
+    return float(np.dot(arr, weights) / weights.sum())
+
+
+class StreamingIndicators:
+    """Computes Hull MA and MACD incrementally from a candle stream.
+
+    Usage:
+        indicators = StreamingIndicators()
+        initial = indicators.seed(historical_df, prior_close)
+        # initial contains full series for chart backfill
+
+        # Then for each live candle:
+        point = indicators.update(close_price, candle_time)
+        # point contains one HMA + MACD data point
+    """
+
+    def __init__(
+        self,
+        hull_length: int = 20,
+        macd_fast: int = 12,
+        macd_slow: int = 26,
+        macd_signal: int = 9,
+    ) -> None:
+        self.hull_length = hull_length
+        self.macd_fast = macd_fast
+        self.macd_slow = macd_slow
+        self.macd_signal = macd_signal
+
+        self.hull_state: HullState | None = None
+        self.macd_state: MacdState | None = None
+        self.seeded = False
+
+    def seed(
+        self,
+        df: pl.DataFrame,
+        prior_close: float | None = None,
+    ) -> dict:
+        """Seed indicators from historical candle data.
+
+        Returns the full computed series as lists for chart backfill.
+        Also initializes rolling state for subsequent update() calls.
+        """
+        if df.is_empty():
+            return {"hma": [], "macd": []}
+
+        pad = prior_close if prior_close is not None else float(df["close"][0])
+
+        # Compute full Hull series
+        hull_df = hull(df, length=self.hull_length, pad_value=pad)
+
+        # Compute full MACD series
+        macd_df = macd(
+            df,
+            prior_close=prior_close,
+            fast_length=self.macd_fast,
+            slow_length=self.macd_slow,
+            macd_length=self.macd_signal,
+        )
+
+        # Initialize Hull rolling state from the tail of the data
+        close_values = df["close"].to_list()
+        self.hull_state = HullState(
+            length=self.hull_length,
+            pad_value=pad,
+        )
+        # Keep enough history for the largest window
+        max_window = max(
+            self.hull_length,
+            self.hull_state.half_length,
+            self.hull_state.sqrt_length,
+        )
+        self.hull_state.wma_full_window = close_values[-max_window:]
+        self.hull_state.wma_half_window = close_values[-max_window:]
+
+        # Recompute the diff series tail for the sqrt WMA window
+        half_len = self.hull_state.half_length
+        full_len = self.hull_length
+        sqrt_len = self.hull_state.sqrt_length
+        tail = (
+            close_values[-(max_window + sqrt_len) :]
+            if len(close_values) > max_window + sqrt_len
+            else close_values
+        )
+        tail_np = np.array(tail, dtype=float)
+        wma_h = padded_wma(tail_np, half_len, pad)
+        wma_f = padded_wma(tail_np, full_len, pad)
+        diff_series = 2 * wma_h - wma_f
+        self.hull_state.wma_sqrt_window = diff_series[-sqrt_len:].tolist()
+
+        # Store last HMA for color determination
+        hma_values = hull_df["HMA"].to_list()
+        self.hull_state.prev_hma = hma_values[-1] if hma_values else pad
+
+        # Initialize MACD rolling state from the tail
+        self.macd_state = MacdState(
+            fast_length=self.macd_fast,
+            slow_length=self.macd_slow,
+            macd_length=self.macd_signal,
+        )
+
+        # Recompute EMA state by running through all values
+        close_np = df["close"].to_numpy().astype(float)
+        seed_val = prior_close if prior_close is not None else float(close_np[0])
+        fast_ema = ema_with_seed(close_np, self.macd_fast, seed_val)
+        slow_ema = ema_with_seed(close_np, self.macd_slow, seed_val)
+        value_line = fast_ema - slow_ema
+        signal_line = ema_with_seed(value_line, self.macd_signal, 0.0)
+        histogram = value_line - signal_line
+
+        self.macd_state.fast_ema = float(fast_ema[-1])
+        self.macd_state.slow_ema = float(slow_ema[-1])
+        self.macd_state.signal_ema = float(signal_line[-1])
+        self.macd_state.prev_histogram = float(histogram[-1])
+
+        self.seeded = True
+
+        # Build response series
+        # InfluxDB returns naive UTC datetimes — must mark as UTC before .timestamp()
+        def to_utc_epoch(t: datetime) -> int:
+            if t.tzinfo is None:
+                return int(t.replace(tzinfo=timezone.utc).timestamp())
+            return int(t.timestamp())
+
+        hma_series = []
+        for i in range(hull_df.height):
+            hma_series.append(
+                {
+                    "time": to_utc_epoch(hull_df["time"][i]),
+                    "value": round(float(hull_df["HMA"][i]), 4),
+                    "color": "#01ffff"
+                    if hull_df["HMA_color"][i] == "Up"
+                    else "#ff66fe",
+                }
+            )
+
+        macd_series = []
+        for i in range(macd_df.height):
+            t = to_utc_epoch(macd_df["time"][i])
+            macd_series.append(
+                {
+                    "time": t,
+                    "value": round(float(macd_df["Value"][i]), 6),
+                    "signal": round(float(macd_df["avg"][i]), 6),
+                    "histogram": round(float(macd_df["diff"][i]), 6),
+                    "histogramColor": str(macd_df["diff_color"][i]),
+                }
+            )
+
+        return {"hma": hma_series, "macd": macd_series}
+
+    def update(self, close: float, time_epoch: int) -> dict | None:
+        """Process one new candle close and return indicator deltas.
+
+        Returns None if not yet seeded.
+        """
+        if not self.seeded or self.hull_state is None or self.macd_state is None:
+            return None
+
+        # --- Hull MA update ---
+        hs = self.hull_state
+
+        # Update the close windows
+        hs.wma_full_window.append(close)
+        hs.wma_half_window.append(close)
+        # Trim to max needed size
+        max_keep = max(hs.length, hs.half_length) + 10
+        if len(hs.wma_full_window) > max_keep:
+            hs.wma_full_window = hs.wma_full_window[-max_keep:]
+            hs.wma_half_window = hs.wma_half_window[-max_keep:]
+
+        # Compute current WMAs
+        wma_half = compute_wma(hs.wma_half_window, hs.half_length)
+        wma_full = compute_wma(hs.wma_full_window, hs.length)
+        diff_val = 2 * wma_half - wma_full
+
+        # Update sqrt window
+        hs.wma_sqrt_window.append(diff_val)
+        if len(hs.wma_sqrt_window) > hs.sqrt_length + 5:
+            hs.wma_sqrt_window = hs.wma_sqrt_window[-(hs.sqrt_length + 5) :]
+
+        hma_val = compute_wma(hs.wma_sqrt_window, hs.sqrt_length)
+        hma_color = "#01ffff" if hma_val > (hs.prev_hma or 0) else "#ff66fe"
+        hs.prev_hma = hma_val
+
+        # --- MACD update ---
+        ms = self.macd_state
+        fast_alpha = 2.0 / (ms.fast_length + 1.0)
+        slow_alpha = 2.0 / (ms.slow_length + 1.0)
+        signal_alpha = 2.0 / (ms.macd_length + 1.0)
+
+        ms.fast_ema = fast_alpha * close + (1 - fast_alpha) * ms.fast_ema
+        ms.slow_ema = slow_alpha * close + (1 - slow_alpha) * ms.slow_ema
+        macd_value = ms.fast_ema - ms.slow_ema
+        ms.signal_ema = signal_alpha * macd_value + (1 - signal_alpha) * ms.signal_ema
+        histogram = macd_value - ms.signal_ema
+
+        # 4-shade histogram color
+        if histogram > 0:
+            hist_color = "#04FE00" if histogram > ms.prev_histogram else "#006401"
+        else:
+            hist_color = "#FE0000" if histogram < ms.prev_histogram else "#7E0100"
+        ms.prev_histogram = histogram
+
+        return {
+            "hma": {
+                "time": time_epoch,
+                "value": round(hma_val, 4),
+                "color": hma_color,
+            },
+            "macd": {
+                "time": time_epoch,
+                "value": round(macd_value, 6),
+                "signal": round(ms.signal_ema, 6),
+                "histogram": round(histogram, 6),
+                "histogramColor": hist_color,
+            },
+        }

--- a/src/tastytrade/charting/server.py
+++ b/src/tastytrade/charting/server.py
@@ -84,7 +84,12 @@ def build_candle_payload(df: pl.DataFrame) -> list[dict[str, Any]]:
 
 
 def find_last_trading_day(from_date: date_type, max_lookback: int = 7) -> date_type:
-    """Walk backwards from from_date to find the last weekday."""
+    """Walk backwards from from_date to find the last weekday.
+
+    Used only for prior day candle lookups (equities don't have daily
+    candles on weekends). For the chart date itself, use
+    find_date_with_data() which tries today first (works for crypto/futures).
+    """
     d = from_date
     for _ in range(max_lookback):
         if d.weekday() < 5:  # Mon-Fri
@@ -170,14 +175,16 @@ class ChartServer:
 
         candle_symbol = f"{symbol}{{={interval}}}"
 
-        # Determine which trading day to display
+        # Determine which trading day to display.
+        # Try the requested date (or today) first. If no data, walk back up to 5 days.
+        # This handles crypto (24/7), Sunday evening futures, and weekday equities.
         if chart_date:
             try:
                 target_date = date_type.fromisoformat(chart_date)
             except ValueError:
-                target_date = find_last_trading_day(date_type.today())
+                target_date = date_type.today()
         else:
-            target_date = find_last_trading_day(date_type.today())
+            target_date = date_type.today()
 
         prior_date = find_last_trading_day(target_date - timedelta(days=1))
 
@@ -190,37 +197,39 @@ class ChartServer:
         )
 
         # --- Fetch single day of candles (ET day boundaries) ---
-        # Convert ET day to UTC range so InfluxDB returns one ET calendar day
-        et_start = datetime(
-            target_date.year,
-            target_date.month,
-            target_date.day,
-            tzinfo=ET,
-        )
-        et_stop = et_start + timedelta(days=1)
-        # Convert to naive UTC for InfluxDB query (MarketDataProvider expects naive UTC)
-        utc_start = et_start.astimezone(timezone.utc).replace(tzinfo=None)
-        utc_stop = et_stop.astimezone(timezone.utc).replace(tzinfo=None)
+        # Try the target date. If no data, walk back up to 5 days.
+        hist_df = None
+        for attempt in range(6):
+            d = target_date - timedelta(days=attempt)
+            et_start = datetime(d.year, d.month, d.day, tzinfo=ET)
+            et_stop = et_start + timedelta(days=1)
+            utc_start = et_start.astimezone(timezone.utc).replace(tzinfo=None)
+            utc_stop = et_stop.astimezone(timezone.utc).replace(tzinfo=None)
 
-        logger.info(
-            "Downloading: symbol=%r ET=%s UTC=%s..%s",
-            candle_symbol,
-            target_date,
-            utc_start,
-            utc_stop,
-        )
-        hist_df = provider.download(
-            symbol=candle_symbol,
-            start=utc_start,
-            stop=utc_stop,
-            debug_mode=True,
-        )
+            logger.info(
+                "Trying: symbol=%r ET=%s UTC=%s..%s",
+                candle_symbol,
+                d,
+                utc_start,
+                utc_stop,
+            )
+            hist_df = provider.download(
+                symbol=candle_symbol,
+                start=utc_start,
+                stop=utc_stop,
+                debug_mode=True,
+            )
+            if hist_df is not None and not hist_df.is_empty():
+                target_date = d
+                prior_date = find_last_trading_day(d - timedelta(days=1))
+                break
+            hist_df = None
 
-        if hist_df is None or hist_df.is_empty():
+        if hist_df is None:
             await ws.send_json(
                 {
                     "type": "error",
-                    "message": f"No data for {candle_symbol} on {target_date}",
+                    "message": f"No data for {candle_symbol} in the last 6 days",
                 }
             )
             influx_client.close()
@@ -309,8 +318,17 @@ class ChartServer:
         symbol: str,
         interval: str,
     ) -> None:
-        """Subscribe to Redis and stream deltas to the WebSocket client."""
+        """Subscribe to Redis and stream deltas to the WebSocket client.
+
+        DXLink sends multiple events per candle period (every tick updates
+        the current candle's OHLC).  Indicators must only advance once per
+        period — when a NEW candle timestamp appears — using the final close
+        of the *previous* candle.  Otherwise HMA windows fill with duplicate
+        values and MACD EMAs are over-updated, causing both to diverge.
+        """
         candle_symbol = f"{symbol}{{={interval}}}"
+        prev_candle_epoch: int = 0
+        prev_candle_close: float = 0.0
 
         async for event_type, event in feed.listen(symbol, candle_symbol):
             if event_type == "candle":
@@ -334,12 +352,21 @@ class ChartServer:
                     "close": round(close, 4),
                 }
 
-                indicator_point = indicators.update(close, et_epoch)
-
                 delta: dict[str, Any] = {"type": "update", "candle": candle_msg}
-                if indicator_point:
-                    delta["hma"] = indicator_point["hma"]
-                    delta["macd"] = indicator_point["macd"]
+
+                # Only advance indicators when a new candle period starts.
+                # Use the final close of the *previous* candle for accuracy.
+                if prev_candle_epoch != 0 and et_epoch != prev_candle_epoch:
+                    indicator_point = indicators.update(
+                        prev_candle_close,
+                        prev_candle_epoch,
+                    )
+                    if indicator_point:
+                        delta["hma"] = indicator_point["hma"]
+                        delta["macd"] = indicator_point["macd"]
+
+                prev_candle_epoch = et_epoch
+                prev_candle_close = close
 
                 await ws.send_text(json.dumps(delta))
 

--- a/src/tastytrade/charting/server.py
+++ b/src/tastytrade/charting/server.py
@@ -1,0 +1,362 @@
+"""HTTP + WebSocket server for live charting.
+
+Thin data pass-through: queries InfluxDB for history, bridges Redis
+pub/sub events to the browser via WebSocket. Does not compute levels
+or write back to any data store.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import uvicorn
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from influxdb_client import InfluxDBClient
+
+from tastytrade.charting.feed import ChartFeed
+from tastytrade.charting.indicators import StreamingIndicators
+from tastytrade.config.manager import RedisConfigManager
+from tastytrade.providers.market import MarketDataProvider
+from tastytrade.providers.subscriptions import RedisSubscription
+
+logger = logging.getLogger(__name__)
+
+STATIC_DIR = Path(__file__).parent / "static"
+ET = ZoneInfo("America/New_York")
+
+
+def utc_epoch_to_et_epoch(utc_epoch: int) -> int:
+    """Convert a UTC epoch to an ET-shifted epoch for lightweight-charts display.
+
+    lightweight-charts always displays timestamps as-is (no timezone support).
+    To show ET times, we shift the epoch by the ET offset so the displayed
+    time matches Eastern Time.
+    """
+    utc_dt = datetime.fromtimestamp(utc_epoch, tz=timezone.utc)
+    et_dt = utc_dt.astimezone(ET)
+    # Get the UTC offset in seconds and add it to the epoch
+    offset_seconds = int(et_dt.utcoffset().total_seconds())  # type: ignore[union-attr]
+    return utc_epoch + offset_seconds
+
+
+def naive_utc_to_epoch(t: datetime) -> int:
+    """Convert a naive UTC datetime (from InfluxDB) to a proper UTC epoch.
+
+    InfluxDB returns naive datetimes that are in UTC. Python's .timestamp()
+    treats naive datetimes as LOCAL time, which is wrong when the server
+    runs in a non-UTC timezone (e.g., EDT). This function explicitly treats
+    the naive datetime as UTC.
+    """
+    if t.tzinfo is None:
+        return int(t.replace(tzinfo=timezone.utc).timestamp())
+    return int(t.timestamp())
+
+
+def build_candle_payload(df: pl.DataFrame) -> list[dict[str, Any]]:
+    """Convert a Polars candle DataFrame to lightweight-charts format with ET times."""
+    candles = []
+    for row in df.iter_rows(named=True):
+        t = row.get("time")
+        if t is None:
+            continue
+        if row.get("close") is None or row.get("close") == 0:
+            continue
+        utc_epoch = naive_utc_to_epoch(t) if isinstance(t, datetime) else int(t)
+        et_epoch = utc_epoch_to_et_epoch(utc_epoch)
+        candles.append(
+            {
+                "time": et_epoch,
+                "open": round(float(row.get("open", 0)), 4),
+                "high": round(float(row.get("high", 0)), 4),
+                "low": round(float(row.get("low", 0)), 4),
+                "close": round(float(row.get("close", 0)), 4),
+            }
+        )
+    return candles
+
+
+def find_last_trading_day(from_date: date_type, max_lookback: int = 7) -> date_type:
+    """Walk backwards from from_date to find the last weekday."""
+    d = from_date
+    for _ in range(max_lookback):
+        if d.weekday() < 5:  # Mon-Fri
+            return d
+        d -= timedelta(days=1)
+    return from_date
+
+
+class ChartServer:
+    """Live chart server combining InfluxDB history with Redis live feed."""
+
+    def __init__(
+        self,
+        symbol: str = "SPX",
+        interval: str = "m",
+        host: str = "0.0.0.0",
+        port: int = 8080,
+    ) -> None:
+        self.symbol = symbol
+        self.interval = interval
+        self.host = host
+        self.port = port
+        self.app = self.create_app()
+
+    def create_app(self) -> FastAPI:
+        app = FastAPI(title="tasty-chart")
+
+        @app.get("/")
+        async def index() -> FileResponse:
+            return FileResponse(
+                STATIC_DIR / "index.html",
+                headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+            )
+
+        @app.get("/api/config")
+        async def config() -> dict:
+            return {"symbol": self.symbol, "interval": self.interval}
+
+        @app.websocket("/ws")
+        async def websocket_endpoint(ws: WebSocket) -> None:
+            await ws.accept(subprotocol=None)
+            symbol = ws.query_params.get("symbol", self.symbol)
+            interval = ws.query_params.get("interval", self.interval)
+            chart_date = ws.query_params.get("date")
+
+            try:
+                await self.handle_chart_session(ws, symbol, interval, chart_date)
+            except WebSocketDisconnect:
+                logger.info("Chart client disconnected for %s", symbol)
+            except Exception:
+                logger.exception("Chart session error for %s", symbol)
+                try:
+                    await ws.close(code=1011)
+                except Exception:
+                    pass
+
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+        return app
+
+    async def handle_chart_session(
+        self,
+        ws: WebSocket,
+        symbol: str,
+        interval: str,
+        chart_date: str | None = None,
+    ) -> None:
+        """Handle a single chart WebSocket session."""
+        config = RedisConfigManager()
+
+        influx_url = config.get("INFLUX_DB_URL", "http://localhost:8086")
+        influx_token = config.get("INFLUX_DB_TOKEN")
+        influx_org = config.get("INFLUX_DB_ORG")
+
+        if not influx_token or not influx_org:
+            await ws.send_json({"type": "error", "message": "InfluxDB not configured"})
+            return
+
+        influx_client = InfluxDBClient(
+            url=influx_url, token=influx_token, org=influx_org
+        )
+        data_sub = RedisSubscription(config)
+        provider = MarketDataProvider(data_feed=data_sub, influx=influx_client)
+
+        candle_symbol = f"{symbol}{{={interval}}}"
+
+        # Determine which trading day to display
+        if chart_date:
+            try:
+                target_date = date_type.fromisoformat(chart_date)
+            except ValueError:
+                target_date = find_last_trading_day(date_type.today())
+        else:
+            target_date = find_last_trading_day(date_type.today())
+
+        prior_date = find_last_trading_day(target_date - timedelta(days=1))
+
+        logger.info(
+            "Chart session: symbol=%r candle=%r date=%s prior=%s",
+            symbol,
+            candle_symbol,
+            target_date,
+            prior_date,
+        )
+
+        # --- Fetch single day of candles (ET day boundaries) ---
+        # Convert ET day to UTC range so InfluxDB returns one ET calendar day
+        et_start = datetime(
+            target_date.year,
+            target_date.month,
+            target_date.day,
+            tzinfo=ET,
+        )
+        et_stop = et_start + timedelta(days=1)
+        # Convert to naive UTC for InfluxDB query (MarketDataProvider expects naive UTC)
+        utc_start = et_start.astimezone(timezone.utc).replace(tzinfo=None)
+        utc_stop = et_stop.astimezone(timezone.utc).replace(tzinfo=None)
+
+        logger.info(
+            "Downloading: symbol=%r ET=%s UTC=%s..%s",
+            candle_symbol,
+            target_date,
+            utc_start,
+            utc_stop,
+        )
+        hist_df = provider.download(
+            symbol=candle_symbol,
+            start=utc_start,
+            stop=utc_stop,
+            debug_mode=True,
+        )
+
+        if hist_df is None or hist_df.is_empty():
+            await ws.send_json(
+                {
+                    "type": "error",
+                    "message": f"No data for {candle_symbol} on {target_date}",
+                }
+            )
+            influx_client.close()
+            return
+
+        # Filter zero-price rows
+        before_count = hist_df.height
+        hist_df = hist_df.filter(
+            (pl.col("close").is_not_null()) & (pl.col("close") != 0)
+        ).sort("time")
+        removed = before_count - hist_df.height
+        if removed > 0:
+            logger.info(
+                "Removed %d zero-price rows from %d total", removed, before_count
+            )
+
+        # --- Prior day candle for levels + indicator seeding ---
+        prior_close: float | None = None
+        daily_candle: dict[str, float | None] | None = None
+        try:
+            prior_day = provider.get_daily_candle(symbol, prior_date)
+            prior_close = float(prior_day.close) if prior_day.close else None
+            daily_candle = {
+                "close": prior_close,
+                "high": float(prior_day.high) if prior_day.high else None,
+                "low": float(prior_day.low) if prior_day.low else None,
+            }
+            logger.info("Prior day close for %s: %s", symbol, prior_close)
+        except Exception:
+            logger.warning("Could not fetch prior day candle for %s", symbol)
+
+        # --- Compute indicators ---
+        indicators = StreamingIndicators()
+        indicator_data = indicators.seed(hist_df, prior_close)
+
+        # --- Build payload with ET-converted timestamps ---
+        candles = build_candle_payload(hist_df)
+
+        # Convert indicator timestamps to ET
+        for point in indicator_data["hma"]:
+            point["time"] = utc_epoch_to_et_epoch(point["time"])
+        for point in indicator_data["macd"]:
+            point["time"] = utc_epoch_to_et_epoch(point["time"])
+
+        initial_payload = {
+            "type": "init",
+            "symbol": symbol,
+            "interval": interval,
+            "date": target_date.isoformat(),
+            "candles": candles,
+            "hma": indicator_data["hma"],
+            "macd": indicator_data["macd"],
+            "dailyCandle": daily_candle,
+        }
+
+        await ws.send_text(json.dumps(initial_payload))
+        logger.info(
+            "Sent %s %s: %d candles, %d HMA, %d MACD",
+            symbol,
+            target_date,
+            len(candles),
+            len(indicator_data["hma"]),
+            len(indicator_data["macd"]),
+        )
+
+        # --- Phase 2: Live updates from Redis ---
+        feed = ChartFeed(config)
+        live_task = asyncio.create_task(
+            self.stream_live_updates(ws, feed, indicators, symbol, interval)
+        )
+
+        # Wait for live feed to complete (client disconnect ends the session)
+        try:
+            await live_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await feed.close()
+            influx_client.close()
+
+    async def stream_live_updates(
+        self,
+        ws: WebSocket,
+        feed: ChartFeed,
+        indicators: StreamingIndicators,
+        symbol: str,
+        interval: str,
+    ) -> None:
+        """Subscribe to Redis and stream deltas to the WebSocket client."""
+        candle_symbol = f"{symbol}{{={interval}}}"
+
+        async for event_type, event in feed.listen(symbol, candle_symbol):
+            if event_type == "candle":
+                close = float(event.get("close", 0))
+                t = event.get("time")
+                if close == 0 or t is None:
+                    continue
+
+                utc_epoch = (
+                    int(t)
+                    if isinstance(t, (int, float))
+                    else int(datetime.fromisoformat(str(t)).timestamp())
+                )
+                et_epoch = utc_epoch_to_et_epoch(utc_epoch)
+
+                candle_msg = {
+                    "time": et_epoch,
+                    "open": round(float(event.get("open", 0)), 4),
+                    "high": round(float(event.get("high", 0)), 4),
+                    "low": round(float(event.get("low", 0)), 4),
+                    "close": round(close, 4),
+                }
+
+                indicator_point = indicators.update(close, et_epoch)
+
+                delta: dict[str, Any] = {"type": "update", "candle": candle_msg}
+                if indicator_point:
+                    delta["hma"] = indicator_point["hma"]
+                    delta["macd"] = indicator_point["macd"]
+
+                await ws.send_text(json.dumps(delta))
+
+            elif event_type == "level":
+                level_msg = {
+                    "type": "level",
+                    "price": float(event.get("price", 0)),
+                    "label": event.get("label", ""),
+                    "color": event.get("color", "#ffffff"),
+                    "lineStyle": event.get("line_dash", "solid"),
+                    "opacity": float(event.get("opacity", 0.7)),
+                }
+                await ws.send_text(json.dumps(level_msg))
+
+    async def start(self, port: int | None = None) -> None:
+        """Start the chart server."""
+        p = port or self.port
+        config = uvicorn.Config(self.app, host=self.host, port=p, log_level="info")
+        server = uvicorn.Server(config)
+        await server.serve()

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -1,0 +1,608 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>tasty-chart</title>
+  <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --bg: #131313; --surface: #1a1a1a; --surface-2: #222;
+      --border: #2a2a2a; --text: #d1d4dc; --text-muted: #787b86;
+      --text-dim: #4a4a5a; --accent: #58a6ff;
+    }
+    body {
+      background: var(--bg); color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      height: 100vh; display: flex; flex-direction: column; overflow: hidden;
+    }
+
+    /* --- Toolbar --- */
+    .toolbar {
+      display: flex; align-items: center;
+      padding: 0 16px; background: var(--surface);
+      border-bottom: 1px solid var(--border); height: 40px; flex-shrink: 0;
+      gap: 16px;
+    }
+    .toolbar-section {
+      display: flex; align-items: center; gap: 8px;
+    }
+    .toolbar-section.controls {
+      flex: 1; justify-content: center; gap: 6px;
+    }
+    .symbol-name { font-size: 15px; font-weight: 700; color: var(--text); letter-spacing: 0.3px; }
+    .badge {
+      font-size: 10px; font-weight: 600; color: var(--text-muted);
+      background: rgba(255,255,255,0.06); padding: 3px 8px; border-radius: 4px;
+      letter-spacing: 0.3px;
+    }
+    .date-input {
+      background: var(--surface-2); border: 1px solid var(--border); border-radius: 4px;
+      color: var(--text); font-size: 12px; padding: 4px 8px; cursor: pointer;
+      font-family: inherit; color-scheme: dark;
+    }
+    .date-input:focus { outline: none; border-color: var(--accent); }
+
+    /* Toggle buttons */
+    .toggle-btn {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 4px 10px; font-size: 11px; font-weight: 500;
+      color: var(--text-dim); background: transparent;
+      border: 1px solid transparent; border-radius: 4px;
+      cursor: pointer; user-select: none; transition: all 0.12s; white-space: nowrap;
+    }
+    .toggle-btn:hover { color: var(--text-muted); }
+    .toggle-btn.active { color: var(--text); border-color: var(--border); background: rgba(255,255,255,0.03); }
+    .toggle-btn .indicator {
+      width: 8px; height: 8px; border-radius: 2px; opacity: 0.8;
+    }
+    .divider { width: 1px; height: 18px; background: var(--border); }
+
+    /* Status */
+    .status { display: flex; align-items: center; gap: 5px; }
+    .status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); flex-shrink: 0; }
+    .status-dot.connected { background: #3fb950; }
+    .status-dot.connecting { background: #d29922; animation: pulse 1s infinite; }
+    .status-dot.disconnected { background: #ef5350; }
+    @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.3;} }
+
+    /* --- Charts --- */
+    .charts-container { flex: 1; display: flex; flex-direction: column; min-height: 0; position: relative; }
+    #chart-candle { min-height: 100px; }
+    #chart-macd { min-height: 60px; }
+
+    /* Resize handle between charts */
+    .chart-resize-handle {
+      height: 5px; cursor: row-resize; background: var(--border);
+      position: relative; z-index: 5; flex-shrink: 0;
+      transition: background 0.15s;
+    }
+    .chart-resize-handle:hover, .chart-resize-handle.dragging {
+      background: var(--accent); height: 5px;
+    }
+    body.chart-resizing { cursor: row-resize; user-select: none; }
+
+    /* Charts need explicit overflow visible for canvas rendering */
+  </style>
+</head>
+<body>
+
+<div class="toolbar">
+  <div class="toolbar-section">
+    <span class="symbol-name" id="symbolName">---</span>
+    <span class="badge" id="intervalBadge">--</span>
+    <input type="date" class="date-input" id="dateInput" title="Trading date">
+  </div>
+
+  <div class="toolbar-section controls" id="levelControls"></div>
+
+  <div class="toolbar-section">
+    <div class="status">
+      <div class="status-dot" id="statusDot"></div>
+    </div>
+  </div>
+</div>
+
+<div class="charts-container" id="chartsContainer">
+  <div id="chart-candle" style="flex:3"></div>
+  <div class="chart-resize-handle" id="chartResizeHandle"></div>
+  <div id="chart-macd" style="flex:1"></div>
+</div>
+
+<script>
+// --- Colors (plots.py) ---
+const C = {
+  bg:'#131313', grid:'rgba(255,255,255,0.03)', text:'#787b86', border:'#2a2a2a',
+  candleUpBorder:'#4CAF50', candleUpBody:'rgba(19,19,19,0.1)',
+  candleDownBorder:'#EF5350', candleDownBody:'#EF5350',
+  hmaUp:'#01FFFF', hmaDown:'#FF66FE',
+  macdValue:'#01FFFF', macdSignal:'#F8E9A6', macdZero:'rgba(255,255,255,0.12)',
+  priorClose:'#FF66FE', priorHigh:'#4CAF50', priorLow:'#F44336', orLevel:'#4CAF50',
+};
+
+const MARKET_OPEN_H = 9, MARKET_OPEN_M = 30;
+
+const candleEl = document.getElementById('chart-candle');
+const macdEl = document.getElementById('chart-macd');
+
+const chartOpts = () => ({
+  layout: { background: { type: 'solid', color: C.bg }, textColor: C.text },
+  grid: { vertLines: { color: C.grid }, horzLines: { color: C.grid } },
+  crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
+  rightPriceScale: { borderColor: C.border, scaleMargins: { top: 0.05, bottom: 0.05 } },
+  timeScale: {
+    borderColor: C.border, timeVisible: true, secondsVisible: false,
+    tickMarkFormatter: (time, tickMarkType) => {
+      const d = new Date(time * 1000);
+      const h = d.getUTCHours(), m = d.getUTCMinutes();
+      if (tickMarkType <= 2) {
+        // Date-level: show month/day
+        const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        return `${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+      }
+      const hh = h > 12 ? h - 12 : (h === 0 ? 12 : h);
+      const mm = m < 10 ? '0' + m : '' + m;
+      return `${hh}:${mm} ${h >= 12 ? 'PM' : 'AM'}`;
+    },
+  },
+  handleScroll: { mouseWheel: true, pressedMouseMove: true, horzTouchDrag: true },
+  handleScale: { mouseWheel: true, pinch: true, axisPressedMouseMove: true },
+});
+
+// Create charts with explicit dimensions — flex containers may not have
+// concrete pixel sizes at creation time
+const candleChart = LightweightCharts.createChart(candleEl, {
+  ...chartOpts(),
+  width: candleEl.clientWidth || window.innerWidth,
+  height: candleEl.clientHeight || Math.floor(window.innerHeight * 0.65),
+});
+const macdChart = LightweightCharts.createChart(macdEl, {
+  ...chartOpts(),
+  width: macdEl.clientWidth || window.innerWidth,
+  height: macdEl.clientHeight || Math.floor(window.innerHeight * 0.2),
+});
+
+// Remove TradingView watermarks via DOM
+function hideWatermarks() { /* disabled for now */ }
+
+
+// Sync time scales
+let syncing = false;
+candleChart.timeScale().subscribeVisibleLogicalRangeChange(r => {
+  if (syncing || !r) return; syncing = true;
+  macdChart.timeScale().setVisibleLogicalRange(r); syncing = false;
+});
+macdChart.timeScale().subscribeVisibleLogicalRangeChange(r => {
+  if (syncing || !r) return; syncing = true;
+  candleChart.timeScale().setVisibleLogicalRange(r); syncing = false;
+});
+
+// --- Series ---
+const candleSeries = candleChart.addCandlestickSeries({
+  upColor: C.candleUpBody, downColor: C.candleDownBody,
+  borderUpColor: C.candleUpBorder, borderDownColor: C.candleDownBorder,
+  wickUpColor: C.candleUpBorder, wickDownColor: C.candleDownBorder,
+});
+
+// HMA: segment series per color run
+let hmaSegmentSeries = [];
+
+function clearHmaSeries() {
+  hmaSegmentSeries.forEach(s => candleChart.removeSeries(s.series));
+  hmaSegmentSeries = [];
+}
+
+function createHmaSegmentSeries(color) {
+  const series = candleChart.addLineSeries({
+    color, lineWidth: 1,
+    priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
+  });
+  if (!hmaVisible) series.applyOptions({ visible: false });
+  const entry = { series, color };
+  hmaSegmentSeries.push(entry);
+  return entry;
+}
+
+function buildHmaSegments(hmaData, candleTimes) {
+  clearHmaSeries();
+  if (!hmaData || !hmaData.length) return;
+  const timeSet = candleTimes ? new Set(candleTimes) : null;
+  let cur = null, curColor = null;
+
+  for (let i = 0; i < hmaData.length; i++) {
+    if (timeSet && !timeSet.has(hmaData[i].time)) continue;
+    const color = hmaData[i].color;
+    const pt = { time: hmaData[i].time, value: hmaData[i].value };
+    if (color !== curColor) {
+      const entry = createHmaSegmentSeries(color);
+      if (cur) cur.series.update(pt); // overlap for continuity
+      entry.series.setData([pt]);
+      cur = entry; curColor = color;
+    } else {
+      cur.series.update(pt);
+    }
+  }
+}
+
+const macdHistSeries = macdChart.addHistogramSeries({
+  priceLineVisible: false, lastValueVisible: false,
+  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+});
+const macdValueSeries = macdChart.addLineSeries({
+  color: C.macdValue, lineWidth: 1,
+  priceLineVisible: false, lastValueVisible: false,
+  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+});
+const macdSignalSeries = macdChart.addLineSeries({
+  color: C.macdSignal, lineWidth: 1,
+  priceLineVisible: false, lastValueVisible: false,
+  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+});
+const macdZeroSeries = macdChart.addLineSeries({
+  color: C.macdZero, lineWidth: 1, lineStyle: LightweightCharts.LineStyle.Dotted,
+  priceLineVisible: false, lastValueVisible: false,
+});
+
+// --- State ---
+let lastHmaColor = C.hmaUp;
+let hmaVisible = true;
+let viewStartEpoch = 0;  // 8:30 AM — for default zoom
+let levelStartEpoch = 0; // 9:30 AM — for horizontal lines
+let levelEndEpoch = 0;   // 5:00 PM — for horizontal lines
+const levels = {};
+
+function lwcStyle(s) {
+  if (s === 'dot' || s === 'dotted') return LightweightCharts.LineStyle.Dotted;
+  if (s === 'dash' || s === 'dashed') return LightweightCharts.LineStyle.Dashed;
+  return LightweightCharts.LineStyle.Solid;
+}
+
+function computeBounds(candles) {
+  viewStartEpoch = 0; levelStartEpoch = 0; levelEndEpoch = 0;
+  for (const c of candles) {
+    const d = new Date(c.time * 1000);
+    const h = d.getUTCHours(), m = d.getUTCMinutes();
+    // View start: 8:30 AM
+    if (h === 8 && m >= 30 && viewStartEpoch === 0) viewStartEpoch = c.time;
+    // Level start: 9:30 AM (market open)
+    if (h === 9 && m >= 30 && levelStartEpoch === 0) levelStartEpoch = c.time;
+    // Level end: last candle at or before 5:00 PM
+    if (h < 17 || (h === 17 && m === 0)) levelEndEpoch = c.time;
+  }
+  if (viewStartEpoch === 0 && candles.length) viewStartEpoch = candles[0].time;
+  if (levelStartEpoch === 0) levelStartEpoch = viewStartEpoch;
+  if (levelEndEpoch === 0 && candles.length) levelEndEpoch = candles[candles.length - 1].time;
+}
+
+// --- Toggles ---
+function toggleHma() {
+  hmaVisible = !hmaVisible;
+  hmaSegmentSeries.forEach(s => s.series.applyOptions({ visible: hmaVisible }));
+  renderControls();
+}
+
+function clearAllLevels() {
+  Object.keys(levels).forEach(id => {
+    levels[id].seriesList.forEach(s => { try { candleChart.removeSeries(s); } catch(e) {} });
+    delete levels[id];
+  });
+}
+
+function createLevelSeries(entry) {
+  const series = candleChart.addLineSeries({
+    color: entry.color, lineWidth: 1,
+    lineStyle: lwcStyle(entry.lineStyle),
+    priceLineVisible: false, lastValueVisible: false,
+    crosshairMarkerVisible: false,
+    // Exclude from auto-scale so levels don't stretch the candle y-axis
+    autoscaleInfoProvider: () => null,
+  });
+  series.setData([
+    { time: levelStartEpoch, value: entry.price },
+    { time: levelEndEpoch, value: entry.price },
+  ]);
+  return series;
+}
+
+function createLevel(id, entries, visible) {
+  if (levels[id]) return;
+  const seriesList = visible ? entries.map(e => createLevelSeries(e)) : [];
+  levels[id] = { seriesList, visible, entries };
+}
+
+function toggleLevel(id) {
+  const lv = levels[id];
+  if (!lv) return;
+  if (lv.visible) {
+    lv.seriesList.forEach(s => { try { candleChart.removeSeries(s); } catch(e) {} });
+    lv.seriesList = []; lv.visible = false;
+  } else {
+    lv.seriesList = lv.entries.map(e => createLevelSeries(e));
+    lv.visible = true;
+  }
+  renderControls();
+}
+
+function renderControls() {
+  const el = document.getElementById('levelControls');
+  const parts = [];
+
+  // HMA
+  const hmaCls = hmaVisible ? 'active' : '';
+  parts.push(`<button class="toggle-btn ${hmaCls}" onclick="toggleHma()">
+    <span class="indicator" style="background:${C.hmaUp}"></span>HMA</button>`);
+
+  parts.push('<div class="divider"></div>');
+
+  // Prior levels
+  ['priorClose','priorHigh','priorLow'].forEach(id => {
+    if (!levels[id]) return;
+    const lv = levels[id], e = lv.entries[0], cls = lv.visible ? 'active' : '';
+    parts.push(`<button class="toggle-btn ${cls}" onclick="toggleLevel('${id}')">
+      <span class="indicator" style="background:${e.color}"></span>${e.label}</button>`);
+  });
+
+  // OR levels
+  const orIds = ['or5','or15','or30'].filter(id => levels[id]);
+  if (orIds.length) {
+    parts.push('<div class="divider"></div>');
+    orIds.forEach(id => {
+      const lv = levels[id], cls = lv.visible ? 'active' : '';
+      const label = id==='or5'?'5m OR':id==='or15'?'15m OR':'30m OR';
+      parts.push(`<button class="toggle-btn ${cls}" onclick="toggleLevel('${id}')">
+        <span class="indicator" style="background:${C.orLevel}"></span>${label}</button>`);
+    });
+  }
+
+  el.innerHTML = parts.join('');
+}
+
+// --- Opening range ---
+const OR_WINDOWS = [
+  { min:5, id:'or5', label:'5m', style:'solid', opacity:0.75 },
+  { min:15, id:'or15', label:'15m', style:'solid', opacity:0.45 },
+  { min:30, id:'or30', label:'30m', style:'dotted', opacity:0.45 },
+];
+const orState = {};
+
+function initOR() {
+  OR_WINDOWS.forEach(w => { orState[w.min] = { high:null, low:null, locked:false }; });
+}
+
+function processCandleOR(candle) {
+  const d = new Date(candle.time * 1000);
+  const h = d.getUTCHours(), m = d.getUTCMinutes();
+  const minSinceOpen = (h - MARKET_OPEN_H) * 60 + (m - MARKET_OPEN_M);
+  if (minSinceOpen < 0) return;
+
+  OR_WINDOWS.forEach(w => {
+    const st = orState[w.min];
+    if (!st || st.locked) return;
+    if (minSinceOpen >= w.min) {
+      st.locked = true;
+      if (st.high !== null) {
+        createLevel(w.id, [
+          { price:st.high, label:`${w.label} Hi`, color:C.orLevel, lineStyle:w.style, opacity:w.opacity },
+          { price:st.low, label:`${w.label} Lo`, color:C.orLevel, lineStyle:w.style, opacity:w.opacity },
+        ], true);
+        renderControls();
+      }
+      return;
+    }
+    if (st.high === null || candle.high > st.high) st.high = candle.high;
+    if (st.low === null || candle.low < st.low) st.low = candle.low;
+  });
+}
+
+// --- View & scale ---
+function setTradingHoursView() {
+  if (viewStartEpoch === 0 || levelEndEpoch === 0) return;
+  candleChart.timeScale().setVisibleRange({ from: viewStartEpoch - 300, to: levelEndEpoch + 600 });
+}
+
+// Let the chart auto-scale to visible candle data.
+// Prior day levels may be off-screen if there's a large gap — that's OK,
+// the user can scroll/zoom to see them. Forcing them into view compresses
+// the candles to invisible.
+
+// --- Chart pane resize ---
+(function() {
+  const handle = document.getElementById('chartResizeHandle');
+  const container = document.getElementById('chartsContainer');
+  let dragging = false, startY = 0, startCandleH = 0, startMacdH = 0;
+
+  function onStart(clientY) {
+    dragging = true;
+    startY = clientY;
+    startCandleH = candleEl.offsetHeight;
+    startMacdH = macdEl.offsetHeight;
+    document.body.classList.add('chart-resizing');
+    handle.classList.add('dragging');
+  }
+
+  handle.addEventListener('mousedown', e => { e.preventDefault(); onStart(e.clientY); });
+  handle.addEventListener('touchstart', e => { e.preventDefault(); onStart(e.touches[0].clientY); }, { passive: false });
+
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    const dy = e.clientY - startY;
+    const newCandle = Math.max(100, startCandleH + dy);
+    const newMacd = Math.max(60, startMacdH - dy);
+    candleEl.style.flex = 'none'; candleEl.style.height = newCandle + 'px';
+    macdEl.style.flex = 'none'; macdEl.style.height = newMacd + 'px';
+    resize();
+  });
+
+  document.addEventListener('touchmove', e => {
+    if (!dragging) return;
+    e.preventDefault();
+    const dy = e.touches[0].clientY - startY;
+    const newCandle = Math.max(100, startCandleH + dy);
+    const newMacd = Math.max(60, startMacdH - dy);
+    candleEl.style.flex = 'none'; candleEl.style.height = newCandle + 'px';
+    macdEl.style.flex = 'none'; macdEl.style.height = newMacd + 'px';
+    resize();
+  }, { passive: false });
+
+  function endDrag() {
+    if (!dragging) return;
+    dragging = false;
+    document.body.classList.remove('chart-resizing');
+    handle.classList.remove('dragging');
+  }
+  document.addEventListener('mouseup', endDrag);
+  document.addEventListener('touchend', endDrag);
+})();
+
+// --- WebSocket ---
+let ws = null;
+let intentionalClose = false;
+
+function setStatus(state) {
+  document.getElementById('statusDot').className = 'status-dot ' + state;
+}
+
+function getParams() {
+  const p = new URLSearchParams(window.location.search);
+  return { symbol: p.get('symbol') || 'SPX', interval: p.get('interval') || 'm' };
+}
+
+function connect(dateOverride) {
+  setStatus('connecting');
+  intentionalClose = true;
+
+  const { symbol, interval } = getParams();
+  document.getElementById('symbolName').textContent = symbol;
+  document.getElementById('intervalBadge').textContent = interval === 'm' ? '1m' : interval;
+
+  if (ws) { try { ws.close(); } catch(e) {} ws = null; }
+
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  let url = `${proto}//${location.host}/ws?symbol=${symbol}&interval=${interval}`;
+  if (dateOverride) url += `&date=${dateOverride}`;
+
+  ws = new WebSocket(url);
+
+  ws.onopen = () => {
+    intentionalClose = false;
+    setStatus('connected');
+  };
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+
+    if (msg.type === 'error') { setStatus('disconnected'); return; }
+
+    if (msg.type === 'init') {
+      clearAllLevels();
+      initOR();
+      hmaVisible = true;
+
+      if (msg.date) document.getElementById('dateInput').value = msg.date;
+
+      candleSeries.setData(msg.candles);
+      computeBounds(msg.candles);
+      msg.candles.forEach(c => processCandleOR(c));
+
+      // HMA
+      if (msg.hma && msg.hma.length > 0) {
+        const candleTimes = msg.candles.map(c => c.time);
+        buildHmaSegments(msg.hma, candleTimes);
+        lastHmaColor = msg.hma[msg.hma.length - 1].color;
+      }
+
+      // MACD
+      if (msg.macd && msg.macd.length > 0) {
+        macdHistSeries.setData(msg.macd.map(p => ({ time:p.time, value:p.histogram, color:p.histogramColor })));
+        macdValueSeries.setData(msg.macd.map(p => ({ time:p.time, value:p.value })));
+        macdSignalSeries.setData(msg.macd.map(p => ({ time:p.time, value:p.signal })));
+        macdZeroSeries.setData([
+          { time:msg.macd[0].time, value:0 },
+          { time:msg.macd[msg.macd.length-1].time, value:0 },
+        ]);
+      }
+
+      // Prior day levels — bounded to 9:30 - 5:00
+      if (msg.dailyCandle) {
+        const dc = msg.dailyCandle;
+        if (dc.close != null) createLevel('priorClose',[
+          {price:dc.close, label:'Prior Close', color:C.priorClose, lineStyle:'dotted', opacity:0.45}], true);
+        if (dc.high != null) createLevel('priorHigh',[
+          {price:dc.high, label:'Prior Hi', color:C.priorHigh, lineStyle:'dotted', opacity:0.45}], true);
+        if (dc.low != null) createLevel('priorLow',[
+          {price:dc.low, label:'Prior Lo', color:C.priorLow, lineStyle:'dotted', opacity:0.45}], true);
+      }
+
+      renderControls();
+      setTimeout(() => { setTradingHoursView(); hideWatermarks(); }, 100);
+      return;
+    }
+
+    if (msg.type === 'update') {
+      candleSeries.update(msg.candle);
+      processCandleOR(msg.candle);
+
+      if (msg.hma) {
+        const pt = { time: msg.hma.time, value: msg.hma.value };
+        const color = msg.hma.color;
+        if (color !== lastHmaColor && hmaSegmentSeries.length > 0) {
+          hmaSegmentSeries[hmaSegmentSeries.length - 1].series.update(pt);
+          const entry = createHmaSegmentSeries(color);
+          entry.series.setData([pt]);
+        } else if (hmaSegmentSeries.length > 0) {
+          hmaSegmentSeries[hmaSegmentSeries.length - 1].series.update(pt);
+        } else {
+          const entry = createHmaSegmentSeries(color);
+          entry.series.setData([pt]);
+        }
+        lastHmaColor = color;
+      }
+
+      if (msg.macd) {
+        macdHistSeries.update({ time:msg.macd.time, value:msg.macd.histogram, color:msg.macd.histogramColor });
+        macdValueSeries.update({ time:msg.macd.time, value:msg.macd.value });
+        macdSignalSeries.update({ time:msg.macd.time, value:msg.macd.signal });
+        macdZeroSeries.update({ time:msg.macd.time, value:0 });
+      }
+      return;
+    }
+
+    if (msg.type === 'level') {
+      const id = (msg.label||'').replace(/\s+/g,'').toLowerCase();
+      createLevel(id,[{price:msg.price,label:msg.label,color:msg.color,lineStyle:msg.lineStyle,opacity:msg.opacity}],true);
+      renderControls();
+      return;
+    }
+  };
+
+  ws.onclose = () => {
+    if (intentionalClose) return;
+    setStatus('disconnected');
+    setTimeout(() => connect(), 3000);
+  };
+
+  ws.onerror = () => setStatus('disconnected');
+}
+
+document.getElementById('dateInput').addEventListener('change', (e) => {
+  if (e.target.value) connect(e.target.value);
+});
+
+// Resize
+function resize() {
+  if (candleEl.clientWidth && candleEl.clientHeight) {
+    candleChart.resize(candleEl.clientWidth, candleEl.clientHeight);
+  }
+  if (macdEl.clientWidth && macdEl.clientHeight) {
+    macdChart.resize(macdEl.clientWidth, macdEl.clientHeight);
+  }
+}
+window.addEventListener('resize', resize);
+new ResizeObserver(resize).observe(candleEl);
+new ResizeObserver(resize).observe(macdEl);
+
+connect();
+</script>
+</body>
+</html>

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -7,6 +7,8 @@
   <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    /* Hide TradingView branding — only <a> tags in chart containers are attribution links */
+    #chart-candle a, #chart-macd a { display: none !important; }
     :root {
       --bg: #131313; --surface: #1a1a1a; --surface-2: #222;
       --border: #2a2a2a; --text: #d1d4dc; --text-muted: #787b86;
@@ -163,8 +165,6 @@ const macdChart = LightweightCharts.createChart(macdEl, {
   height: macdEl.clientHeight || Math.floor(window.innerHeight * 0.2),
 });
 
-// Remove TradingView watermarks via DOM
-function hideWatermarks() { /* disabled for now */ }
 
 
 // Sync time scales
@@ -183,6 +183,8 @@ const candleSeries = candleChart.addCandlestickSeries({
   upColor: C.candleUpBody, downColor: C.candleDownBody,
   borderUpColor: C.candleUpBorder, borderDownColor: C.candleDownBorder,
   wickUpColor: C.candleUpBorder, wickDownColor: C.candleDownBorder,
+  lastValueVisible: false,
+  priceLineVisible: false,
 });
 
 // HMA: segment series per color run
@@ -247,9 +249,10 @@ const macdZeroSeries = macdChart.addLineSeries({
 // --- State ---
 let lastHmaColor = C.hmaUp;
 let hmaVisible = true;
-let viewStartEpoch = 0;  // 8:30 AM — for default zoom
+let lastCandles = [];
+let viewStartEpoch = 0;  // 9:00 AM — for default zoom
 let levelStartEpoch = 0; // 9:30 AM — for horizontal lines
-let levelEndEpoch = 0;   // 5:00 PM — for horizontal lines
+let levelEndEpoch = 0;   // 4:30 PM — for horizontal lines + view end
 const levels = {};
 
 function lwcStyle(s) {
@@ -258,21 +261,35 @@ function lwcStyle(s) {
   return LightweightCharts.LineStyle.Solid;
 }
 
+// Market hours vs extended hours — user-toggled
+let hasMarketHours = true;
+
 function computeBounds(candles) {
   viewStartEpoch = 0; levelStartEpoch = 0; levelEndEpoch = 0;
+
   for (const c of candles) {
     const d = new Date(c.time * 1000);
     const h = d.getUTCHours(), m = d.getUTCMinutes();
-    // View start: 8:30 AM
-    if (h === 8 && m >= 30 && viewStartEpoch === 0) viewStartEpoch = c.time;
-    // Level start: 9:30 AM (market open)
+    if (h === 9 && m >= 0 && viewStartEpoch === 0) viewStartEpoch = c.time;
     if (h === 9 && m >= 30 && levelStartEpoch === 0) levelStartEpoch = c.time;
-    // Level end: last candle at or before 5:00 PM
-    if (h < 17 || (h === 17 && m === 0)) levelEndEpoch = c.time;
+    if (h < 16 || (h === 16 && m <= 30)) levelEndEpoch = c.time;
   }
-  if (viewStartEpoch === 0 && candles.length) viewStartEpoch = candles[0].time;
-  if (levelStartEpoch === 0) levelStartEpoch = viewStartEpoch;
-  if (levelEndEpoch === 0 && candles.length) levelEndEpoch = candles[candles.length - 1].time;
+
+  if (!hasMarketHours || viewStartEpoch === 0) {
+    viewStartEpoch = candles.length ? candles[0].time : 0;
+    levelStartEpoch = viewStartEpoch;
+    levelEndEpoch = candles.length ? candles[candles.length - 1].time : 0;
+  } else {
+    if (levelStartEpoch === 0) levelStartEpoch = viewStartEpoch;
+    if (levelEndEpoch === 0 && candles.length) levelEndEpoch = candles[candles.length - 1].time;
+  }
+}
+
+function toggleMarketHours() {
+  hasMarketHours = !hasMarketHours;
+  computeBounds(lastCandles);
+  setTradingHoursView();
+  renderControls();
 }
 
 // --- Toggles ---
@@ -355,6 +372,13 @@ function renderControls() {
     });
   }
 
+  // Market hours toggle
+  parts.push('<div class="divider"></div>');
+  const mhCls = hasMarketHours ? 'active' : '';
+  const extCls = hasMarketHours ? '' : 'active';
+  parts.push(`<button class="toggle-btn ${mhCls}" onclick="toggleMarketHours()" title="Market hours (9:00–4:30)">MKT</button>`);
+  parts.push(`<button class="toggle-btn ${extCls}" onclick="toggleMarketHours()" title="Extended / 24h view">EXT</button>`);
+
   el.innerHTML = parts.join('');
 }
 
@@ -397,14 +421,38 @@ function processCandleOR(candle) {
 
 // --- View & scale ---
 function setTradingHoursView() {
+  if (!hasMarketHours) {
+    candleChart.timeScale().fitContent();
+    return;
+  }
   if (viewStartEpoch === 0 || levelEndEpoch === 0) return;
   candleChart.timeScale().setVisibleRange({ from: viewStartEpoch - 300, to: levelEndEpoch + 600 });
 }
 
-// Let the chart auto-scale to visible candle data.
-// Prior day levels may be off-screen if there's a large gap — that's OK,
-// the user can scroll/zoom to see them. Forcing them into view compresses
-// the candles to invisible.
+// Extend candle series auto-scale to include prior day levels.
+// Level line series have autoscaleInfoProvider: () => null so they don't
+// contribute — only the candle series range matters, preventing double-stretch.
+let priorLevelPrices = [];
+
+function applyPriorLevelScale(candles) {
+  if (!priorLevelPrices.length || !candles.length) return;
+  // Compute the full range from candle data + prior levels
+  let lo = Infinity, hi = -Infinity;
+  candles.forEach(c => {
+    if (c.low < lo) lo = c.low;
+    if (c.high > hi) hi = c.high;
+  });
+  priorLevelPrices.forEach(p => {
+    if (p < lo) lo = p;
+    if (p > hi) hi = p;
+  });
+  const pad = (hi - lo) * 0.03;
+  candleSeries.applyOptions({
+    autoscaleInfoProvider: () => ({
+      priceRange: { minValue: lo - pad, maxValue: hi + pad },
+    }),
+  });
+}
 
 // --- Chart pane resize ---
 (function() {
@@ -501,9 +549,11 @@ function connect(dateOverride) {
 
       if (msg.date) document.getElementById('dateInput').value = msg.date;
 
+      lastCandles = msg.candles;
       candleSeries.setData(msg.candles);
       computeBounds(msg.candles);
-      msg.candles.forEach(c => processCandleOR(c));
+      // Only compute opening range for instruments with market hours
+      if (hasMarketHours) msg.candles.forEach(c => processCandleOR(c));
 
       // HMA
       if (msg.hma && msg.hma.length > 0) {
@@ -524,24 +574,42 @@ function connect(dateOverride) {
       }
 
       // Prior day levels — bounded to 9:30 - 5:00
+      priorLevelPrices = [];
       if (msg.dailyCandle) {
         const dc = msg.dailyCandle;
-        if (dc.close != null) createLevel('priorClose',[
-          {price:dc.close, label:'Prior Close', color:C.priorClose, lineStyle:'dotted', opacity:0.45}], true);
-        if (dc.high != null) createLevel('priorHigh',[
-          {price:dc.high, label:'Prior Hi', color:C.priorHigh, lineStyle:'dotted', opacity:0.45}], true);
-        if (dc.low != null) createLevel('priorLow',[
-          {price:dc.low, label:'Prior Lo', color:C.priorLow, lineStyle:'dotted', opacity:0.45}], true);
+        if (dc.close != null) {
+          createLevel('priorClose',[{price:dc.close, label:'Prior Close', color:C.priorClose, lineStyle:'dotted', opacity:0.45}], true);
+          priorLevelPrices.push(dc.close);
+        }
+        if (dc.high != null) {
+          createLevel('priorHigh',[{price:dc.high, label:'Prior Hi', color:C.priorHigh, lineStyle:'dotted', opacity:0.45}], true);
+          priorLevelPrices.push(dc.high);
+        }
+        if (dc.low != null) {
+          createLevel('priorLow',[{price:dc.low, label:'Prior Lo', color:C.priorLow, lineStyle:'dotted', opacity:0.45}], true);
+          priorLevelPrices.push(dc.low);
+        }
+        applyPriorLevelScale(msg.candles);
       }
 
       renderControls();
-      setTimeout(() => { setTradingHoursView(); hideWatermarks(); }, 100);
+      setTimeout(() => { setTradingHoursView(); }, 100);
       return;
     }
 
     if (msg.type === 'update') {
       candleSeries.update(msg.candle);
       processCandleOR(msg.candle);
+
+      // Extend all visible level lines to the latest candle time
+      const newTime = msg.candle.time;
+      for (const id in levels) {
+        if (levels[id].visible) {
+          levels[id].seriesList.forEach((s, i) => {
+            s.update({ time: newTime, value: levels[id].entries[i].price });
+          });
+        }
+      }
 
       if (msg.hma) {
         const pt = { time: msg.hma.time, value: msg.hma.value };

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -59,32 +59,6 @@
     .seg-btn.active { color: var(--text); background: rgba(255,255,255,0.06); }
     .seg-btn:hover:not(.active) { color: var(--text-muted); }
 
-    /* Settings gear + popover */
-    .gear-btn {
-      background: none; border: 1px solid transparent; border-radius: 4px;
-      color: var(--text-dim); cursor: pointer; padding: 4px 6px; font-size: 14px;
-      transition: all 0.12s; line-height: 1;
-    }
-    .gear-btn:hover { color: var(--text); border-color: var(--border); }
-    .settings-popover {
-      display: none; position: absolute; top: 40px; right: 60px; z-index: 20;
-      background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
-      padding: 8px 0; min-width: 160px; box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-    }
-    .settings-popover.open { display: block; }
-    .settings-item {
-      display: flex; align-items: center; gap: 8px;
-      padding: 6px 14px; font-size: 12px; color: var(--text-muted);
-      cursor: pointer; transition: background 0.1s; user-select: none;
-    }
-    .settings-item:hover { background: rgba(255,255,255,0.04); }
-    .settings-item .dot {
-      width: 6px; height: 6px; border-radius: 2px; flex-shrink: 0;
-    }
-    .settings-item .check {
-      width: 14px; text-align: center; font-size: 11px; color: var(--accent); flex-shrink: 0;
-    }
-    .settings-divider { height: 1px; background: var(--border); margin: 4px 0; }
 
     /* Status */
     .status { display: flex; align-items: center; gap: 5px; }
@@ -94,9 +68,43 @@
     .status-dot.disconnected { background: #ef5350; }
     @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.3;} }
 
+    /* Chart legend */
+    .chart-legend {
+      position: absolute; bottom: 8px; left: 90px; z-index: 10;
+      background: rgba(19,19,19,0.88); border: 1px solid var(--border);
+      border-radius: 5px; overflow: hidden;
+      font-family: monospace; font-size: 11px;
+      color: var(--text-muted); user-select: none;
+    }
+    .chart-legend:empty { display: none; }
+    .chart-legend.dragging .legend-grip { cursor: grabbing; }
+    .legend-grip {
+      height: 14px; cursor: grab; display: flex; align-items: center;
+      justify-content: center; background: rgba(255,255,255,0.03);
+      border-bottom: 1px solid var(--border);
+    }
+    .legend-grip-dots {
+      width: 24px; height: 2px;
+      border-top: 2px dotted rgba(255,255,255,0.15);
+    }
+    .legend-body { padding: 6px 12px 8px; }
+    .legend-row {
+      display: flex; align-items: center; gap: 8px; white-space: nowrap;
+      padding: 3px 4px; border-radius: 3px; cursor: pointer;
+      transition: opacity 0.12s;
+    }
+    .legend-row:hover { background: rgba(255,255,255,0.04); }
+    .legend-row.off { opacity: 0.3; }
+    .legend-line {
+      width: 18px; height: 0; flex-shrink: 0;
+      border-top-width: 2px; border-top-style: solid;
+    }
+    .legend-line.dotted { border-top-style: dotted; }
+    .legend-line.dashed { border-top-style: dashed; }
+
     /* --- Charts --- */
     .charts-container { flex: 1; display: flex; flex-direction: column; min-height: 0; position: relative; }
-    #chart-candle { min-height: 100px; }
+    #chart-candle { min-height: 100px; position: relative; }
     #chart-macd { min-height: 60px; }
 
     /* Resize handle between charts */
@@ -127,8 +135,6 @@
 
   <div class="toolbar-section">
     <div class="seg-ctrl" id="mktExtCtrl"></div>
-    <button class="gear-btn" id="gearBtn" title="Chart settings">&#9881;</button>
-    <div class="settings-popover" id="settingsPopover"></div>
     <div class="status">
       <div class="status-dot" id="statusDot"></div>
     </div>
@@ -136,7 +142,12 @@
 </div>
 
 <div class="charts-container" id="chartsContainer">
-  <div id="chart-candle" style="flex:3"></div>
+  <div id="chart-candle" style="flex:3">
+    <div class="chart-legend" id="chartLegend">
+      <div class="legend-grip" id="legendGrip"><div class="legend-grip-dots"></div></div>
+      <div class="legend-body" id="legendBody"></div>
+    </div>
+  </div>
   <div class="chart-resize-handle" id="chartResizeHandle"></div>
   <div id="chart-macd" style="flex:1"></div>
 </div>
@@ -371,6 +382,7 @@ function clearAllLevels() {
     levels[id].seriesList.forEach(s => { try { candleChart.removeSeries(s); } catch(e) {} });
     delete levels[id];
   });
+  document.getElementById('legendBody').innerHTML = '';
 }
 
 function createLevelSeries(entry) {
@@ -406,63 +418,84 @@ function toggleLevel(id) {
     lv.visible = true;
   }
   renderControls();
+  renderLegend();
 }
 
+function renderLegend() {
+  const el = document.getElementById('legendBody');
+  const rows = [];
+
+  function row(id, label, color, style, priceText, onclick) {
+    const vis = id === 'hma' ? hmaVisible : (levels[id] && levels[id].visible);
+    const cls = vis ? '' : 'off';
+    const dash = style === 'dotted' ? 'dotted' : style === 'dashed' ? 'dashed' : '';
+    const handler = onclick || `toggleLevel('${id}');renderLegend()`;
+    return `<div class="legend-row ${cls}" onclick="${handler}">
+      <span class="legend-line ${dash}" style="border-color:${color}"></span>
+      <span>${label}</span>
+      <span style="color:var(--text-dim)">${priceText}</span>
+    </div>`;
+  }
+
+  // HMA
+  rows.push(row('hma', 'HMA', C.hmaUp, 'solid', '', 'toggleHma();renderLegend()'));
+
+  // Prior day levels
+  ['priorClose','priorHigh','priorLow'].forEach(id => {
+    const lv = levels[id];
+    if (!lv) return;
+    const e = lv.entries[0];
+    rows.push(row(id, e.label, e.color, e.lineStyle, e.price.toFixed(0)));
+  });
+  // OR levels — group hi/lo pairs
+  ['or5','or15','or30'].forEach(id => {
+    const lv = levels[id];
+    if (!lv || !lv.entries.length) return;
+    const label = id==='or5'?'5m OR':id==='or15'?'15m OR':'30m OR';
+    const hi = lv.entries.find(e => e.label.includes('Hi'));
+    const lo = lv.entries.find(e => e.label.includes('Lo'));
+    const prices = [hi,lo].filter(Boolean).map(e => e.price.toFixed(0)).join(' / ');
+    rows.push(row(id, label, lv.entries[0].color, lv.entries[0].lineStyle, prices));
+  });
+  el.innerHTML = rows.join('');
+}
+
+// Draggable legend via grip bar
+(function() {
+  const legend = document.getElementById('chartLegend');
+  const grip = document.getElementById('legendGrip');
+  let dragging = false, startX = 0, startY = 0, origLeft = 0, origTop = 0;
+
+  grip.addEventListener('mousedown', (e) => {
+    dragging = true; startX = e.clientX; startY = e.clientY;
+    // Switch from bottom-anchored to top-anchored on first drag
+    if (legend.style.bottom !== '') {
+      const rect = legend.getBoundingClientRect();
+      const parentRect = legend.parentElement.getBoundingClientRect();
+      legend.style.top = (rect.top - parentRect.top) + 'px';
+      legend.style.bottom = 'auto';
+    }
+    origLeft = legend.offsetLeft; origTop = legend.offsetTop;
+    legend.classList.add('dragging');
+    e.preventDefault();
+  });
+  document.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    legend.style.left = (origLeft + e.clientX - startX) + 'px';
+    legend.style.top = (origTop + e.clientY - startY) + 'px';
+  });
+  document.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false; legend.classList.remove('dragging');
+  });
+})();
+
 function renderControls() {
-  // Segmented control: MKT / EXT
   const seg = document.getElementById('mktExtCtrl');
   seg.innerHTML = `
     <button class="seg-btn ${hasMarketHours ? 'active' : ''}" onclick="toggleMarketHours()">MKT</button>
     <button class="seg-btn ${hasMarketHours ? '' : 'active'}" onclick="toggleMarketHours()">EXT</button>`;
-
-  // Settings popover items
-  const pop = document.getElementById('settingsPopover');
-  const items = [];
-
-  // HMA
-  items.push(settingsItem('HMA', C.hmaUp, hmaVisible, 'toggleHma()'));
-  items.push('<div class="settings-divider"></div>');
-
-  // Prior levels
-  ['priorClose','priorHigh','priorLow'].forEach(id => {
-    if (!levels[id]) return;
-    const lv = levels[id], e = lv.entries[0];
-    items.push(settingsItem(e.label, e.color, lv.visible, `toggleLevel('${id}')`));
-  });
-
-  // OR levels
-  const orIds = ['or5','or15','or30'].filter(id => levels[id]);
-  if (orIds.length) {
-    items.push('<div class="settings-divider"></div>');
-    orIds.forEach(id => {
-      const lv = levels[id];
-      const label = id==='or5'?'5m OR':id==='or15'?'15m OR':'30m OR';
-      items.push(settingsItem(label, C.orLevel, lv.visible, `toggleLevel('${id}')`));
-    });
-  }
-
-  pop.innerHTML = items.join('');
 }
-
-function settingsItem(label, color, active, onclick) {
-  return `<div class="settings-item" onclick="${onclick}">
-    <span class="check">${active ? '\u2713' : ''}</span>
-    <span class="dot" style="background:${color}"></span>
-    ${label}
-  </div>`;
-}
-
-// Gear button toggle
-document.getElementById('gearBtn').addEventListener('click', (e) => {
-  e.stopPropagation();
-  document.getElementById('settingsPopover').classList.toggle('open');
-});
-document.addEventListener('click', () => {
-  document.getElementById('settingsPopover').classList.remove('open');
-});
-document.getElementById('settingsPopover').addEventListener('click', (e) => {
-  e.stopPropagation();
-});
 
 // --- Opening range ---
 const OR_WINDOWS = [
@@ -493,6 +526,7 @@ function processCandleOR(candle) {
           { price:st.low, label:`${w.label} Lo`, color:C.orLevel, lineStyle:w.style, opacity:w.opacity },
         ], true);
         renderControls();
+        renderLegend();
       }
       return;
     }
@@ -682,6 +716,7 @@ function connect(dateOverride) {
       }
 
       renderControls();
+      renderLegend();
       setTimeout(() => { setTradingHoursView(); }, 100);
       return;
     }
@@ -729,6 +764,7 @@ function connect(dateOverride) {
       const id = (msg.label||'').replace(/\s+/g,'').toLowerCase();
       createLevel(id,[{price:msg.price,label:msg.label,color:msg.color,lineStyle:msg.lineStyle,opacity:msg.opacity}],true);
       renderControls();
+      renderLegend();
       return;
     }
   };

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -46,20 +46,45 @@
     }
     .date-input:focus { outline: none; border-color: var(--accent); }
 
-    /* Toggle buttons */
-    .toggle-btn {
-      display: inline-flex; align-items: center; gap: 5px;
-      padding: 4px 10px; font-size: 11px; font-weight: 500;
-      color: var(--text-dim); background: transparent;
-      border: 1px solid transparent; border-radius: 4px;
-      cursor: pointer; user-select: none; transition: all 0.12s; white-space: nowrap;
+    /* Segmented control (MKT/EXT) */
+    .seg-ctrl {
+      display: inline-flex; border: 1px solid var(--border); border-radius: 4px; overflow: hidden;
     }
-    .toggle-btn:hover { color: var(--text-muted); }
-    .toggle-btn.active { color: var(--text); border-color: var(--border); background: rgba(255,255,255,0.03); }
-    .toggle-btn .indicator {
-      width: 8px; height: 8px; border-radius: 2px; opacity: 0.8;
+    .seg-btn {
+      padding: 3px 10px; font-size: 10px; font-weight: 600; letter-spacing: 0.3px;
+      color: var(--text-dim); background: transparent; border: none;
+      cursor: pointer; transition: all 0.12s;
     }
-    .divider { width: 1px; height: 18px; background: var(--border); }
+    .seg-btn:not(:last-child) { border-right: 1px solid var(--border); }
+    .seg-btn.active { color: var(--text); background: rgba(255,255,255,0.06); }
+    .seg-btn:hover:not(.active) { color: var(--text-muted); }
+
+    /* Settings gear + popover */
+    .gear-btn {
+      background: none; border: 1px solid transparent; border-radius: 4px;
+      color: var(--text-dim); cursor: pointer; padding: 4px 6px; font-size: 14px;
+      transition: all 0.12s; line-height: 1;
+    }
+    .gear-btn:hover { color: var(--text); border-color: var(--border); }
+    .settings-popover {
+      display: none; position: absolute; top: 40px; right: 60px; z-index: 20;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+      padding: 8px 0; min-width: 160px; box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    }
+    .settings-popover.open { display: block; }
+    .settings-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 6px 14px; font-size: 12px; color: var(--text-muted);
+      cursor: pointer; transition: background 0.1s; user-select: none;
+    }
+    .settings-item:hover { background: rgba(255,255,255,0.04); }
+    .settings-item .dot {
+      width: 6px; height: 6px; border-radius: 2px; flex-shrink: 0;
+    }
+    .settings-item .check {
+      width: 14px; text-align: center; font-size: 11px; color: var(--accent); flex-shrink: 0;
+    }
+    .settings-divider { height: 1px; background: var(--border); margin: 4px 0; }
 
     /* Status */
     .status { display: flex; align-items: center; gap: 5px; }
@@ -76,12 +101,13 @@
 
     /* Resize handle between charts */
     .chart-resize-handle {
-      height: 5px; cursor: row-resize; background: var(--border);
+      height: 3px; cursor: row-resize;
+      background: linear-gradient(to right, transparent 0%, rgba(255,255,255,0.08) 15%, rgba(255,255,255,0.08) 85%, transparent 100%);
       position: relative; z-index: 5; flex-shrink: 0;
-      transition: background 0.15s;
+      transition: all 0.15s;
     }
     .chart-resize-handle:hover, .chart-resize-handle.dragging {
-      background: var(--accent); height: 5px;
+      background: linear-gradient(to right, transparent 0%, var(--accent) 15%, var(--accent) 85%, transparent 100%);
     }
     body.chart-resizing { cursor: row-resize; user-select: none; }
 
@@ -97,9 +123,12 @@
     <input type="date" class="date-input" id="dateInput" title="Trading date">
   </div>
 
-  <div class="toolbar-section controls" id="levelControls"></div>
+  <div class="toolbar-section" style="flex:1"></div>
 
   <div class="toolbar-section">
+    <div class="seg-ctrl" id="mktExtCtrl"></div>
+    <button class="gear-btn" id="gearBtn" title="Chart settings">&#9881;</button>
+    <div class="settings-popover" id="settingsPopover"></div>
     <div class="status">
       <div class="status-dot" id="statusDot"></div>
     </div>
@@ -128,24 +157,33 @@ const MARKET_OPEN_H = 9, MARKET_OPEN_M = 30;
 const candleEl = document.getElementById('chart-candle');
 const macdEl = document.getElementById('chart-macd');
 
+// Format time as AM/PM — shared by tick labels and crosshair tooltip
+function fmtTime(epochSec) {
+  const d = new Date(epochSec * 1000);
+  const h = d.getUTCHours(), m = d.getUTCMinutes();
+  const hh = h > 12 ? h - 12 : (h === 0 ? 12 : h);
+  const mm = m < 10 ? '0' + m : '' + m;
+  return `${hh}:${mm} ${h >= 12 ? 'PM' : 'AM'}`;
+}
+
 const chartOpts = () => ({
-  layout: { background: { type: 'solid', color: C.bg }, textColor: C.text },
+  layout: { background: { type: 'solid', color: C.bg }, textColor: C.text, fontFamily: 'monospace' },
   grid: { vertLines: { color: C.grid }, horzLines: { color: C.grid } },
   crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
-  rightPriceScale: { borderColor: C.border, scaleMargins: { top: 0.05, bottom: 0.05 } },
+  rightPriceScale: { visible: false },
+  leftPriceScale: { visible: true, borderColor: C.border, scaleMargins: { top: 0.05, bottom: 0.05 } },
+  localization: {
+    timeFormatter: (t) => fmtTime(t),
+  },
   timeScale: {
     borderColor: C.border, timeVisible: true, secondsVisible: false,
     tickMarkFormatter: (time, tickMarkType) => {
-      const d = new Date(time * 1000);
-      const h = d.getUTCHours(), m = d.getUTCMinutes();
       if (tickMarkType <= 2) {
-        // Date-level: show month/day
+        const d = new Date(time * 1000);
         const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
         return `${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
       }
-      const hh = h > 12 ? h - 12 : (h === 0 ? 12 : h);
-      const mm = m < 10 ? '0' + m : '' + m;
-      return `${hh}:${mm} ${h >= 12 ? 'PM' : 'AM'}`;
+      return fmtTime(time);
     },
   },
   handleScroll: { mouseWheel: true, pressedMouseMove: true, horzTouchDrag: true },
@@ -154,13 +192,27 @@ const chartOpts = () => ({
 
 // Create charts with explicit dimensions — flex containers may not have
 // concrete pixel sizes at creation time
+// Pad price labels to consistent width so both charts' left axes align.
+// LWC auto-sizes price scales from label width — matching char count = matching width.
+const PAD = 8;
+const candleFmt = (p) => p.toFixed(0).padStart(PAD);
+const macdFmt = (p) => p.toFixed(2).padStart(PAD);
+
 const candleChart = LightweightCharts.createChart(candleEl, {
   ...chartOpts(),
+  localization: { ...chartOpts().localization, priceFormatter: candleFmt },
+  timeScale: { ...chartOpts().timeScale, visible: false },
   width: candleEl.clientWidth || window.innerWidth,
   height: candleEl.clientHeight || Math.floor(window.innerHeight * 0.65),
 });
 const macdChart = LightweightCharts.createChart(macdEl, {
   ...chartOpts(),
+  localization: { ...chartOpts().localization, priceFormatter: macdFmt },
+  watermark: {
+    visible: true, text: 'MACD (12,26,9)',
+    color: 'rgba(255,255,255,0.06)', fontSize: 12,
+    horzAlign: 'left', vertAlign: 'top',
+  },
   width: macdEl.clientWidth || window.innerWidth,
   height: macdEl.clientHeight || Math.floor(window.innerHeight * 0.2),
 });
@@ -178,13 +230,23 @@ macdChart.timeScale().subscribeVisibleLogicalRangeChange(r => {
   candleChart.timeScale().setVisibleLogicalRange(r); syncing = false;
 });
 
+// Sync crosshairs between panes
+candleChart.subscribeCrosshairMove(param => {
+  if (!param.time) { macdChart.clearCrosshairPosition(); return; }
+  macdChart.setCrosshairPosition(0, param.time, macdHistSeries);
+});
+macdChart.subscribeCrosshairMove(param => {
+  if (!param.time) { candleChart.clearCrosshairPosition(); return; }
+  candleChart.setCrosshairPosition(0, param.time, candleSeries);
+});
+
 // --- Series ---
 const candleSeries = candleChart.addCandlestickSeries({
   upColor: C.candleUpBody, downColor: C.candleDownBody,
   borderUpColor: C.candleUpBorder, borderDownColor: C.candleDownBorder,
   wickUpColor: C.candleUpBorder, wickDownColor: C.candleDownBorder,
-  lastValueVisible: false,
-  priceLineVisible: false,
+  lastValueVisible: false, priceLineVisible: false,
+  priceScaleId: 'left',
 });
 
 // HMA: segment series per color run
@@ -199,6 +261,7 @@ function createHmaSegmentSeries(color) {
   const series = candleChart.addLineSeries({
     color, lineWidth: 1,
     priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
+    priceScaleId: 'left',
   });
   if (!hmaVisible) series.applyOptions({ visible: false });
   const entry = { series, color };
@@ -229,21 +292,25 @@ function buildHmaSegments(hmaData, candleTimes) {
 
 const macdHistSeries = macdChart.addHistogramSeries({
   priceLineVisible: false, lastValueVisible: false,
-  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+  priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+  priceScaleId: 'left',
 });
 const macdValueSeries = macdChart.addLineSeries({
   color: C.macdValue, lineWidth: 1,
   priceLineVisible: false, lastValueVisible: false,
-  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+  priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+  priceScaleId: 'left',
 });
 const macdSignalSeries = macdChart.addLineSeries({
   color: C.macdSignal, lineWidth: 1,
   priceLineVisible: false, lastValueVisible: false,
-  priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+  priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+  priceScaleId: 'left',
 });
 const macdZeroSeries = macdChart.addLineSeries({
   color: C.macdZero, lineWidth: 1, lineStyle: LightweightCharts.LineStyle.Dotted,
   priceLineVisible: false, lastValueVisible: false,
+  priceScaleId: 'left',
 });
 
 // --- State ---
@@ -312,7 +379,7 @@ function createLevelSeries(entry) {
     lineStyle: lwcStyle(entry.lineStyle),
     priceLineVisible: false, lastValueVisible: false,
     crosshairMarkerVisible: false,
-    // Exclude from auto-scale so levels don't stretch the candle y-axis
+    priceScaleId: 'left',
     autoscaleInfoProvider: () => null,
   });
   series.setData([
@@ -342,51 +409,66 @@ function toggleLevel(id) {
 }
 
 function renderControls() {
-  const el = document.getElementById('levelControls');
-  const parts = [];
+  // Segmented control: MKT / EXT
+  const seg = document.getElementById('mktExtCtrl');
+  seg.innerHTML = `
+    <button class="seg-btn ${hasMarketHours ? 'active' : ''}" onclick="toggleMarketHours()">MKT</button>
+    <button class="seg-btn ${hasMarketHours ? '' : 'active'}" onclick="toggleMarketHours()">EXT</button>`;
+
+  // Settings popover items
+  const pop = document.getElementById('settingsPopover');
+  const items = [];
 
   // HMA
-  const hmaCls = hmaVisible ? 'active' : '';
-  parts.push(`<button class="toggle-btn ${hmaCls}" onclick="toggleHma()">
-    <span class="indicator" style="background:${C.hmaUp}"></span>HMA</button>`);
-
-  parts.push('<div class="divider"></div>');
+  items.push(settingsItem('HMA', C.hmaUp, hmaVisible, 'toggleHma()'));
+  items.push('<div class="settings-divider"></div>');
 
   // Prior levels
   ['priorClose','priorHigh','priorLow'].forEach(id => {
     if (!levels[id]) return;
-    const lv = levels[id], e = lv.entries[0], cls = lv.visible ? 'active' : '';
-    parts.push(`<button class="toggle-btn ${cls}" onclick="toggleLevel('${id}')">
-      <span class="indicator" style="background:${e.color}"></span>${e.label}</button>`);
+    const lv = levels[id], e = lv.entries[0];
+    items.push(settingsItem(e.label, e.color, lv.visible, `toggleLevel('${id}')`));
   });
 
   // OR levels
   const orIds = ['or5','or15','or30'].filter(id => levels[id]);
   if (orIds.length) {
-    parts.push('<div class="divider"></div>');
+    items.push('<div class="settings-divider"></div>');
     orIds.forEach(id => {
-      const lv = levels[id], cls = lv.visible ? 'active' : '';
+      const lv = levels[id];
       const label = id==='or5'?'5m OR':id==='or15'?'15m OR':'30m OR';
-      parts.push(`<button class="toggle-btn ${cls}" onclick="toggleLevel('${id}')">
-        <span class="indicator" style="background:${C.orLevel}"></span>${label}</button>`);
+      items.push(settingsItem(label, C.orLevel, lv.visible, `toggleLevel('${id}')`));
     });
   }
 
-  // Market hours toggle
-  parts.push('<div class="divider"></div>');
-  const mhCls = hasMarketHours ? 'active' : '';
-  const extCls = hasMarketHours ? '' : 'active';
-  parts.push(`<button class="toggle-btn ${mhCls}" onclick="toggleMarketHours()" title="Market hours (9:00–4:30)">MKT</button>`);
-  parts.push(`<button class="toggle-btn ${extCls}" onclick="toggleMarketHours()" title="Extended / 24h view">EXT</button>`);
-
-  el.innerHTML = parts.join('');
+  pop.innerHTML = items.join('');
 }
+
+function settingsItem(label, color, active, onclick) {
+  return `<div class="settings-item" onclick="${onclick}">
+    <span class="check">${active ? '\u2713' : ''}</span>
+    <span class="dot" style="background:${color}"></span>
+    ${label}
+  </div>`;
+}
+
+// Gear button toggle
+document.getElementById('gearBtn').addEventListener('click', (e) => {
+  e.stopPropagation();
+  document.getElementById('settingsPopover').classList.toggle('open');
+});
+document.addEventListener('click', () => {
+  document.getElementById('settingsPopover').classList.remove('open');
+});
+document.getElementById('settingsPopover').addEventListener('click', (e) => {
+  e.stopPropagation();
+});
 
 // --- Opening range ---
 const OR_WINDOWS = [
-  { min:5, id:'or5', label:'5m', style:'solid', opacity:0.75 },
-  { min:15, id:'or15', label:'15m', style:'solid', opacity:0.45 },
-  { min:30, id:'or30', label:'30m', style:'dotted', opacity:0.45 },
+  { min:5, id:'or5', label:'5m', style:'solid', opacity:0.6 },
+  { min:15, id:'or15', label:'15m', style:'dashed', opacity:0.4 },
+  { min:30, id:'or30', label:'30m', style:'dotted', opacity:0.3 },
 ];
 const orState = {};
 
@@ -550,6 +632,13 @@ function connect(dateOverride) {
       if (msg.date) document.getElementById('dateInput').value = msg.date;
 
       lastCandles = msg.candles;
+      // Auto-fit price precision: no decimals for large prices, 2 for small
+      if (msg.candles.length) {
+        const mid = msg.candles[Math.floor(msg.candles.length / 2)].close;
+        const prec = mid >= 100 ? 0 : mid >= 1 ? 2 : 4;
+        const mv = mid >= 100 ? 1 : mid >= 1 ? 0.01 : 0.0001;
+        candleSeries.applyOptions({ priceFormat: { type:'price', precision:prec, minMove:mv } });
+      }
       candleSeries.setData(msg.candles);
       computeBounds(msg.candles);
       // Only compute opening range for instruments with market hours
@@ -578,15 +667,15 @@ function connect(dateOverride) {
       if (msg.dailyCandle) {
         const dc = msg.dailyCandle;
         if (dc.close != null) {
-          createLevel('priorClose',[{price:dc.close, label:'Prior Close', color:C.priorClose, lineStyle:'dotted', opacity:0.45}], true);
+          createLevel('priorClose',[{price:dc.close, label:'Prior Close', color:C.priorClose, lineStyle:'dotted', opacity:0.35}], true);
           priorLevelPrices.push(dc.close);
         }
         if (dc.high != null) {
-          createLevel('priorHigh',[{price:dc.high, label:'Prior Hi', color:C.priorHigh, lineStyle:'dotted', opacity:0.45}], true);
+          createLevel('priorHigh',[{price:dc.high, label:'Prior Hi', color:C.priorHigh, lineStyle:'dotted', opacity:0.25}], true);
           priorLevelPrices.push(dc.high);
         }
         if (dc.low != null) {
-          createLevel('priorLow',[{price:dc.low, label:'Prior Lo', color:C.priorLow, lineStyle:'dotted', opacity:0.45}], true);
+          createLevel('priorLow',[{price:dc.low, label:'Prior Lo', color:C.priorLow, lineStyle:'dotted', opacity:0.25}], true);
           priorLevelPrices.push(dc.low);
         }
         applyPriorLevelScale(msg.candles);

--- a/uv.lock
+++ b/uv.lock
@@ -2772,6 +2772,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3242,6 +3261,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -3842,6 +3873,7 @@ dev = [
     { name = "jupyterlab" },
     { name = "mypy" },
     { name = "pandas-stubs" },
+    { name = "playwright" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -3899,6 +3931,7 @@ dev = [
     { name = "jupyterlab", specifier = ">=4.4.5" },
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pandas-stubs", specifier = ">=2.3.0.250703" },
+    { name = "playwright", specifier = ">=1.58.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary
- Standalone live charting module (`tasty-chart` CLI) rendering ThinkorSwim-style interactive charts in the browser using TradingView's lightweight-charts library
- Event-driven architecture: InfluxDB for historical candles, Redis pub/sub for live streaming via WebSocket
- HMA-20 (color-coded direction segments) and MACD (12,26,9) with 4-shade histogram
- Prior day levels (Close/Hi/Lo) and Opening Range (5m/15m/30m) with toggleable legend
- Supports equities, futures, and 24/7 instruments (crypto) with MKT/EXT view toggle

## What's included
- `src/tastytrade/charting/` — server, feed, indicators, CLI, frontend
- `justfile` — `chart`, `chart-list`, `chart-kill` recipes
- Shared time axis between candle and MACD panes with crosshair sync
- Draggable chart legend with click-to-toggle visibility
- ET timezone display, auto-fit price precision, monospace axis alignment
- Fix for live indicator divergence (one update per candle period, not per tick)

## Test plan
- [ ] `just chart` starts server, prints URL, loads SPX 1m chart
- [ ] `just chart SPY` loads SPY chart with prior day levels
- [ ] `just chart BTC/USD:CXTALP` loads 24/7 crypto chart (EXT mode)
- [ ] Live candle updates stream via WebSocket (green status dot)
- [ ] HMA color-codes direction changes (cyan up, magenta down)
- [ ] MACD histogram uses 4-shade coloring
- [ ] Legend toggles show/hide HMA, prior levels, OR levels
- [ ] Legend is draggable via grip bar
- [ ] MKT/EXT toggle switches between market hours and full day view
- [ ] Date picker navigates to historical dates
- [ ] `just chart-list` shows running servers, `just chart-kill 8091` stops them