### PR TITLE
TT-115: Widen Jade Lizard delta thresholds and add critical tier

### DIFF
--- a/config/strategy_health.toml
+++ b/config/strategy_health.toml
@@ -8,6 +8,7 @@ dte_critical = 7
 max_loss_warning = 0.75
 max_loss_critical = 0.90
 delta_drift_warning = 0.30
+delta_drift_critical = 0.50
 
 [iron_condor]
 dte_warning = 14
@@ -24,4 +25,5 @@ dte_warning = 5
 dte_critical = 3
 
 [jade_lizard]
-delta_drift_warning = 0.35
+delta_drift_warning = 0.40
+delta_drift_critical = 0.50

--- a/src/tastytrade/analytics/strategies/health.py
+++ b/src/tastytrade/analytics/strategies/health.py
@@ -34,6 +34,7 @@ class HealthThresholds:
     max_loss_warning: float = 0.75
     max_loss_critical: float = 0.90
     delta_drift_warning: float = 0.30
+    delta_drift_critical: float = 0.50
 
 
 @dataclass(frozen=True)
@@ -73,6 +74,7 @@ class StrategyHealthMonitor:
             max_loss_warning=default_section.get("max_loss_warning", 0.75),
             max_loss_critical=default_section.get("max_loss_critical", 0.90),
             delta_drift_warning=default_section.get("delta_drift_warning", 0.30),
+            delta_drift_critical=default_section.get("delta_drift_critical", 0.50),
         )
 
         # Load per-strategy-type overrides
@@ -95,6 +97,10 @@ class StrategyHealthMonitor:
                 delta_drift_warning=section.get(
                     "delta_drift_warning",
                     self.default_thresholds.delta_drift_warning,
+                ),
+                delta_drift_critical=section.get(
+                    "delta_drift_critical",
+                    self.default_thresholds.delta_drift_critical,
                 ),
             )
 
@@ -157,7 +163,19 @@ class StrategyHealthMonitor:
                 else 1
             )
             per_pos_delta = net_delta / qty if qty > 0 else net_delta
-            if abs(per_pos_delta) > thresholds.delta_drift_warning:
+            abs_delta = abs(per_pos_delta)
+            if abs_delta > thresholds.delta_drift_critical:
+                alerts.append(
+                    HealthAlert(
+                        strategy=strategy,
+                        level=AlertLevel.CRITICAL,
+                        message=(
+                            f"Net delta={per_pos_delta:.2f} exceeds "
+                            f"+/-{thresholds.delta_drift_critical}"
+                        ),
+                    )
+                )
+            elif abs_delta > thresholds.delta_drift_warning:
                 alerts.append(
                     HealthAlert(
                         strategy=strategy,

--- a/unit_tests/analytics/strategies/test_health.py
+++ b/unit_tests/analytics/strategies/test_health.py
@@ -64,6 +64,7 @@ class TestHealthThresholds:
         assert t.max_loss_warning == 0.75
         assert t.max_loss_critical == 0.90
         assert t.delta_drift_warning == 0.30
+        assert t.delta_drift_critical == 0.50
 
     def test_frozen(self):
         t = HealthThresholds()
@@ -86,6 +87,13 @@ class TestStrategyHealthMonitor:
         assert t.dte_warning == 14
         assert t.dte_critical == 7
         assert t.delta_drift_warning == 0.20
+
+    def test_jade_lizard_thresholds(self):
+        """Jade lizard uses relaxed delta thresholds from TOML."""
+        monitor = StrategyHealthMonitor()
+        t = monitor.thresholds_for(StrategyType.JADE_LIZARD)
+        assert t.delta_drift_warning == 0.40
+        assert t.delta_drift_critical == 0.50
 
     def test_thresholds_for_unknown_type_falls_back_to_default(self):
         monitor = StrategyHealthMonitor()
@@ -207,6 +215,193 @@ class TestHealthChecks:
         delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
         assert len(delta_alerts) == 1
         assert delta_alerts[0].level == AlertLevel.WARNING
+
+    def test_delta_drift_critical(self):
+        """Very high net delta triggers delta drift critical."""
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".SPYC310",
+                symbol="SPY  C310",
+                underlying="SPY",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("310"),
+                expiration=date(2026, 3, 20),
+                days_to_expiration=30,
+                delta=-0.70,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.NAKED_CALL,
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 1
+        assert delta_alerts[0].level == AlertLevel.CRITICAL
+
+    def test_jade_lizard_no_warning_at_039(self):
+        """Jade lizard at delta=-0.39 should NOT trigger warning (threshold=0.40).
+
+        net_delta = (-1)(-0.40) + (1)(-0.35) + (-1)(0.44) = 0.40 - 0.35 - 0.44 = -0.39
+        """
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".QQQP542",
+                symbol="QQQ  P542",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="P",
+                strike=Decimal("542"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.40,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQP538",
+                symbol="QQQ  P538",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=1,
+                option_type="P",
+                strike=Decimal("538"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.35,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQC600",
+                symbol="QQQ  C600",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("600"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=0.44,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.JADE_LIZARD,
+            underlying="QQQ",
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 0
+
+    def test_jade_lizard_warning_at_045(self):
+        """Jade lizard at delta=-0.45 triggers WARNING (between 0.40 and 0.50).
+
+        net_delta = (-1)(-0.40) + (1)(-0.35) + (-1)(0.50) = 0.40 - 0.35 - 0.50 = -0.45
+        """
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".QQQP542",
+                symbol="QQQ  P542",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="P",
+                strike=Decimal("542"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.40,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQP538",
+                symbol="QQQ  P538",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=1,
+                option_type="P",
+                strike=Decimal("538"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.35,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQC600",
+                symbol="QQQ  C600",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("600"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=0.50,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.JADE_LIZARD,
+            underlying="QQQ",
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 1
+        assert delta_alerts[0].level == AlertLevel.WARNING
+
+    def test_jade_lizard_critical_at_055(self):
+        """Jade lizard at delta=-0.55 triggers CRITICAL (exceeds 0.50).
+
+        net_delta = (-1)(-0.40) + (1)(-0.35) + (-1)(0.60) = 0.40 - 0.35 - 0.60 = -0.55
+        """
+        legs = (
+            ParsedLeg(
+                streamer_symbol=".QQQP542",
+                symbol="QQQ  P542",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="P",
+                strike=Decimal("542"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.40,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQP538",
+                symbol="QQQ  P538",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=1,
+                option_type="P",
+                strike=Decimal("538"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=-0.35,
+            ),
+            ParsedLeg(
+                streamer_symbol=".QQQC600",
+                symbol="QQQ  C600",
+                underlying="QQQ",
+                instrument_type=InstrumentType.EQUITY_OPTION,
+                signed_quantity=-1,
+                option_type="C",
+                strike=Decimal("600"),
+                expiration=date(2026, 5, 15),
+                days_to_expiration=39,
+                delta=0.60,
+            ),
+        )
+        strategy = make_strategy(
+            strategy_type=StrategyType.JADE_LIZARD,
+            underlying="QQQ",
+            legs=legs,
+        )
+        monitor = StrategyHealthMonitor()
+        alerts = monitor.check(strategy)
+        delta_alerts = [a for a in alerts if "delta" in a.message.lower()]
+        assert len(delta_alerts) == 1
+        assert delta_alerts[0].level == AlertLevel.CRITICAL
 
     def test_no_delta_alert_for_long_stock(self):
         """Long Stock is delta-exempt — no delta drift warning."""


### PR DESCRIPTION
## Summary
- Relaxed Jade Lizard delta warning threshold from ±0.35 to ±0.40 to eliminate false positives (e.g. QQQ at -0.39)
- Added two-tier delta drift alerting: WARNING at threshold, CRITICAL at a higher `delta_drift_critical` threshold (±0.50)
- New `delta_drift_critical` field added to `HealthThresholds` dataclass, loaded from TOML config, available to all strategy types

## Related Jira Issue
**Jira**: [TT-115](https://mandeng.atlassian.net/browse/TT-115)

## Changes
| File | Change |
|------|--------|
| `config/strategy_health.toml` | Jade Lizard warning 0.35→0.40, added `delta_drift_critical = 0.50` (default + jade_lizard) |
| `src/tastytrade/analytics/strategies/health.py` | Added `delta_drift_critical` field, two-tier delta check logic (critical > warning) |
| `unit_tests/analytics/strategies/test_health.py` | 5 new tests covering jade_lizard thresholds, delta critical tier, and boundary cases |

## Test plan
- [x] `uv run pytest unit_tests/analytics/strategies/test_health.py` — 21 tests pass
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check` — all checks passed
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, trim-whitespace, toml check)

## Evidence
- Jade Lizard at delta=-0.39: **no alert** (was WARNING before, now below ±0.40 threshold)
- Jade Lizard at delta=-0.45: **WARNING** (between ±0.40 and ±0.50)
- Jade Lizard at delta=-0.55: **CRITICAL** (exceeds ±0.50)

[TT-115]: https://mandeng.atlassian.net/browse/TT-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ