### PR TITLE
TT-107: Fix KeyError on empty InfluxDB query result

### DIFF
--- a/src/tastytrade/providers/market.py
+++ b/src/tastytrade/providers/market.py
@@ -148,6 +148,10 @@ class MarketDataProvider:
 
             if isinstance(raw, list):
                 raw = _pd.concat(raw, ignore_index=True) if raw else _pd.DataFrame()
+
+            if raw.empty:
+                return pl.DataFrame()
+
             df = raw.assign(time=lambda d: d["_time"].dt.tz_localize(None))
 
             # Remove InfluxDB metadata columns

--- a/unit_tests/providers/test_market_data_provider.py
+++ b/unit_tests/providers/test_market_data_provider.py
@@ -119,6 +119,28 @@ def test_get_daily_candle_skips_null_close(monkeypatch: pytest.MonkeyPatch):
     assert result.close == 6025.0
 
 
+def test_download_empty_result_returns_empty_dataframe(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When InfluxDB returns no rows, download() returns an empty Polars DataFrame."""
+    monkeypatch.setattr(
+        "tastytrade.providers.market.config",
+        MagicMock(get=MagicMock(return_value="test-bucket")),
+    )
+    mock_influx = _mock_query_api(pd.DataFrame())
+    provider = MarketDataProvider(data_feed=MagicMock(), influx=mock_influx)
+
+    result = provider.download(
+        symbol="SPX{=m}",
+        start=datetime(2026, 2, 11, 14, 0),
+        stop=datetime(2026, 2, 11, 21, 0),
+        debug_mode=True,
+    )
+
+    assert isinstance(result, pl.DataFrame)
+    assert result.is_empty()
+
+
 def test_get_daily_candle_bare_symbol(monkeypatch: pytest.MonkeyPatch):
     """Call with bare symbol (no {=...} suffix), assert download called with SPX{=d}."""
     provider = _make_provider()


### PR DESCRIPTION
## Summary

Fixes `KeyError: '_time'` crash in `MarketDataProvider.download()` when InfluxDB returns an empty DataFrame (no matching data for the queried symbol/time range). The charting server calls `download()` in a retry loop over recent trading days — an empty result for one day should return an empty Polars DataFrame so the loop tries the next day, but instead the KeyError propagated as a ValueError and terminated the entire chart session.

**Fix:** Added an empty-result guard before accessing `_time`. Returns an empty Polars DataFrame immediately when the raw result has no rows.

**Files changed:**
- `src/tastytrade/providers/market.py` — 3-line guard before `_time` access
- `unit_tests/providers/test_market_data_provider.py` — new test for empty-result path

## Functional Evidence

Tested via Playwright against live charting server (`tasty-chart --symbol SPX --interval m --port 8090`):

- **SPX loads without crash** — page renders with candlestick chart, HMA, MACD, prior day levels, opening ranges. No error overlay.
- **Symbol switching works** — switched from SPX to NVDA, chart re-rendered with correct data. WebSocket reconnected.
- **MKT/EXT toggle works** — toggled to extended hours, pre-market candles and MACD activity visible.
- **Connection status green** — WebSocket readyState=1 (OPEN), status dot shows connected.
- **No KeyError** — server logs clean, no `_time` traceback.

## Test plan
- [x] New unit test: `test_download_empty_result_returns_empty_dataframe`
- [x] 848 unit tests passing (847 existing + 1 new)
- [x] 0 pyright errors
- [x] 0 ruff lint errors
- [x] Playwright UI test: page loads, symbol switching, MKT/EXT toggle all verified
