### PR TITLE
TT-119: Fix broken dependencies, pre-commit hooks, and add pre-push test gate

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -14,10 +14,10 @@ export PATH="$HOME/.local/bin:$PATH"
 echo "Installing dependencies with UV..."
 uv sync
 # Step 2: Install pre-commit hooks
-if [ -d "/workspace/.git" ] && command -v pre-commit > /dev/null 2>&1; then
+if [ -d "/workspace/.git" ]; then
     echo "Installing pre-commit hooks..."
     cd /workspace
-    pre-commit install 2>/dev/null || echo "  pre-commit install failed (non-critical)"
+    uv run pre-commit install 2>/dev/null || echo "  pre-commit install failed (non-critical)"
 fi
 
 # Step 3: Run startup.sh (env persistence, git, gh CLI)

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,11 +13,11 @@ export PATH="$HOME/.local/bin:$PATH"
 # Step 1: Install all project dependencies
 echo "Installing dependencies with UV..."
 uv sync
-# Step 2: Install pre-commit hooks
+# Step 2: Activate checked-in pre-commit hooks
 if [ -d "/workspace/.git" ]; then
-    echo "Installing pre-commit hooks..."
+    echo "Activating pre-commit hooks via core.hooksPath..."
     cd /workspace
-    uv run pre-commit install 2>/dev/null || echo "  pre-commit install failed (non-critical)"
+    git config core.hooksPath .githooks
 fi
 
 # Step 3: Run startup.sh (env persistence, git, gh CLI)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Checked-in pre-commit hook. Uses core.hooksPath so pre-commit install
+# is never needed and no absolute paths get baked in.
+#
+# Resolution order:
+#   1. .venv/bin/python relative to repo root (local dev, devcontainer, worktree)
+#   2. pre-commit on PATH (CI, global install)
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+REPO_PYTHON="${REPO_ROOT:-.}/.venv/bin/python"
+
+ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=pre-commit --hook-dir "$(cd "$(dirname "$0")" && pwd)" -- "$@")
+
+if [ -x "$REPO_PYTHON" ]; then
+    exec "$REPO_PYTHON" -mpre_commit "${ARGS[@]}"
+elif command -v pre-commit > /dev/null; then
+    exec pre-commit "${ARGS[@]}"
+else
+    echo '`pre-commit` not found. Run: uv sync && git config core.hooksPath .githooks' 1>&2
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-push hook: run pytest before pushing commits.
+# Skips when there are no new commits ahead of the remote.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+REPO_PYTHON="${REPO_ROOT:-.}/.venv/bin/python"
+
+# Read push info from stdin (provided by git)
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Skip branch deletions
+    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    fi
+
+    # Skip if no new commits (initial push or no changes)
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        # New branch — check if there are commits ahead of main
+        COMMIT_COUNT=$(git rev-list --count main.."$local_sha" 2>/dev/null || echo "0")
+    else
+        COMMIT_COUNT=$(git rev-list --count "$remote_sha".."$local_sha" 2>/dev/null || echo "0")
+    fi
+
+    if [ "$COMMIT_COUNT" -eq 0 ]; then
+        continue
+    fi
+
+    echo "pre-push: $COMMIT_COUNT new commit(s) — running pytest..."
+
+    if [ -x "$REPO_PYTHON" ]; then
+        exec "$REPO_PYTHON" -m pytest -q "$REPO_ROOT/unit_tests"
+    elif command -v uv > /dev/null; then
+        exec uv run pytest -q "$REPO_ROOT/unit_tests"
+    else
+        echo "pre-push: no python environment found, skipping tests" >&2
+        exit 0
+    fi
+done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ When working in git worktrees (e.g., `/tmp/worktrees/TT-XXX`):
    cp "$(git rev-parse --show-toplevel)/.env" .env
    uv venv
    uv sync
+   uv run pre-commit install
    ```
 3. Verify: `uv run pytest --co -q`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ When working in git worktrees (e.g., `/tmp/worktrees/TT-XXX`):
    cp "$(git rev-parse --show-toplevel)/.env" .env
    uv venv
    uv sync
-   uv run pre-commit install
+   git config core.hooksPath .githooks
    ```
 3. Verify: `uv run pytest --co -q`
 

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@ set dotenv-load := true
 # TastyTrade SDK - Common development recipes
 # Run `just --list` to see all available recipes
 
+# First-time setup: install dependencies and activate pre-commit hooks
+setup:
+    uv sync
+    git config core.hooksPath .githooks
+    @echo "Setup complete. Pre-commit hooks active."
+
 # Default symbols and intervals for subscription
 default_symbols := "BTC/USD:CXTALP,NVDA,AAPL,QQQ,SPY,SPX"
 default_intervals := "1d,1h,30m,15m,5m,m"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "pytest-asyncio>=1.1.0",
     "pytest-cov>=6.2.1",
     "pytest-mock>=3.14.1",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.12.5",
     "types-pillow>=10.0.0",
     "types-pytz>=2025.2.0.20250516",
@@ -79,6 +80,9 @@ build-backend = "hatchling.build"
 # ============================================================================
 # Tool Configuration
 # ============================================================================
+
+[tool.pytest.ini_options]
+addopts = "-n auto"
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "plotly>=6.0.0",
     "influxdb-client>=1.48.0",
     "uvicorn>=0.34.0",
+    "fastapi>=0.115.8",
     "redis>=5.2.1",
     "hiredis>=3.1.0",
     "kaleido==0.1.0",

--- a/unit_tests/accounts/test_fill_monitor.py
+++ b/unit_tests/accounts/test_fill_monitor.py
@@ -503,7 +503,7 @@ async def run_monitor_briefly(
     """Run the fill monitor and cancel it after a brief timeout."""
     influx = MagicMock()
     task = asyncio.create_task(
-        monitor_fills_for_entry_credits(redis_client, publisher, influx)
+        monitor_fills_for_entry_credits(redis_client, publisher, influx, "TEST00001")
     )
     await asyncio.sleep(timeout)
     task.cancel()

--- a/uv.lock
+++ b/uv.lock
@@ -731,6 +731,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2867,6 +2876,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3360,6 +3382,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pillow" },
     { name = "types-pytz" },
@@ -3408,6 +3431,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.12.5" },
     { name = "types-pillow", specifier = ">=10.0.0" },
     { name = "types-pytz", specifier = ">=2025.2.0.20250516" },

--- a/uv.lock
+++ b/uv.lock
@@ -154,6 +154,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +737,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
 ]
 
 [[package]]
@@ -3279,12 +3304,26 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "tastytrade"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
+    { name = "fastapi" },
     { name = "hiredis" },
     { name = "influxdb-client" },
     { name = "injector" },
@@ -3332,6 +3371,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.2" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "fastapi", specifier = ">=0.115.8" },
     { name = "hiredis", specifier = ">=3.1.0" },
     { name = "influxdb-client", specifier = ">=1.48.0" },
     { name = "injector", specifier = ">=0.22.0" },


### PR DESCRIPTION
## Summary
- Restore `fastapi>=0.115.8` dependency removed by TT-48 but still imported by `charting/server.py`
- Replace fragile `pre-commit install` with checked-in `.githooks/` directory and `core.hooksPath` — no hardcoded absolute paths, works across local dev, devcontainers, and worktrees
- Add pre-push hook that runs the full test suite before allowing pushes with new commits
- Add `pytest-xdist` for parallel test execution (~5s on 12 cores vs ~10s sequential)
- Fix 9 broken `test_fill_monitor.py` tests (missing `account_number` param since TT-108)
- Add `just setup` recipe as single onboarding command

## Test plan
- [x] Pre-commit hooks verified in devcontainer (docker compose build + commit test)
- [x] Pre-commit hooks verified in fresh worktree (new branch, bootstrap, commit test)
- [x] Pre-commit hooks verified in fresh clone simulation (no core.hooksPath → just setup → commit)
- [x] Pre-push hook blocked push when fill_monitor tests were broken (9 failures)
- [x] Pre-push hook passed after test fix (844 tests, parallel execution)
- [x] `just setup` activates hooks without `pre-commit install`

Closes TT-119