### PR TITLE
TT-91: Relocate trade explorer and remove stale futures symbols

### DIFF
--- a/docs/plans/features/TT-91-trade-explorer.html
+++ b/docs/plans/features/TT-91-trade-explorer.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Trade Fills</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap');
+  :root {
+    --ink: #c9d1d9; --ink-2: #8b949e; --ink-3: #6e7681;
+    --paper: #0d1117; --paper-raised: #161b22; --paper-inset: #090c10;
+    --rule: #30363d; --gain: #3fb950; --loss: #f85149; --hl: #58a6ff;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'JetBrains Mono', monospace; background: var(--paper); color: var(--ink); font-size: 12px; line-height: 1.5; }
+
+  .shell { display: flex; flex-direction: column; height: 100vh; }
+  .topbar { padding: 12px 20px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 20px; background: var(--paper-raised); flex-shrink: 0; }
+  .topbar h1 { font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--hl); text-transform: uppercase; }
+  .refresh-btn {
+    background: var(--paper-inset); border: 1px solid var(--rule); color: var(--ink-2);
+    padding: 3px 10px; border-radius: 3px; font-family: inherit; font-size: 11px;
+    cursor: pointer; transition: border-color 0.15s, color 0.15s;
+  }
+  .refresh-btn:hover { border-color: var(--hl); color: var(--ink); }
+  .refresh-btn.loading { color: var(--hl); cursor: wait; }
+  .topbar .stat { color: var(--ink-2); font-size: 11px; }
+  .topbar .stat b { color: var(--ink); font-weight: 500; }
+
+  .filters { padding: 8px 20px; border-bottom: 1px solid var(--rule); display: flex; align-items: center; gap: 14px; background: var(--paper-raised); flex-shrink: 0; }
+  .filters label { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.8px; }
+  .filters select, .filters input { background: var(--paper-inset); border: 1px solid var(--rule); color: var(--ink); padding: 4px 8px; border-radius: 3px; font-family: inherit; font-size: 11px; }
+  .filters select:focus, .filters input:focus { outline: none; border-color: var(--hl); }
+
+  .workspace { display: flex; flex: 1; overflow: hidden; }
+  .timeline { overflow-y: auto; padding: 16px 20px; flex-shrink: 0; width: 380px; min-width: 260px; }
+  .gutter { width: 4px; cursor: col-resize; background: var(--rule); flex-shrink: 0; transition: background 0.1s; }
+  .gutter:hover, .gutter.active { background: var(--hl); }
+  .right-pane { flex: 1; display: flex; flex-direction: column; min-width: 200px; background: var(--paper-inset); }
+
+  .pane-tabs { display: flex; border-bottom: 1px solid var(--rule); flex-shrink: 0; }
+  .pane-tab { padding: 8px 16px; font-family: inherit; font-size: 11px; background: none; border: none; color: var(--ink-3); cursor: pointer; border-bottom: 2px solid transparent; text-transform: uppercase; letter-spacing: 0.5px; }
+  .pane-tab:hover { color: var(--ink-2); }
+  .pane-tab.active { color: var(--hl); border-bottom-color: var(--hl); }
+  .pane-body { flex: 1; overflow-y: auto; }
+  .pane-content { display: none; height: 100%; }
+  .pane-content.active { display: flex; flex-direction: column; }
+
+  .inspector-wrap { flex: 1; overflow-y: auto; padding: 16px 20px; }
+  .inspector-empty { color: var(--ink-3); padding: 40px 0; text-align: center; font-size: 11px; }
+  .inspector-label { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 6px; }
+  .json-block { font-size: 11px; line-height: 1.65; white-space: pre-wrap; word-break: break-all; color: var(--ink-2); }
+  .json-block .k { color: var(--hl); } .json-block .s { color: var(--gain); }
+  .json-block .n { color: #d19a66; } .json-block .b { color: #c678dd; } .json-block .null { color: var(--ink-3); }
+
+  .chart-wrap { flex: 1; display: flex; flex-direction: column; padding: 12px; }
+  .chart-info { font-size: 11px; color: var(--ink-2); margin-bottom: 8px; display: flex; gap: 16px; flex-wrap: wrap; }
+  .chart-info .ci-label { color: var(--ink-3); text-transform: uppercase; font-size: 10px; }
+  .chart-info .ci-val { font-weight: 500; }
+  .chart-info .ci-val.cr { color: var(--gain); } .chart-info .ci-val.dr { color: var(--loss); }
+  .chart-canvas-wrap { flex: 1; position: relative; min-height: 200px; }
+  .chart-canvas-wrap canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+  .chart-empty { color: var(--ink-3); text-align: center; padding: 60px 20px; font-size: 11px; }
+
+  .day { margin-bottom: 20px; }
+  .day-label { font-size: 10px; font-weight: 500; color: var(--ink-3); text-transform: uppercase; letter-spacing: 1px; padding-bottom: 4px; margin-bottom: 8px; border-bottom: 1px solid var(--rule); }
+
+  .ticket { margin-bottom: 6px; padding: 8px 10px; border: 1px solid var(--rule); border-radius: 4px; cursor: pointer; transition: border-color 0.1s, background 0.1s; background: var(--paper-raised); }
+  .ticket:hover { border-color: var(--ink-3); }
+  .ticket.selected { border-color: var(--hl); background: rgba(88,166,255,0.06); }
+  .ticket-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4px; }
+  .ticket-time { font-size: 11px; color: var(--ink-2); }
+  .ticket-price { font-size: 12px; font-weight: 500; }
+  .ticket-price.cr { color: var(--gain); } .ticket-price.dr { color: var(--loss); }
+  .leg-row { display: flex; gap: 6px; font-size: 11px; padding: 1px 0; color: var(--ink); }
+  .leg-action { width: 110px; flex-shrink: 0; }
+  .leg-action.buy { color: var(--gain); } .leg-action.sell { color: var(--loss); }
+  .leg-detail { color: var(--ink-2); } .leg-at { color: var(--ink-3); }
+  .ticket-id { font-size: 10px; color: var(--ink-3); margin-top: 3px; }
+
+  .sel-count { font-size: 10px; color: var(--hl); margin-left: auto; }
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="topbar">
+    <h1>Trade Fills</h1>
+    <div class="stat">Orders: <b id="s-orders">-</b></div>
+    <div class="stat">Fills: <b id="s-fills">-</b></div>
+    <button class="refresh-btn" id="refresh-btn" onclick="refreshData()">Refresh</button>
+    <div class="sel-count" id="sel-count"></div>
+  </div>
+  <div class="filters">
+    <label>Underlying</label>
+    <select id="f-underlying"><option value="">All</option></select>
+    <label>Search</label>
+    <input id="f-search" type="text" placeholder="symbol, order id..." style="width:160px">
+  </div>
+  <div class="workspace">
+    <div class="timeline" id="timeline"></div>
+    <div class="gutter" id="gutter"></div>
+    <div class="right-pane">
+      <div class="pane-tabs">
+        <button class="pane-tab active" data-pane="chart">P&L Chart</button>
+        <button class="pane-tab" data-pane="json">JSON</button>
+      </div>
+      <div class="pane-body">
+        <div class="pane-content active" id="pane-chart">
+          <div class="chart-wrap">
+            <div class="chart-info" id="chart-info"></div>
+            <div class="chart-canvas-wrap" id="chart-area">
+              <div class="chart-empty">Select orders to plot P&L at expiration</div>
+            </div>
+          </div>
+        </div>
+        <div class="pane-content" id="pane-json">
+          <div class="inspector-wrap" id="inspector">
+            <div class="inspector-empty">Click an order to inspect the raw Redis object</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+const TZ = 'America/New_York';
+let DATA, MARKET, ORDERS = [], SELECTED = new Set(), MULTIPLIERS = {};
+let GREEKS_MAP = {}; // fill symbol → {iv, delta, theta}
+let QUOTES_MAP = {}; // underlying → {bid, ask, mid}
+let lastClicked = null;
+
+// --- Black-Scholes ---
+function normCdf(x) { return 0.5 * (1 + erf(x / Math.SQRT2)); }
+function erf(x) {
+  const a1=0.254829592, a2=-0.284496736, a3=1.421413741, a4=-1.453152027, a5=1.061405429, p=0.3275911;
+  const sign = x < 0 ? -1 : 1;
+  x = Math.abs(x);
+  const t = 1 / (1 + p * x);
+  const y = 1 - (((((a5*t+a4)*t)+a3)*t+a2)*t+a1)*t * Math.exp(-x*x);
+  return sign * y;
+}
+function bsPrice(S, K, T, r, sigma, optType) {
+  if (T <= 0) return optType === 'C' ? Math.max(0, S-K) : Math.max(0, K-S);
+  if (sigma <= 0) return optType === 'C' ? Math.max(0, S-K) : Math.max(0, K-S);
+  const d1 = (Math.log(S/K) + (r + sigma*sigma/2)*T) / (sigma*Math.sqrt(T));
+  const d2 = d1 - sigma*Math.sqrt(T);
+  if (optType === 'C') return S*normCdf(d1) - K*Math.exp(-r*T)*normCdf(d2);
+  else return K*Math.exp(-r*T)*normCdf(-d2) - S*normCdf(-d1);
+}
+
+async function boot() {
+  DATA = await (await fetch('raw_redis_data.json')).json();
+  try { MARKET = await (await fetch('market_data.json')).json(); } catch(e) { MARKET = {greeks:{},quotes:{},positions:{}}; }
+
+  // Build Greeks lookup: map fill symbol → streamer key → greeks
+  // Patterns:
+  //   Equity: "SPY   260501P00645000" → ".SPY260501P645"
+  //   Future: "./ZBM6 OZBK6 260424P111" → "./OZBK26P111:XCBT" (year digit expanded)
+  // We'll match by strike+type+expiry since that's unique enough
+  const greeksByStrikeKey = {};
+  for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+    // Extract type+strike from greeks key
+    const m = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+    if (m) {
+      const k = m[1] + '_' + m[2];
+      greeksByStrikeKey[k] = { iv: gVal.volatility, delta: gVal.delta, theta: gVal.theta, key: gKey };
+    }
+  }
+
+  // Build underlying quote lookup — keyed by both streamer symbol and API symbol
+  for (const [qKey, qVal] of Object.entries(MARKET.quotes || {})) {
+    if (!qKey.startsWith('.')) {
+      const bid = qVal.bidPrice || 0;
+      const ask = qVal.askPrice || 0;
+      QUOTES_MAP[qKey] = { bid, ask, mid: (bid + ask) / 2 };
+    }
+  }
+  // Map API symbols to streamer quotes via instruments (e.g. /ZBM6 → /ZBM26:XCBT)
+  for (const [instKey, instVal] of Object.entries(MARKET.instruments || {})) {
+    const ss = instVal.streamer_symbol;
+    if (ss && QUOTES_MAP[ss] && !QUOTES_MAP[instKey]) {
+      QUOTES_MAP[instKey] = QUOTES_MAP[ss];
+    }
+  }
+
+  // Map position underlying → multiplier, and also store streamer→greeks link
+  for (const [sym, pos] of Object.entries(MARKET.positions || {})) {
+    if (pos.streamer_symbol && MARKET.greeks[pos.streamer_symbol]) {
+      GREEKS_MAP[sym] = MARKET.greeks[pos.streamer_symbol];
+    }
+  }
+
+  // Build multiplier lookup from positions
+  DATA.positions.forEach(rec => {
+    const p = rec.raw;
+    const u = p['underlying-symbol'] || '';
+    const m = p.multiplier;
+    if (u && m) MULTIPLIERS[u] = m;
+  });
+
+  DATA.orders.forEach(rec => {
+    const o = rec.raw;
+    const legs = o.legs || [];
+    const filledLegs = legs.filter(l => (l.fills || []).length > 0);
+    if (!filledLegs.length) return;
+
+    let earliest = '';
+    filledLegs.forEach(l => (l.fills||[]).forEach(f => {
+      const t = f['filled-at'] || '';
+      if (t && (!earliest || t < earliest)) earliest = t;
+    }));
+
+    ORDERS.push({
+      id: o.id,
+      time: earliest || o['updated-at'] || o['received-at'] || '',
+      underlying: o['underlying-symbol'] || '',
+      price: o.price,
+      size: o.size || 1,
+      priceEffect: o['price-effect'] || '',
+      legs: filledLegs.map(l => {
+        const fill = (l.fills||[])[0] || {};
+        return {
+          action: l.action || '',
+          symbol: (l.symbol || '').trim(),
+          instrumentType: l['instrument-type'] || '',
+          qty: parseFloat(fill.quantity || fill['fill-quantity'] || l.quantity || 0),
+          fillPrice: parseFloat(fill['fill-price'] ?? 0),
+        };
+      }),
+      _raw: o, _redisKey: rec.redis_key,
+    });
+  });
+
+  ORDERS.sort((a, b) => b.time.localeCompare(a.time));
+
+  const uu = [...new Set(ORDERS.map(o => o.underlying))].filter(Boolean).sort();
+  const sel = document.getElementById('f-underlying');
+  uu.forEach(u => { const opt = document.createElement('option'); opt.value = u; opt.textContent = u; sel.appendChild(opt); });
+
+  document.getElementById('s-orders').textContent = ORDERS.length;
+  document.getElementById('s-fills').textContent = ORDERS.reduce((n, o) => n + o.legs.length, 0);
+
+  render();
+}
+
+// --- Symbol parsing ---
+function parseOption(leg) {
+  const sym = leg.symbol;
+  const iType = leg.instrumentType;
+  let strike, optType, dateStr;
+
+  if (iType === 'Equity Option') {
+    const m = sym.match(/(\d{6})([CP])(\d{8})$/);
+    if (m) { dateStr = m[1]; optType = m[2]; strike = parseInt(m[3]) / 1000; }
+  } else if (iType === 'Future Option') {
+    const m = sym.match(/(\d{6})([CP])(.+)$/);
+    if (m) { dateStr = m[1]; optType = m[2]; strike = parseFloat(m[3]); }
+  }
+  if (!strike || !optType) return null;
+
+  // Parse DTE from date string (YYMMDD)
+  let dte = 30; // fallback
+  if (dateStr) {
+    const exp = new Date(2000 + parseInt(dateStr.slice(0,2)), parseInt(dateStr.slice(2,4))-1, parseInt(dateStr.slice(4,6)));
+    const now = new Date();
+    dte = Math.max(1, Math.round((exp - now) / 86400000));
+  }
+
+  // Look up IV from Greeks — match by strike+type key
+  const strikeKey = optType + '_' + strike;
+  let iv = 0.20; // fallback
+  // Try direct position match first
+  if (GREEKS_MAP[sym]) {
+    iv = GREEKS_MAP[sym].volatility || iv;
+  } else {
+    // Search greeks by strike key pattern
+    for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+      const m2 = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+      if (m2 && m2[1] === optType && parseFloat(m2[2]) === strike) {
+        iv = gVal.volatility || iv;
+        break;
+      }
+    }
+  }
+
+  const isBuy = leg.action.startsWith('Buy');
+  return { strike, optType, isLong: isBuy, qty: leg.qty, premium: leg.fillPrice, dte, iv, symbol: sym };
+}
+
+// --- P&L computation ---
+function computePayoff(parsedLegs, multiplier, priceRange) {
+  return priceRange.map(s => {
+    let total = 0;
+    parsedLegs.forEach(leg => {
+      let intrinsic = leg.optType === 'C' ? Math.max(0, s - leg.strike) : Math.max(0, leg.strike - s);
+      let pnl = leg.isLong
+        ? (intrinsic - leg.premium) * leg.qty * multiplier
+        : (leg.premium - intrinsic) * leg.qty * multiplier;
+      total += pnl;
+    });
+    return { price: s, pnl: total };
+  });
+}
+
+function computeDay0Payoff(parsedLegs, multiplier, priceRange) {
+  const r = 0.04; // risk-free rate approximation
+  return priceRange.map(s => {
+    let total = 0;
+    parsedLegs.forEach(leg => {
+      const T = leg.dte / 365;
+      const theo = bsPrice(s, leg.strike, T, r, leg.iv, leg.optType);
+      let pnl = leg.isLong
+        ? (theo - leg.premium) * leg.qty * multiplier
+        : (leg.premium - theo) * leg.qty * multiplier;
+      total += pnl;
+    });
+    return { price: s, pnl: total };
+  });
+}
+
+function estimateUnderlyingPrice(parsedLegs, underlying) {
+  // Try quotes first
+  const q = QUOTES_MAP[underlying];
+  if (q && q.mid > 0) return q.mid;
+  // Estimate from near-ATM option: the strike where |delta| is closest to 0.5
+  let bestStrike = null, bestDeltaDiff = Infinity;
+  for (const leg of parsedLegs) {
+    // Look up delta
+    for (const [gKey, gVal] of Object.entries(MARKET.greeks || {})) {
+      const m = gKey.match(/([CP])([0-9.]+?)(?::.*)?$/);
+      if (m && m[1] === leg.optType && parseFloat(m[2]) === leg.strike && gVal.delta != null) {
+        const diff = Math.abs(Math.abs(gVal.delta) - 0.5);
+        if (diff < bestDeltaDiff) { bestDeltaDiff = diff; bestStrike = leg.strike; }
+      }
+    }
+  }
+  return bestStrike || parsedLegs[0]?.strike || 100;
+}
+
+// --- Chart drawing ---
+function drawChart() {
+  const info = document.getElementById('chart-info');
+  const area = document.getElementById('chart-area');
+
+  if (SELECTED.size === 0) {
+    info.innerHTML = '';
+    area.innerHTML = '<div class="chart-empty">Select orders to plot P&L at expiration</div>';
+    return;
+  }
+
+  // Gather all legs from selected orders
+  const selectedOrders = ORDERS.filter(o => SELECTED.has(o.id));
+  const allLegs = [];
+  let underlying = '';
+  selectedOrders.forEach(o => {
+    if (!underlying) underlying = o.underlying;
+    o.legs.forEach(l => {
+      const parsed = parseOption(l);
+      if (parsed) allLegs.push(parsed);
+    });
+  });
+
+  if (!allLegs.length) {
+    info.innerHTML = '';
+    area.innerHTML = '<div class="chart-empty">Could not parse option data from selected orders</div>';
+    return;
+  }
+
+  const mult = MULTIPLIERS[underlying] || 100;
+  const strikes = allLegs.map(l => l.strike);
+  const minK = Math.min(...strikes);
+  const maxK = Math.max(...strikes);
+  const spread = maxK - minK || maxK * 0.1 || 10;
+  const lo = minK - spread * 0.6;
+  const hi = maxK + spread * 0.6;
+  const steps = 300;
+  const range = [];
+  for (let i = 0; i <= steps; i++) range.push(lo + (hi - lo) * i / steps);
+
+  const isSmallStrike = strikes[0] < 10;
+  const payoff = computePayoff(allLegs, mult, range);
+  const day0 = computeDay0Payoff(allLegs, mult, range);
+  // Time decay projections: scale DTE by fraction, recompute BS
+  const timeSlices = [0.75, 0.50, 0.25];
+  const projections = timeSlices.map(frac => {
+    const projLegs = allLegs.map(l => ({ ...l, dte: Math.max(1, Math.round(l.dte * frac)) }));
+    return { frac, data: computeDay0Payoff(projLegs, mult, range) };
+  });
+  const spotPrice = estimateUnderlyingPrice(allLegs, underlying);
+
+  // Compute summary
+  const maxProfit = Math.max(...payoff.map(p => p.pnl));
+  const maxLoss = Math.min(...payoff.map(p => p.pnl));
+  const day0AtSpot = day0.find(d => Math.abs(d.price - spotPrice) < (hi-lo)/steps*1.5);
+  const netPremium = selectedOrders.reduce((sum, o) => {
+    const sign = o.priceEffect === 'Credit' ? 1 : -1;
+    return sum + (o.price || 0) * (o.size || 1) * mult * sign;
+  }, 0);
+
+  const avgDte = Math.round(allLegs.reduce((s,l) => s+l.dte, 0) / allLegs.length);
+  const day0Pnl = day0AtSpot ? day0AtSpot.pnl : 0;
+
+  info.innerHTML = `
+    <div><span class="ci-label">Underlying</span> <span class="ci-val">${esc(underlying)} @ ${spotPrice.toFixed(isSmallStrike ? 3 : 1)}</span></div>
+    <div><span class="ci-label">DTE</span> <span class="ci-val">${avgDte}</span></div>
+    <div><span class="ci-label">Net Premium</span> <span class="ci-val ${netPremium >= 0 ? 'cr' : 'dr'}">${netPremium >= 0 ? '+' : ''}${netPremium.toFixed(2)}</span></div>
+    <div><span class="ci-label">Day 0 P&L</span> <span class="ci-val ${day0Pnl >= 0 ? 'cr' : 'dr'}">${day0Pnl >= 0 ? '+' : ''}${day0Pnl.toFixed(2)}</span></div>
+    <div><span class="ci-label">Max Profit</span> <span class="ci-val cr">${maxProfit === Infinity ? '∞' : '+' + maxProfit.toFixed(2)}</span></div>
+    <div><span class="ci-label">Max Loss</span> <span class="ci-val dr">${maxLoss === -Infinity ? '-∞' : maxLoss.toFixed(2)}</span></div>
+  `;
+
+  // Canvas — two layers: static chart + hover overlay
+  area.innerHTML = '<canvas id="chart-cv"></canvas><canvas id="chart-hover" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none"></canvas>';
+  const canvas = document.getElementById('chart-cv');
+  const hoverCanvas = document.getElementById('chart-hover');
+  const rect = area.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr; canvas.height = rect.height * dpr;
+  hoverCanvas.width = rect.width * dpr; hoverCanvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+  const W = rect.width, H = rect.height;
+  const pad = { top: 20, right: 20, bottom: 36, left: 68 };
+  const cw = W - pad.left - pad.right;
+  const ch = H - pad.top - pad.bottom;
+
+  const pnls = payoff.map(p => p.pnl);
+  const day0pnls = day0.map(p => p.pnl);
+  const projPnls = projections.flatMap(pr => pr.data.map(p => p.pnl));
+  const allPnls = pnls.concat(day0pnls, projPnls);
+  const rawMin = Math.min(...allPnls, 0);
+  const rawMax = Math.max(...allPnls, 0);
+
+  // Round Y axis to nice numbers
+  function niceStep(range) {
+    const rough = range / 5;
+    const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+    const norm = rough / mag;
+    let step;
+    if (norm <= 1.5) step = 1;
+    else if (norm <= 3) step = 2;
+    else if (norm <= 7) step = 5;
+    else step = 10;
+    return step * mag;
+  }
+  const yStep = niceStep(rawMax - rawMin || 1);
+  let minP = Math.floor(rawMin / yStep) * yStep - yStep;
+  let maxP = Math.ceil(rawMax / yStep) * yStep + yStep;
+  // Ensure zero is included
+  if (minP > 0) minP = 0;
+  if (maxP < 0) maxP = 0;
+
+  function x(price) { return pad.left + (price - lo) / (hi - lo) * cw; }
+  function y(pnl) { return pad.top + (1 - (pnl - minP) / (maxP - minP)) * ch; }
+  function fmtDollar(v) { return (v >= 0 ? '+' : '') + v.toLocaleString('en-US', { maximumFractionDigits: 0 }); }
+
+  // Grid lines at nice intervals
+  ctx.strokeStyle = '#21262d';
+  ctx.lineWidth = 1;
+  ctx.font = '10px JetBrains Mono';
+  ctx.textAlign = 'right';
+  for (let val = minP; val <= maxP; val += yStep) {
+    const yy = y(val);
+    if (yy < pad.top - 1 || yy > pad.top + ch + 1) continue;
+    ctx.beginPath(); ctx.moveTo(pad.left, yy); ctx.lineTo(W - pad.right, yy); ctx.stroke();
+    ctx.fillStyle = '#484f58';
+    ctx.fillText(fmtDollar(val), pad.left - 6, yy + 3);
+  }
+
+  // Zero line
+  if (minP < 0 && maxP > 0) {
+    ctx.strokeStyle = '#484f58'; ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath(); ctx.moveTo(pad.left, y(0)); ctx.lineTo(W - pad.right, y(0)); ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  // X axis labels
+  const xTicks = Math.min(strikes.length + 2, 8);
+  const xStep = (hi - lo) / xTicks;
+  ctx.fillStyle = '#484f58'; ctx.textAlign = 'center';
+  for (let i = 0; i <= xTicks; i++) {
+    const val = lo + xStep * i;
+    ctx.fillText(val.toFixed(isSmallStrike ? 2 : 0), x(val), H - pad.bottom + 16);
+  }
+
+  // Strike markers
+  ctx.strokeStyle = '#30363d'; ctx.lineWidth = 1;
+  ctx.setLineDash([2, 4]);
+  strikes.forEach(k => { ctx.beginPath(); ctx.moveTo(x(k), pad.top); ctx.lineTo(x(k), H - pad.bottom); ctx.stroke(); });
+  ctx.setLineDash([]);
+
+  // Fill: green above zero, red below zero
+  const y0 = y(0);
+  const clippedY0 = Math.max(pad.top, Math.min(pad.top + ch, y0));
+
+  ctx.save();
+  ctx.beginPath(); ctx.rect(pad.left, pad.top, cw, clippedY0 - pad.top); ctx.clip();
+  ctx.beginPath(); ctx.moveTo(x(payoff[0].price), clippedY0);
+  payoff.forEach(p => ctx.lineTo(x(p.price), y(p.pnl)));
+  ctx.lineTo(x(payoff[payoff.length-1].price), clippedY0); ctx.closePath();
+  ctx.fillStyle = 'rgba(63,185,80,0.12)'; ctx.fill(); ctx.restore();
+
+  ctx.save();
+  ctx.beginPath(); ctx.rect(pad.left, clippedY0, cw, pad.top + ch - clippedY0); ctx.clip();
+  ctx.beginPath(); ctx.moveTo(x(payoff[0].price), clippedY0);
+  payoff.forEach(p => ctx.lineTo(x(p.price), y(p.pnl)));
+  ctx.lineTo(x(payoff[payoff.length-1].price), clippedY0); ctx.closePath();
+  ctx.fillStyle = 'rgba(248,81,73,0.12)'; ctx.fill(); ctx.restore();
+
+  // Time decay projections (75%, 50%, 25% DTE remaining)
+  projections.forEach(proj => {
+    ctx.beginPath();
+    proj.data.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+    ctx.strokeStyle = '#484f58'; ctx.lineWidth = 1; ctx.lineJoin = 'round';
+    ctx.setLineDash([4, 3]); ctx.stroke(); ctx.setLineDash([]);
+  });
+
+  // Day 0 curve (Black-Scholes theoretical)
+  ctx.beginPath();
+  day0.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+  ctx.strokeStyle = '#58a6ff'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round';
+  ctx.setLineDash([6, 3]); ctx.stroke(); ctx.setLineDash([]);
+
+  // Current price vertical line
+  const spotX = x(spotPrice);
+  ctx.strokeStyle = '#58a6ff55'; ctx.lineWidth = 1;
+  ctx.setLineDash([4, 3]);
+  ctx.beginPath(); ctx.moveTo(spotX, pad.top); ctx.lineTo(spotX, pad.top + ch); ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.fillStyle = '#58a6ff'; ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'center';
+  ctx.fillText(spotPrice.toFixed(isSmallStrike ? 3 : 1), spotX, pad.top + ch + 14);
+
+  // Spot price marker on Day 0 curve
+  const spotY = day0.reduce((best, p) => Math.abs(p.price - spotPrice) < Math.abs(best.price - spotPrice) ? p : best, day0[0]);
+  ctx.beginPath(); ctx.arc(x(spotY.price), y(spotY.pnl), 5, 0, Math.PI * 2);
+  ctx.fillStyle = '#58a6ff'; ctx.fill();
+  ctx.strokeStyle = '#0d1117'; ctx.lineWidth = 1.5; ctx.stroke();
+
+  // Expiration P&L line
+  ctx.beginPath();
+  payoff.forEach((p, i) => { const px = x(p.price), py = y(p.pnl); i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py); });
+  ctx.strokeStyle = '#c9d1d9'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+
+  // Max profit / max loss markers on Y axis
+  const maxProfitVal = Math.max(...pnls);
+  const maxLossVal = Math.min(...pnls);
+
+  function drawYMarker(val, color, label, fullWidth) {
+    const yy = y(val);
+    if (yy < pad.top || yy > pad.top + ch) return;
+    let endX = W - pad.right;
+    if (!fullWidth) {
+      for (let i = 0; i < payoff.length; i++) {
+        if (Math.abs(payoff[i].pnl - val) < Math.abs(pnls[0] - val) * 0.01 + 0.5) {
+          endX = x(payoff[i].price); break;
+        }
+      }
+    }
+    ctx.strokeStyle = color + '55'; ctx.lineWidth = 1;
+    ctx.setLineDash([4, 3]);
+    ctx.beginPath(); ctx.moveTo(pad.left, yy); ctx.lineTo(endX, yy); ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'right'; ctx.fillStyle = color;
+    ctx.fillText(label + ' ' + fmtDollar(val), pad.left - 6, yy + 3);
+  }
+  if (maxProfitVal !== 0) drawYMarker(maxProfitVal, '#3fb950', 'MAX', true);
+  if (maxLossVal !== 0) drawYMarker(maxLossVal, '#f85149', 'MAX', false);
+
+  // Breakeven dots
+  for (let i = 1; i < payoff.length; i++) {
+    if ((payoff[i-1].pnl <= 0 && payoff[i].pnl >= 0) || (payoff[i-1].pnl >= 0 && payoff[i].pnl <= 0)) {
+      const ratio = Math.abs(payoff[i-1].pnl) / (Math.abs(payoff[i-1].pnl) + Math.abs(payoff[i].pnl));
+      const bPrice = payoff[i-1].price + (payoff[i].price - payoff[i-1].price) * ratio;
+      ctx.beginPath(); ctx.arc(x(bPrice), y(0), 4, 0, Math.PI * 2);
+      ctx.fillStyle = '#58a6ff'; ctx.fill();
+      ctx.fillStyle = '#c9d1d9'; ctx.font = '10px JetBrains Mono'; ctx.textAlign = 'center';
+      ctx.fillText(bPrice.toFixed(isSmallStrike ? 3 : 1), x(bPrice), y(0) - 8);
+    }
+  }
+
+  // Hover crosshair
+  canvas.style.pointerEvents = 'auto';
+  canvas.onmousemove = (e) => {
+    const cr = canvas.getBoundingClientRect();
+    const mx = e.clientX - cr.left;
+    const my = e.clientY - cr.top;
+    const hctx = hoverCanvas.getContext('2d');
+    hctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    hctx.clearRect(0, 0, W, H);
+
+    if (mx < pad.left || mx > W - pad.right || my < pad.top || my > pad.top + ch) return;
+
+    // Find nearest payoff point
+    const hoverPrice = lo + (mx - pad.left) / cw * (hi - lo);
+    let closest = payoff[0], closestD0 = day0[0], closestDist = Infinity;
+    payoff.forEach((p, i) => { const d = Math.abs(p.price - hoverPrice); if (d < closestDist) { closestDist = d; closest = p; closestD0 = day0[i]; } });
+
+    const px = x(closest.price), py = y(closest.pnl);
+    const d0y = y(closestD0.pnl);
+
+    // Vertical line
+    hctx.strokeStyle = 'rgba(139,148,158,0.4)'; hctx.lineWidth = 1;
+    hctx.setLineDash([3, 3]);
+    hctx.beginPath(); hctx.moveTo(px, pad.top); hctx.lineTo(px, pad.top + ch); hctx.stroke();
+    hctx.setLineDash([]);
+
+    // Dot on expiration curve
+    hctx.beginPath(); hctx.arc(px, py, 3.5, 0, Math.PI * 2);
+    hctx.fillStyle = closest.pnl >= 0 ? '#3fb950' : '#f85149'; hctx.fill();
+    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1; hctx.stroke();
+
+    // Dot on Day 0 curve
+    hctx.beginPath(); hctx.arc(px, d0y, 3.5, 0, Math.PI * 2);
+    hctx.fillStyle = '#58a6ff'; hctx.fill();
+    hctx.strokeStyle = '#0d1117'; hctx.lineWidth = 1; hctx.stroke();
+
+    // Tooltip with both values
+    const priceStr = closest.price.toFixed(isSmallStrike ? 3 : 1);
+    const expStr = fmtDollar(closest.pnl);
+    const d0Str = fmtDollar(closestD0.pnl);
+    const text = `${priceStr}  Exp: ${expStr}  Now: ${d0Str}`;
+    hctx.font = '11px JetBrains Mono';
+    const tw = hctx.measureText(text).width + 12;
+    const tx = Math.min(px + 8, W - pad.right - tw);
+    const ty = Math.max(Math.min(py, d0y) - 28, pad.top + 2);
+
+    hctx.fillStyle = '#161b22'; hctx.strokeStyle = '#30363d'; hctx.lineWidth = 1;
+    hctx.beginPath();
+    hctx.roundRect(tx, ty, tw, 20, 3);
+    hctx.fill(); hctx.stroke();
+
+    hctx.fillStyle = '#c9d1d9';
+    hctx.textAlign = 'left';
+    hctx.fillText(text, tx + 6, ty + 14);
+  };
+
+  canvas.onmouseleave = () => {
+    const hctx = hoverCanvas.getContext('2d');
+    hctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    hctx.clearRect(0, 0, W, H);
+  };
+}
+
+function var_hl() { return '#58a6ff'; }
+
+function filtered() {
+  const u = document.getElementById('f-underlying').value;
+  const q = document.getElementById('f-search').value.toLowerCase();
+  return ORDERS.filter(o => {
+    if (u && o.underlying !== u) return false;
+    if (q) {
+      const hay = [o.id, o.underlying, ...o.legs.map(l => l.symbol + ' ' + l.action)].join(' ').toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function render() {
+  const orders = filtered();
+  const panel = document.getElementById('timeline');
+  const days = {};
+  orders.forEach(o => {
+    let day = 'Unknown';
+    if (o.time) try { day = new Date(o.time).toLocaleDateString('en-CA', { timeZone: TZ }); } catch(e) {}
+    (days[day] = days[day] || []).push(o);
+  });
+
+  let html = '';
+  Object.keys(days).sort().reverse().forEach(day => {
+    const label = day === 'Unknown' ? day : new Date(day + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    html += `<div class="day"><div class="day-label">${esc(label)}</div>`;
+    days[day].forEach(o => {
+      const t = o.time ? new Date(o.time).toLocaleTimeString('en-US', { timeZone: TZ, hour: '2-digit', minute: '2-digit', second: '2-digit' }) : '';
+      const isCr = o.priceEffect === 'Credit';
+      const isDr = o.priceEffect === 'Debit';
+      const priceCls = isCr ? 'cr' : isDr ? 'dr' : '';
+      const sign = isCr ? '+' : isDr ? '-' : '';
+      const total = o.price != null && o.size != null ? (o.price * o.size) : o.price;
+      const totalStr = total != null ? parseFloat(total.toFixed(6)) : null;
+      const priceStr = totalStr != null ? `${sign}${totalStr} ${o.priceEffect}` : '';
+      const sel = SELECTED.has(o.id) ? ' selected' : '';
+
+      html += `<div class="ticket${sel}" data-oid="${o.id}">`;
+      html += `<div class="ticket-head"><span class="ticket-time">${t}</span><span class="ticket-price ${priceCls}">${esc(priceStr)}</span></div>`;
+      html += `<div class="ticket-legs">`;
+      o.legs.forEach(l => {
+        const isBuy = l.action.startsWith('Buy');
+        const aCls = isBuy ? 'buy' : 'sell';
+        const at = l.fillPrice ? ` <span class="leg-at">@ ${l.fillPrice}</span>` : '';
+        html += `<div class="leg-row"><span class="leg-action ${aCls}">${esc(l.action)}</span><span class="leg-detail">${esc(l.qty)}x ${esc(l.symbol)}${at}</span></div>`;
+      });
+      html += `</div>`;
+      html += `<div class="ticket-id">${o.underlying} · #${o.id}</div>`;
+      html += `</div>`;
+    });
+    html += `</div>`;
+  });
+  if (!html) html = '<div class="inspector-empty">No matching fills</div>';
+  panel.innerHTML = html;
+
+  // Attach click handlers — toggle selection
+  document.querySelectorAll('.ticket').forEach(el => {
+    el.addEventListener('click', () => {
+      const oid = parseInt(el.dataset.oid);
+      if (SELECTED.has(oid)) { SELECTED.delete(oid); el.classList.remove('selected'); }
+      else { SELECTED.add(oid); el.classList.add('selected'); }
+      lastClicked = oid;
+      updateSelectionUI();
+    });
+  });
+
+  updateSelectionUI();
+}
+
+function updateSelectionUI() {
+  document.getElementById('sel-count').textContent = SELECTED.size ? `${SELECTED.size} selected` : '';
+  drawChart();
+  // Update JSON pane with last clicked
+  if (lastClicked != null) {
+    const o = ORDERS.find(x => x.id === lastClicked);
+    if (o) {
+      document.getElementById('inspector').innerHTML =
+        `<div class="inspector-label">Redis key: ${esc(o._redisKey)} in ${esc(DATA.redis_keys.orders)}</div>` +
+        `<div class="json-block">${highlight(JSON.stringify(o._raw, null, 2))}</div>`;
+    }
+  }
+}
+
+function highlight(json) {
+  return json.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+    .replace(/"([^"]+)"(?=\s*:)/g, '<span class="k">"$1"</span>')
+    .replace(/:\s*"([^"]*)"/g, ': <span class="s">"$1"</span>')
+    .replace(/:\s*(-?\d+\.?\d*(?:[eE][+-]?\d+)?)/g, ': <span class="n">$1</span>')
+    .replace(/:\s*(true|false)/g, ': <span class="b">$1</span>')
+    .replace(/:\s*null/g, ': <span class="null">null</span>');
+}
+function esc(s) { return String(s||'').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+// Tab switching
+document.querySelectorAll('.pane-tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.pane-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.pane-content').forEach(c => c.classList.remove('active'));
+    tab.classList.add('active');
+    document.getElementById('pane-' + tab.dataset.pane).classList.add('active');
+    if (tab.dataset.pane === 'chart') drawChart();
+  });
+});
+
+// Draggable gutter
+(function() {
+  const gutter = document.getElementById('gutter');
+  const timeline = document.getElementById('timeline');
+  let dragging = false, startX, startW;
+  gutter.addEventListener('mousedown', e => {
+    dragging = true; startX = e.clientX; startW = timeline.offsetWidth;
+    gutter.classList.add('active'); document.body.style.cursor = 'col-resize'; document.body.style.userSelect = 'none'; e.preventDefault();
+  });
+  document.addEventListener('mousemove', e => { if (!dragging) return; timeline.style.width = Math.max(240, Math.min(window.innerWidth - 200, startW + e.clientX - startX)) + 'px'; });
+  document.addEventListener('mouseup', () => { if (!dragging) return; dragging = false; gutter.classList.remove('active'); document.body.style.cursor = ''; document.body.style.userSelect = ''; });
+})();
+
+// Resize redraw
+window.addEventListener('resize', () => { if (SELECTED.size) drawChart(); });
+
+async function refreshData() {
+  const btn = document.getElementById('refresh-btn');
+  btn.textContent = 'Refreshing...'; btn.classList.add('loading');
+  try {
+    const resp = await fetch('/api/refresh', { method: 'POST' });
+    const result = await resp.json();
+    if (result.ok) {
+      // Reload all data
+      ORDERS = []; SELECTED.clear(); GREEKS_MAP = {}; QUOTES_MAP = {};
+      await boot();
+      btn.textContent = 'Done'; setTimeout(() => { btn.textContent = 'Refresh'; }, 1500);
+    } else {
+      btn.textContent = 'Error'; setTimeout(() => { btn.textContent = 'Refresh'; }, 2000);
+      console.error('Refresh failed:', result.error);
+    }
+  } catch(e) {
+    btn.textContent = 'Error'; setTimeout(() => { btn.textContent = 'Refresh'; }, 2000);
+    console.error('Refresh error:', e);
+  }
+  btn.classList.remove('loading');
+}
+
+document.getElementById('f-underlying').onchange = () => { SELECTED.clear(); render(); };
+document.getElementById('f-search').oninput = render;
+
+boot();
+</script>
+</body>
+</html>

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set dotenv-load := true
 # Run `just --list` to see all available recipes
 
 # Default symbols and intervals for subscription
-default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX,/ZBM26:XCBT,/6EM26:XCME,/GCM26:XCEC,/RTYM26:XCME,/CLK26:XNYM"
+default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX"
 default_intervals := "1d,1h,30m,15m,5m,m"
 
 # Prior workday calculation: Mon->Fri(-3), Sun->Fri(-2), else->yesterday(-1)


### PR DESCRIPTION
## Summary
- Moves `trade_explorer.html` to `docs/plans/features/TT-91-trade-explorer.html` with Jira prefix for traceability
- Removes hardcoded stale futures contract symbols (`/ZBM26`, `/6EM26`, `/GCM26`, `/RTYM26`, `/CLK26`) from justfile defaults — these are resolved dynamically from open positions via `PositionSymbolResolver`

## Related Jira Issue
**Jira**: [TT-91](https://mandeng.atlassian.net/browse/TT-91)

## Context
Supersedes #146 which had merge conflicts and 31K lines of stale JSON layout presets. The P&L fix from that PR is already on `main`. This PR preserves the trade explorer playground and applies the justfile cleanup.

Closes #146

## Test plan
- [ ] Verify `just subscribe` runs without stale futures symbols
- [ ] Verify trade explorer HTML renders correctly from new location

[TT-91]: https://mandeng.atlassian.net/browse/TT-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ