### PR TITLE
TT-104: Fix chart x-axis time labels showing irregular jumps

### DIFF
--- a/src/tastytrade/charting/static/index.html
+++ b/src/tastytrade/charting/static/index.html
@@ -602,6 +602,11 @@ const macdAnchorSeries = macdChart.addLineSeries({
 });
 macdChart.priceScale('anchor-hidden').applyOptions({ visible: false });
 
+// Snap epoch down to the nearest hour boundary
+function floorHour(epoch) { return epoch - (epoch % 3600); }
+// Snap epoch up to the nearest hour boundary
+function ceilHour(epoch) { return epoch % 3600 === 0 ? epoch : floorHour(epoch) + 3600; }
+
 function setTradingHoursView() {
   // Clear stale anchors before repopulating — prevents previous mode's
   // timestamps from polluting the time axis after a MKT/EXT toggle.
@@ -609,17 +614,15 @@ function setTradingHoursView() {
   macdAnchorSeries.setData([]);
 
   if (!hasMarketHours) {
-    // EXT mode: fit to actual data with padding for comfortable scrolling
+    // EXT mode: fit to actual data, snapped to hour boundaries
     if (!lastCandles.length) return;
     const first = lastCandles[0].time;
     const last = lastCandles[lastCandles.length - 1].time;
-    const span = last - first;
-    const pad = Math.max(900, span * 0.15); // at least 15 min, or 15% of span
-    const from = first - pad;
-    const to = last + pad;
-    const step = Math.max(60, Math.floor((to - from) / 200));
+    const from = floorHour(first - 1800);  // pad 30 min before, snap to hour
+    const to = ceilHour(last + 1800);      // pad 30 min after, snap to hour
+    // Anchor every 30 minutes for clean tick marks
     const anchors = [];
-    for (let t = from; t <= to; t += step) anchors.push({ time: t, value: 0 });
+    for (let t = from; t <= to; t += 1800) anchors.push({ time: t, value: 0 });
     anchorSeries.setData(anchors);
     macdAnchorSeries.setData(anchors);
     syncing = true;
@@ -629,13 +632,14 @@ function setTradingHoursView() {
     return;
   }
 
-  // MKT mode: anchor to regular trading hours
+  // MKT mode: anchor to regular trading hours, snapped to hour boundaries
   if (viewStartEpoch === 0 || marketCloseEpoch === 0) return;
-  const from = viewStartEpoch;
+  const from = floorHour(viewStartEpoch);
   const lastCandle = lastCandles.length ? lastCandles[lastCandles.length - 1].time : levelStartEpoch;
-  const to = Math.min(marketCloseEpoch, Math.max(lastCandle + 7200, levelStartEpoch + 7200));
+  const to = ceilHour(Math.min(marketCloseEpoch, Math.max(lastCandle + 3600, levelStartEpoch + 3600)));
+  // Anchor every 30 minutes for clean tick marks
   const anchors = [];
-  for (let t = from; t <= to; t += 300) anchors.push({ time: t, value: 0 });
+  for (let t = from; t <= to; t += 1800) anchors.push({ time: t, value: 0 });
   anchorSeries.setData(anchors);
   macdAnchorSeries.setData(anchors);
   syncing = true;


### PR DESCRIPTION
## Summary
- Fixes x-axis time labels in the live chart displaying irregular jumps (e.g., 4:56 PM → 9:04 PM) in both MKT and EXT modes
- Snaps anchor series boundaries to clean hour boundaries using `floorHour`/`ceilHour` helpers
- Uses 30-minute anchor intervals so lightweight-charts places ticks at round :00/:30 positions

## Root Cause
`setTradingHoursView()` padded the visible range by 15% of span (EXT) or `+7200` (MKT), creating non-round `from`/`to` timestamps. Lightweight-charts auto-generates tick marks at mathematically-spaced positions within the range, which landed on irregular times like 4:56 PM and 9:04 PM.

## Fix
- Added `floorHour()` and `ceilHour()` helpers to snap epoch timestamps to hour boundaries
- EXT mode: pad 30 min + snap to hour on both sides, anchor every 30 min
- MKT mode: floor the start, ceil the end, anchor every 30 min (was 5 min / 300s before)

## Verification Evidence
Mathematical proof with concrete epoch values:
- **Before**: `from` at 4:22, `to` at 18:04 → tick labels at arbitrary times
- **After**: `from` at 5:00, `to` at 17:00 → all 25 anchor points on clean :00/:30 boundaries (5:00, 5:30, 6:00, ... 16:30, 17:00)

## Test Plan
- [x] All 847 unit tests pass
- [x] Pre-commit hooks pass
- [x] Chart server starts successfully
- [x] Verified anchor alignment with concrete epoch arithmetic

Jira: [TT-104](https://mandeng.atlassian.net/browse/TT-104)

[TT-104]: https://mandeng.atlassian.net/browse/TT-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ