### PR TITLE
TT-99: Add interactive chart controls with symbol picker and interval dropdown

### DIFF
--- a/src/tastytrade/charting/server.py
+++ b/src/tastytrade/charting/server.py
@@ -128,6 +128,25 @@ class ChartServer:
         async def config() -> dict:
             return {"symbol": self.symbol, "interval": self.interval}
 
+        @app.get("/api/symbols")
+        async def symbols() -> dict:
+            """Return deduplicated base symbols from active subscriptions."""
+            from tastytrade.connections.subscription import (
+                RedisSubscriptionStore,
+            )
+
+            store = RedisSubscriptionStore()
+            try:
+                await store.initialize()
+                subs = await store.get_active_subscriptions()
+                base = {sym.split("{=")[0] for sym in subs if "{=" in sym}
+                return {"symbols": sorted(base)}
+            except Exception:
+                logger.exception("Failed to fetch symbols")
+                return {"symbols": []}
+            finally:
+                await store.redis.close()  # type: ignore[union-attr]
+
         @app.websocket("/ws")
         async def websocket_endpoint(ws: WebSocket) -> None:
             await ws.accept(subprotocol=None)

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -33,17 +33,43 @@
     .toolbar-section.controls {
       flex: 1; justify-content: center; gap: 6px;
     }
-    .symbol-name { font-size: 15px; font-weight: 700; color: var(--text); letter-spacing: 0.3px; }
-    .badge {
-      font-size: 10px; font-weight: 600; color: var(--text-muted);
-      background: rgba(255,255,255,0.06); padding: 3px 8px; border-radius: 4px;
-      letter-spacing: 0.3px;
+    /* Dropdown controls */
+    .dropdown {
+      position: relative; display: inline-block;
     }
+    .dropdown-btn {
+      background: var(--surface-2); border: 1px solid var(--border); border-radius: 4px;
+      color: var(--text); font-size: 12px; font-family: monospace; font-weight: 600;
+      padding: 4px 24px 4px 8px; cursor: pointer; white-space: nowrap;
+      appearance: none; user-select: none;
+    }
+    .dropdown-btn:hover { border-color: var(--text-dim); }
+    .dropdown-btn::after {
+      content: '\25BE'; position: absolute; right: 8px; top: 50%;
+      transform: translateY(-50%); font-size: 9px; color: var(--text-dim);
+      pointer-events: none;
+    }
+    .dropdown-btn.sym { font-size: 15px; font-weight: 700; padding: 4px 28px 4px 8px; letter-spacing: 0.3px; }
+    .dropdown-list {
+      display: none; position: absolute; top: 100%; left: 0; z-index: 30;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 4px;
+      margin-top: 2px; max-height: 300px; overflow-y: auto; min-width: 100%;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+    }
+    .dropdown-list.open { display: block; }
+    .dropdown-list.right { left: auto; right: 0; }
+    .dropdown-item {
+      padding: 6px 12px; font-size: 12px; font-family: monospace;
+      color: var(--text-muted); cursor: pointer; white-space: nowrap;
+    }
+    .dropdown-item:hover { background: rgba(255,255,255,0.05); color: var(--text); }
+    .dropdown-item.active { color: var(--accent); }
     .date-input {
       background: var(--surface-2); border: 1px solid var(--border); border-radius: 4px;
       color: var(--text); font-size: 12px; padding: 4px 8px; cursor: pointer;
-      font-family: inherit; color-scheme: dark;
+      font-family: monospace; color-scheme: dark;
     }
+    .date-input:hover { border-color: var(--text-dim); }
     .date-input:focus { outline: none; border-color: var(--accent); }
 
     /* Segmented control (MKT/EXT) */
@@ -126,8 +152,14 @@
 
 <div class="toolbar">
   <div class="toolbar-section">
-    <span class="symbol-name" id="symbolName">---</span>
-    <span class="badge" id="intervalBadge">--</span>
+    <div class="dropdown" id="symbolDropdown">
+      <div class="dropdown-btn sym" id="symbolBtn">---</div>
+      <div class="dropdown-list" id="symbolList"></div>
+    </div>
+    <div class="dropdown" id="intervalDropdown">
+      <div class="dropdown-btn" id="intervalBtn">1m</div>
+      <div class="dropdown-list" id="intervalList"></div>
+    </div>
     <input type="date" class="date-input" id="dateInput" title="Trading date">
   </div>
 
@@ -627,18 +659,90 @@ function setStatus(state) {
   document.getElementById('statusDot').className = 'status-dot ' + state;
 }
 
+// --- Dropdown controls ---
+const INTERVALS = [
+  { value:'m', label:'1m' }, { value:'5m', label:'5m' },
+  { value:'15m', label:'15m' }, { value:'30m', label:'30m' },
+  { value:'1h', label:'1h' }, { value:'1d', label:'1d' },
+];
+let currentSymbol = 'SPX';
+let currentInterval = 'm';
+
 function getParams() {
   const p = new URLSearchParams(window.location.search);
   return { symbol: p.get('symbol') || 'SPX', interval: p.get('interval') || 'm' };
 }
+
+function initDropdown(btnId, listId, items, onSelect) {
+  const btn = document.getElementById(btnId);
+  const list = document.getElementById(listId);
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    // Close other dropdowns
+    document.querySelectorAll('.dropdown-list.open').forEach(el => {
+      if (el.id !== listId) el.classList.remove('open');
+    });
+    list.classList.toggle('open');
+  });
+  list.addEventListener('click', (e) => {
+    const item = e.target.closest('.dropdown-item');
+    if (!item) return;
+    onSelect(item.dataset.value);
+    list.classList.remove('open');
+  });
+}
+
+function populateIntervals() {
+  const list = document.getElementById('intervalList');
+  list.innerHTML = INTERVALS.map(i =>
+    `<div class="dropdown-item ${i.value === currentInterval ? 'active' : ''}" data-value="${i.value}">${i.label}</div>`
+  ).join('');
+}
+
+async function populateSymbols() {
+  try {
+    const resp = await fetch('/api/symbols');
+    const data = await resp.json();
+    const list = document.getElementById('symbolList');
+    list.innerHTML = (data.symbols || []).map(s =>
+      `<div class="dropdown-item ${s === currentSymbol ? 'active' : ''}" data-value="${s}">${s}</div>`
+    ).join('');
+  } catch(e) { /* symbols endpoint unavailable */ }
+}
+
+// Close all dropdowns on outside click
+document.addEventListener('click', () => {
+  document.querySelectorAll('.dropdown-list.open').forEach(el => el.classList.remove('open'));
+});
+
+initDropdown('symbolBtn', 'symbolList', [], (sym) => {
+  currentSymbol = sym;
+  const p = new URLSearchParams(window.location.search);
+  p.set('symbol', sym); p.set('interval', currentInterval);
+  history.replaceState(null, '', '?' + p.toString());
+  document.getElementById('symbolBtn').textContent = sym;
+  connect();
+});
+
+initDropdown('intervalBtn', 'intervalList', [], (intv) => {
+  currentInterval = intv;
+  const label = INTERVALS.find(i => i.value === intv)?.label || intv;
+  const p = new URLSearchParams(window.location.search);
+  p.set('symbol', currentSymbol); p.set('interval', intv);
+  history.replaceState(null, '', '?' + p.toString());
+  document.getElementById('intervalBtn').textContent = label;
+  connect();
+});
 
 function connect(dateOverride) {
   setStatus('connecting');
   intentionalClose = true;
 
   const { symbol, interval } = getParams();
-  document.getElementById('symbolName').textContent = symbol;
-  document.getElementById('intervalBadge').textContent = interval === 'm' ? '1m' : interval;
+  currentSymbol = symbol; currentInterval = interval;
+  document.getElementById('symbolBtn').textContent = symbol;
+  document.getElementById('intervalBtn').textContent = INTERVALS.find(i => i.value === interval)?.label || interval;
+  populateIntervals();
 
   if (ws) { try { ws.close(); } catch(e) {} ws = null; }
 
@@ -795,6 +899,8 @@ window.addEventListener('resize', resize);
 new ResizeObserver(resize).observe(candleEl);
 new ResizeObserver(resize).observe(macdEl);
 
+populateSymbols();
+populateIntervals();
 connect();
 </script>
 </body>

--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -96,7 +96,7 @@
 
     /* Chart legend */
     .chart-legend {
-      position: absolute; bottom: 8px; left: 90px; z-index: 10;
+      position: absolute; top: 60%; left: 90px; z-index: 10;
       background: rgba(19,19,19,0.88); border: 1px solid var(--border);
       border-radius: 5px; overflow: hidden;
       font-family: monospace; font-size: 11px;
@@ -237,9 +237,14 @@ const chartOpts = () => ({
 // concrete pixel sizes at creation time
 // Pad price labels to consistent width so both charts' left axes align.
 // LWC auto-sizes price scales from label width — matching char count = matching width.
-const PAD = 8;
-const candleFmt = (p) => p.toFixed(0).padStart(PAD);
-const macdFmt = (p) => p.toFixed(2).padStart(PAD);
+// Pad both formatters to same width so left axes align
+const fmtWidth = 7;
+const candleFmt = (p) => {
+  const abs = Math.abs(p);
+  const dec = abs >= 1000 ? 0 : abs >= 10 ? 2 : 4;
+  return p.toFixed(dec).padStart(fmtWidth);
+};
+const macdFmt = (p) => p.toFixed(2).padStart(fmtWidth);
 
 const candleChart = LightweightCharts.createChart(candleEl, {
   ...chartOpts(),
@@ -362,7 +367,8 @@ let hmaVisible = true;
 let lastCandles = [];
 let viewStartEpoch = 0;  // 9:00 AM — for default zoom
 let levelStartEpoch = 0; // 9:30 AM — for horizontal lines
-let levelEndEpoch = 0;   // 4:30 PM — for horizontal lines + view end
+let levelEndEpoch = 0;   // last candle — for horizontal line endpoint
+let marketCloseEpoch = 0; // 4:30 PM — for view range end
 const levels = {};
 
 function lwcStyle(s) {
@@ -375,22 +381,29 @@ function lwcStyle(s) {
 let hasMarketHours = true;
 
 function computeBounds(candles) {
-  viewStartEpoch = 0; levelStartEpoch = 0; levelEndEpoch = 0;
+  viewStartEpoch = 0; levelStartEpoch = 0; levelEndEpoch = 0; marketCloseEpoch = 0;
 
   for (const c of candles) {
     const d = new Date(c.time * 1000);
     const h = d.getUTCHours(), m = d.getUTCMinutes();
-    if (h === 9 && m >= 0 && viewStartEpoch === 0) viewStartEpoch = c.time;
-    if (h === 9 && m >= 30 && levelStartEpoch === 0) levelStartEpoch = c.time;
     if (h < 16 || (h === 16 && m <= 30)) levelEndEpoch = c.time;
   }
 
-  if (!hasMarketHours || viewStartEpoch === 0) {
+  // Compute fixed times from chart date (independent of candle data)
+  if (candles.length) {
+    const d = new Date(candles[0].time * 1000);
+    const y = d.getUTCFullYear(), mo = d.getUTCMonth(), day = d.getUTCDate();
+    viewStartEpoch = Date.UTC(y, mo, day, 8, 30) / 1000;   // 8:30 AM
+    levelStartEpoch = Date.UTC(y, mo, day, 9, 30) / 1000;   // 9:30 AM
+    marketCloseEpoch = Date.UTC(y, mo, day, 16, 30) / 1000;  // 4:30 PM
+  }
+
+  if (!hasMarketHours) {
     viewStartEpoch = candles.length ? candles[0].time : 0;
     levelStartEpoch = viewStartEpoch;
     levelEndEpoch = candles.length ? candles[candles.length - 1].time : 0;
+    marketCloseEpoch = levelEndEpoch;
   } else {
-    if (levelStartEpoch === 0) levelStartEpoch = viewStartEpoch;
     if (levelEndEpoch === 0 && candles.length) levelEndEpoch = candles[candles.length - 1].time;
   }
 }
@@ -428,7 +441,7 @@ function createLevelSeries(entry) {
   });
   series.setData([
     { time: levelStartEpoch, value: entry.price },
-    { time: levelEndEpoch, value: entry.price },
+    { time: marketCloseEpoch || levelEndEpoch, value: entry.price },
   ]);
   return series;
 }
@@ -500,13 +513,6 @@ function renderLegend() {
 
   grip.addEventListener('mousedown', (e) => {
     dragging = true; startX = e.clientX; startY = e.clientY;
-    // Switch from bottom-anchored to top-anchored on first drag
-    if (legend.style.bottom !== '') {
-      const rect = legend.getBoundingClientRect();
-      const parentRect = legend.parentElement.getBoundingClientRect();
-      legend.style.top = (rect.top - parentRect.top) + 'px';
-      legend.style.bottom = 'auto';
-    }
     origLeft = legend.offsetLeft; origTop = legend.offsetTop;
     legend.classList.add('dragging');
     e.preventDefault();
@@ -568,13 +574,41 @@ function processCandleOR(candle) {
 }
 
 // --- View & scale ---
+// Invisible anchor series — extends the time axis beyond candle data
+const anchorSeries = candleChart.addLineSeries({
+  color: 'transparent', lineWidth: 0,
+  priceLineVisible: false, lastValueVisible: false,
+  crosshairMarkerVisible: false, priceScaleId: 'left',
+  autoscaleInfoProvider: () => null,
+});
+// MACD anchor on a hidden scale — extends time axis without affecting MACD y-axis
+const macdAnchorSeries = macdChart.addLineSeries({
+  color: 'transparent', lineWidth: 0,
+  priceLineVisible: false, lastValueVisible: false,
+  crosshairMarkerVisible: false, priceScaleId: 'anchor-hidden',
+  autoscaleInfoProvider: () => null,
+});
+macdChart.priceScale('anchor-hidden').applyOptions({ visible: false });
+
 function setTradingHoursView() {
   if (!hasMarketHours) {
     candleChart.timeScale().fitContent();
     return;
   }
-  if (viewStartEpoch === 0 || levelEndEpoch === 0) return;
-  candleChart.timeScale().setVisibleRange({ from: viewStartEpoch - 300, to: levelEndEpoch + 600 });
+  if (viewStartEpoch === 0 || marketCloseEpoch === 0) return;
+  const from = viewStartEpoch;
+  const lastCandle = lastCandles.length ? lastCandles[lastCandles.length - 1].time : levelStartEpoch;
+  const to = Math.min(marketCloseEpoch, Math.max(lastCandle + 7200, levelStartEpoch + 7200));
+  // Populate anchor series across full range so LWC extends the time axis
+  const anchors = [];
+  for (let t = from; t <= to; t += 300) anchors.push({ time: t, value: 0 });
+  anchorSeries.setData(anchors);
+  macdAnchorSeries.setData(anchors);
+  // Set range on both charts — syncing flag prevents callback fight
+  syncing = true;
+  candleChart.timeScale().setVisibleRange({ from, to });
+  macdChart.timeScale().setVisibleRange({ from, to });
+  syncing = false;
 }
 
 // Extend candle series auto-scale to include prior day levels.
@@ -829,13 +863,15 @@ function connect(dateOverride) {
       candleSeries.update(msg.candle);
       processCandleOR(msg.candle);
 
-      // Extend all visible level lines to the latest candle time
-      const newTime = msg.candle.time;
-      for (const id in levels) {
-        if (levels[id].visible) {
-          levels[id].seriesList.forEach((s, i) => {
-            s.update({ time: newTime, value: levels[id].entries[i].price });
-          });
+      // Extend level lines in EXT mode only (MKT uses fixed 4:30 PM endpoint)
+      if (!hasMarketHours) {
+        const newTime = msg.candle.time;
+        for (const id in levels) {
+          if (levels[id].visible) {
+            levels[id].seriesList.forEach((s, i) => {
+              s.update({ time: newTime, value: levels[id].entries[i].price });
+            });
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Replace static toolbar inputs with custom-styled dropdown controls for symbol, interval, and date
- Add `/api/symbols` endpoint serving deduplicated base symbols from active Redis candle subscriptions
- Fix chart view range, MACD pane alignment, and adaptive price precision

## Related Jira Issue
**Jira**: [TT-99](https://mandeng.atlassian.net/browse/TT-99)

## Changes
- **Symbol dropdown** — populated from `/api/symbols`, triggers WebSocket reconnect on selection
- **Interval dropdown** — 1m, 5m, 15m, 30m, 1h, 1d with human-readable labels
- **View range** — fixed 8:30 AM start, adaptive end (last candle + 2h, capped at 4:30 PM)
- **MACD alignment** — anchor series on hidden price scale keeps panes synced on scroll
- **Price precision** — adaptive: 0 decimals for prices >=1000, 2 for >=10, 4 for <10
- **Level lines** — span full business day in MKT mode (no per-tick extension)
- **Legend** — repositioned away from MACD divider

## Test plan
- [x] Symbol dropdown lists all actively subscribed candle symbols
- [x] Selecting a symbol reconnects WebSocket and loads new chart
- [x] Interval dropdown switches between 1m, 5m, 15m, 30m, 1h, 1d
- [x] MKT view shows 8:30 AM to adaptive end, EXT shows all data
- [x] MACD pane stays aligned when scrolling right past candle data
- [x] Crude oil (/CLK26) shows 2-decimal prices, SPX shows whole numbers
- [x] Level lines span 9:30 AM to 4:30 PM without per-tick updates
- [x] Live candle updates stream correctly after symbol switch

[TT-99]: https://mandeng.atlassian.net/browse/TT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ