### PR TITLE
TT-109: Fix ColumnNotFoundError when InfluxDB returns metadata-only rows

### DIFF
--- a/src/tastytrade/charting/server.py
+++ b/src/tastytrade/charting/server.py
@@ -238,7 +238,12 @@ class ChartServer:
                 stop=utc_stop,
                 debug_mode=True,
             )
-            if hist_df is not None and not hist_df.is_empty():
+            required_cols = {"open", "high", "low", "close"}
+            if (
+                hist_df is not None
+                and not hist_df.is_empty()
+                and required_cols.issubset(hist_df.columns)
+            ):
                 target_date = d
                 prior_date = find_last_trading_day(d - timedelta(days=1))
                 break


### PR DESCRIPTION
## Summary

Fixes chart server crash (`polars.exceptions.ColumnNotFoundError: unable to find column "close"`) that occurs when InfluxDB returns candle rows with only metadata columns (`eventSymbol`, `count`, `eventFlags`, `index`, `sequence`, `time`) but no OHLCV columns. Adds required column validation (`open`, `high`, `low`, `close`) to the day-walkback loop so metadata-only DataFrames are treated as no-data and the loop continues to the previous day.

## Related Jira Issue

**Jira**: [TT-109](https://mandeng.atlassian.net/browse/TT-109)

## Root Cause

InfluxDB can return partial rows for time ranges outside market hours. The existing `hist_df.is_empty()` check passed because rows existed, but the subsequent `pl.col("close")` filter crashed since no OHLCV columns were present.

## Acceptance Criteria - Functional Evidence

### AC1: Metadata-only DataFrames are rejected by the column check

**Real Example: DataFrame with only metadata columns**
```
is_empty(): False           # Old check passes — BUG
has required cols: False    # New check rejects — FIXED
```

The new guard `required_cols.issubset(hist_df.columns)` correctly identifies that a DataFrame containing only `["eventSymbol", "count", "eventFlags", "index", "sequence", "time"]` does not satisfy the `{"open", "high", "low", "close"}` requirement, so the walkback loop continues to the previous day instead of crashing.

### AC2: Valid OHLCV DataFrames still pass the check

**Real Example: DataFrame with full candle columns**
```
valid df has required cols: True
```

A DataFrame containing `["eventSymbol", "time", "open", "high", "low", "close", "volume"]` correctly passes the `required_cols.issubset()` check and proceeds to chart rendering.

## Test Evidence

- All **848 unit tests pass** (`uv run pytest`)
- **ruff**: 0 errors
- **pyright**: 0 errors
- All pre-commit hooks pass

## Changes Made

- `src/tastytrade/charting/server.py`: Added `required_cols = {"open", "high", "low", "close"}` set and `required_cols.issubset(hist_df.columns)` guard to the day-walkback loop condition (line ~241). This ensures that DataFrames with rows but no OHLCV columns are treated as empty, preventing the `ColumnNotFoundError` on `pl.col("close")`.

[TT-109]: https://mandeng.atlassian.net/browse/TT-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ