### PR TITLE
TT-73: Fix mypy false positives on Pydantic aliased fields

### DIFF
--- a/src/tastytrade/accounts/messages.py
+++ b/src/tastytrade/accounts/messages.py
@@ -29,8 +29,12 @@ class StreamerConnectMessage(BaseModel):
 
     action: str = Field(default="connect")
     value: list[str] = Field(description="Account numbers to subscribe to")
-    auth_token: str = Field(alias="auth-token", description="Raw session token")
-    request_id: int = Field(alias="request-id", description="Client request ID")
+    auth_token: str = Field(
+        serialization_alias="auth-token", description="Raw session token"
+    )
+    request_id: int = Field(
+        serialization_alias="request-id", description="Client request ID"
+    )
 
 
 class StreamerHeartbeatMessage(BaseModel):
@@ -48,8 +52,12 @@ class StreamerHeartbeatMessage(BaseModel):
     )
 
     action: str = Field(default="heartbeat")
-    auth_token: str = Field(alias="auth-token", description="Raw session token")
-    request_id: int = Field(alias="request-id", description="Client request ID")
+    auth_token: str = Field(
+        serialization_alias="auth-token", description="Raw session token"
+    )
+    request_id: int = Field(
+        serialization_alias="request-id", description="Client request ID"
+    )
 
 
 class StreamerResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Switch outbound streamer message models (`StreamerConnectMessage`, `StreamerHeartbeatMessage`) from `alias` to `serialization_alias` so mypy recognizes Python field names as canonical constructor arguments
- Eliminates 4 false-positive mypy errors in `accounts/streamer.py` without suppression comments
- Wire format (hyphenated JSON keys) is preserved — `model_dump_json(by_alias=True)` still produces `auth-token` and `request-id`

## Related Jira Issue
**Jira**: [TT-73](https://mandeng.atlassian.net/browse/TT-73)

## Verification Evidence

**AC1 — mypy passes cleanly:**
```
$ uv run mypy src/tastytrade/accounts/streamer.py
Success: no issues found in 1 source file
```

**AC2 — No type: ignore comments:**
No `type: ignore` in changed file.

**AC3 — Wire format unchanged:**
```json
ConnectMessage: {"action":"connect","value":["ACCT1"],"auth-token":"tok123","request-id":1}
HeartbeatMessage: {"action":"heartbeat","auth-token":"tok123","request-id":2}
```

**AC4 — No regressions:**
```
822 passed, 0 failures
```

## Test Evidence

- All tests passing (`just test`) — 822 passed, 0 failures
- Pre-commit hooks passed (ruff, ruff-format, mypy, etc.)

## Test plan
- [x] mypy passes with zero errors on `accounts/streamer.py`
- [x] No `type: ignore` suppressions added
- [x] JSON serialization preserves hyphenated wire keys
- [x] Full test suite passes (822 tests)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, etc.)

## Changes Made

- `src/tastytrade/accounts/messages.py`: Replace `alias` with `serialization_alias` on `auth_token` and `request_id` fields in `StreamerConnectMessage` and `StreamerHeartbeatMessage` — mypy now sees `auth_token`/`request_id` as valid constructor kwargs while `model_dump_json(by_alias=True)` still emits hyphenated JSON keys

[TT-73]: https://mandeng.atlassian.net/browse/TT-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ