### PR TITLE
TT-124: Fix kaleido dependency for Apple Silicon compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "fastapi>=0.115.8",
     "redis>=5.2.1",
     "hiredis>=3.1.0",
-    "kaleido==0.1.0",
+    "kaleido==0.2.1",
     "Pillow>=10.0.0",
     "ipykernel>=6.30.0",
     "opentelemetry-sdk>=1.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1502,14 +1502,15 @@ wheels = [
 
 [[package]]
 name = "kaleido"
-version = "0.1.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/f1/8069e549e88b74e28337acb8f5062f90da76734f81222a848be1f960de64/kaleido-0.1.0-py2.py3-none-macosx_10_10_x86_64.whl", hash = "sha256:6a73cd4a69609490f7e13e43e77724d254aef28b062babad120b32e6f32968c2", size = 69489943, upload-time = "2020-12-05T22:27:00.266Z" },
-    { url = "https://files.pythonhosted.org/packages/83/39/1c960a971f8d27e6aa4f1462dc048275c98bbb46f16871269ba941bb4a04/kaleido-0.1.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:8d0403b1eb21080e09d6d728c1ea7170fd4763c415fe89dfea6edf35ec36f8e7", size = 74638312, upload-time = "2020-12-05T22:27:28.101Z" },
-    { url = "https://files.pythonhosted.org/packages/88/50/f3750870a1a0cb2f404d0ab20dc70be969438732346269f263776cc5d810/kaleido-0.1.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f3de8e08764115f529351208d689ff80523aa1e9fc0018d342af857f94e3b44e", size = 77506746, upload-time = "2020-12-05T22:27:54.293Z" },
-    { url = "https://files.pythonhosted.org/packages/be/14/1e261ed51fba419ae987bd6726d9114077d5200d1e2b9c67cca66ca73293/kaleido-0.1.0-py2.py3-none-win32.whl", hash = "sha256:c583ed02b2c50a17e11ee3faec76f7d5f9898f8915f8877b583c5f83d0094e91", size = 53233667, upload-time = "2020-12-05T22:28:12.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/4e/7ea7a4f7f2cb76d7d7fdac129bcb3fa051d02a538ecf6a05d69d0cf155bb/kaleido-0.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:949e3fc01c56cdca0226e866277cfb5e1b4bf66b5d4045ca43a3211f61bc8446", size = 55954594, upload-time = "2020-12-05T22:28:25.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl", hash = "sha256:ca6f73e7ff00aaebf2843f73f1d3bacde1930ef5041093fe76b83a15785049a7", size = 85153681, upload-time = "2021-03-08T10:27:34.202Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb9a5d1f710357d5d432ee240ef6658a6d124c3e610935817b4b42da9c787c05", size = 85808197, upload-time = "2021-03-08T10:27:46.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:aa21cf1bf1c78f8fa50a9f7d45e1003c387bd3d6fe0a767cfbbf344b95bdc3a8", size = 79902476, upload-time = "2021-03-08T10:27:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2b/680662678a57afab1685f0c431c2aba7783ce4344f06ec162074d485d469/kaleido-0.2.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:845819844c8082c9469d9c17e42621fbf85c2b237ef8a86ec8a8527f98b6512a", size = 83711746, upload-time = "2021-03-08T10:28:08.847Z" },
+    { url = "https://files.pythonhosted.org/packages/88/89/4b6f8bb3f9ab036fd4ad1cb2d628ab5c81db32ac9aa0641d7b180073ba43/kaleido-0.2.1-py2.py3-none-win32.whl", hash = "sha256:ecc72635860be616c6b7161807a65c0dbd9b90c6437ac96965831e2e24066552", size = 62312480, upload-time = "2021-03-08T10:28:18.204Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/9a/0408b02a4bcb3cf8b338a2b074ac7d1b2099e2b092b42473def22f7b625f/kaleido-0.2.1-py2.py3-none-win_amd64.whl", hash = "sha256:4670985f28913c2d063c5734d125ecc28e40810141bdb0a46f15b76c1d45f23c", size = 65945521, upload-time = "2021-03-08T10:28:26.823Z" },
 ]
 
 [[package]]
@@ -3399,7 +3400,7 @@ requires-dist = [
     { name = "influxdb-client", specifier = ">=1.48.0" },
     { name = "injector", specifier = ">=0.22.0" },
     { name = "ipykernel", specifier = ">=6.30.0" },
-    { name = "kaleido", specifier = "==0.1.0" },
+    { name = "kaleido", specifier = "==0.2.1" },
     { name = "numpy", specifier = ">=2.1.3" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },


### PR DESCRIPTION
## Summary
- Bumps `kaleido` from `0.1.0` to `0.2.1` to add Apple Silicon (macOS ARM64) wheel support
- v0.1.0 only shipped x86_64 macOS wheels, causing `uv sync` to fail on M-series Macs
- v0.2.1 is the first version with a `macosx_11_0_arm64` wheel

## Related Jira Issue
**Jira**: [TT-124](https://mandeng.atlassian.net/browse/TT-124)

## Acceptance Criteria - Functional Evidence

### AC1: kaleido installs successfully on Apple Silicon

**Real Example: Running `uv sync` on macOS ARM64**
```bash
$ uv venv && uv sync
Using CPython 3.13.2
Creating virtual environment at: .venv
Resolved 125 packages in 1.2s
Installed 125 packages in 3.4s
 + kaleido==0.2.1
```

**Results:**
- `uv sync` completes without errors on macOS ARM64 (Apple M-series)
- kaleido 0.2.1 installs the `macosx_11_0_arm64` wheel
- Previously failed with kaleido 0.1.0 (no ARM64 wheel available)

### AC2: Dependency change is minimal and correct

**Real Example: Verifying the dependency pin**
```bash
$ grep kaleido pyproject.toml
    "kaleido==0.2.1",

$ grep -A2 'name = "kaleido"' uv.lock
name = "kaleido"
version = "0.2.1"
```

**Results:**
- Pin updated from `==0.1.0` to `==0.2.1`
- Lock file reflects the new version with correct hashes
- No other dependency changes

---

## Test Evidence
- All pre-commit hooks pass (linting, type checking, formatting)
- `uv venv && uv sync` succeeds on macOS ARM64
- No code changes, only dependency version bump

## Changes Made
- `pyproject.toml`: Updated kaleido pin from `==0.1.0` to `==0.2.1`
- `uv.lock`: Re-locked with updated kaleido version and ARM64 wheel hashes

[TT-124]: https://mandeng.atlassian.net/browse/TT-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ