### PR TITLE
TT-99: Debounce WebSocket connect to prevent rapid reconnection loop

### DIFF
--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -768,7 +768,14 @@ initDropdown('intervalBtn', 'intervalList', [], (intv) => {
   connect();
 });
 
+let connectTimer = null;
 function connect(dateOverride) {
+  // Debounce rapid calls (page reload + dropdown init can fire multiple times)
+  if (connectTimer) clearTimeout(connectTimer);
+  connectTimer = setTimeout(() => doConnect(dateOverride), 100);
+}
+
+function doConnect(dateOverride) {
   setStatus('connecting');
   intentionalClose = true;
 


### PR DESCRIPTION
## Summary
- Dropdown selections and page loads could fire `connect()` multiple times in quick succession, killing the WebSocket before live streaming began
- A 100ms debounce collapses rapid calls into a single connection

## Changes
- Wrap `connect()` with a `setTimeout` debounce that clears on each call
- Actual connection logic moved to `doConnect()`
- Fixes the rapid reconnect loop visible in server logs (connect → disconnect → connect within 1 second)

## Test plan
- [ ] Load chart page — single WebSocket connection (no rapid reconnect in server logs)
- [ ] Switch symbol via dropdown — clean disconnect + single reconnect
- [ ] Switch interval via dropdown — clean disconnect + single reconnect
- [ ] Live candle updates continue streaming after initial load
- [ ] Verified: 4 live update messages received in 15 seconds (QQQ 1m)