### PR TITLE
TT-128: Open source /plan-review skill as Claude Code plugin

### DIFF
--- a/docs/plans/TT-128-open-source-plan-review-plugin-review.html
+++ b/docs/plans/TT-128-open-source-plan-review-plugin-review.html
@@ -1,0 +1,1939 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plan Review: TT-128: Open-Source /plan-review Plugin</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --bg: #0d1117;
+      --bg-surface: #161b22;
+      --bg-surface-2: #1c2128;
+      --bg-hover: #21262d;
+      --border: #30363d;
+      --border-light: #484f58;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --text-dim: #6e7681;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --green-bg: rgba(63, 185, 80, 0.10);
+      --amber: #d29922;
+      --amber-bg: rgba(210, 153, 34, 0.10);
+      --red: #f85149;
+      --red-bg: rgba(248, 81, 73, 0.08);
+      --purple: #bc8cff;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      height: 100vh;
+      height: -webkit-fill-available;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Top bar */
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+      height: 52px;
+    }
+
+    .topbar h1 {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .topbar .stats {
+      display: flex;
+      gap: 16px;
+      font-size: 12px;
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    .stat .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+
+    .dot-pending {
+      background: var(--amber);
+    }
+
+    .dot-approved {
+      background: var(--green);
+    }
+
+    .dot-revision {
+      background: var(--red);
+    }
+
+    .dot-question {
+      background: var(--purple);
+    }
+
+    /* Main layout */
+    .main {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+
+    /* Resize handles */
+    .resize-handle {
+      width: 1px;
+      cursor: col-resize;
+      background: var(--border);
+      position: relative;
+      flex-shrink: 0;
+      z-index: 10;
+      overflow: visible;
+    }
+
+    .resize-handle::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -10px;
+      right: -10px;
+    }
+
+    .resize-handle:hover,
+    .resize-handle.dragging {
+      background: var(--accent);
+      width: 3px;
+    }
+
+    body.resizing {
+      cursor: col-resize;
+      user-select: none;
+    }
+
+    /* Topbar collapse toggle buttons */
+    .topbar-toggles {
+      display: flex;
+      gap: 6px;
+    }
+
+    .collapse-toggle {
+      width: 36px;
+      height: 32px;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: manipulation;
+      -webkit-user-select: none;
+      user-select: none;
+      transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+    }
+
+    @media (hover: hover) {
+      .collapse-toggle:hover {
+        background: var(--bg-hover);
+        color: var(--text);
+        border-color: var(--accent);
+      }
+    }
+
+    .collapse-toggle.panel-collapsed {
+      background: var(--accent);
+      color: var(--bg);
+      border-color: var(--accent);
+    }
+
+    /* Collapsed panel states */
+    .nav.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      padding: 0 !important;
+      overflow: hidden;
+    }
+
+    .right-panel.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      overflow: hidden;
+    }
+
+    .right-panel.collapsed>* {
+      display: none;
+    }
+
+    .nav.collapsed>* {
+      display: none;
+    }
+
+    .nav,
+    .right-panel {
+      transition: width 0.2s ease, min-width 0.2s ease, padding 0.2s ease;
+    }
+
+    /* Section nav */
+    .nav {
+      width: 240px;
+      min-width: 140px;
+      background: var(--bg-surface);
+      overflow-y: auto;
+      padding: 12px 0;
+    }
+
+    .nav-item {
+      padding: 8px 16px;
+      font-size: 12px;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-left: 3px solid transparent;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .nav-item:hover {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+
+    .nav-item.active {
+      background: var(--bg-hover);
+      border-left-color: var(--accent);
+      color: var(--text);
+    }
+
+    .nav-item .status-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+    }
+
+    .nav-item .label {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Document panel */
+    .doc-panel {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px 32px;
+      min-width: 0;
+    }
+
+    .doc-panel::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .doc-panel::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .doc-panel::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 4px;
+    }
+
+    /* Section rendering */
+    .section {
+      margin-bottom: 16px;
+      scroll-margin-top: 20px;
+      padding: 16px 16px 10px;
+      border-radius: 6px;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .section-header h2 {
+      font-size: 18px;
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .section-header h3 {
+      font-size: 15px;
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .section-content {
+      font-size: 14px;
+      line-height: 1.7;
+      color: var(--text-muted);
+    }
+
+    .section-content p {
+      margin-bottom: 12px;
+    }
+
+    .section-content strong {
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .section-content code {
+      font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+      font-size: 12px;
+      background: var(--bg-surface-2);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: var(--accent);
+    }
+
+    .section-content pre {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 14px;
+      margin: 12px 0;
+      overflow-x: auto;
+      font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text-muted);
+    }
+
+    .section-content pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+
+    .section-content ul,
+    .section-content ol {
+      margin: 8px 0 12px 24px;
+    }
+
+    .section-content li {
+      margin-bottom: 4px;
+    }
+
+    .section-content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0;
+      font-size: 13px;
+    }
+
+    .section-content th,
+    .section-content td {
+      text-align: left;
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+    }
+
+    .section-content th {
+      background: var(--bg-surface-2);
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .section-content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 20px 0;
+    }
+
+    /* Review actions */
+    .review-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+    }
+
+    .review-btn {
+      padding: 6px 14px;
+      font-size: 12px;
+      font-weight: 500;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      transition: all 0.15s;
+    }
+
+    .review-btn:hover {
+      border-color: var(--border-light);
+      color: var(--text);
+    }
+
+    .review-btn.active-approved {
+      background: var(--green-bg);
+      border-color: var(--green);
+      color: var(--green);
+    }
+
+    .review-btn.active-revision {
+      background: var(--red-bg);
+      border-color: var(--red);
+      color: var(--red);
+    }
+
+    .review-btn.active-question {
+      background: rgba(188, 140, 255, 0.10);
+      border-color: var(--purple);
+      color: var(--purple);
+    }
+
+    .comment-area {
+      margin-top: 10px;
+      display: none;
+    }
+
+    .comment-area.visible {
+      display: block;
+    }
+
+    .comment-area textarea {
+      width: 100%;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      padding: 10px;
+      font-family: inherit;
+      font-size: 13px;
+      resize: vertical;
+      min-height: 60px;
+      outline: none;
+      margin-bottom: 0;
+      display: block;
+    }
+
+    .comment-area textarea:focus {
+      border-color: var(--accent);
+    }
+
+    .comment-area textarea::placeholder {
+      color: var(--text-dim);
+    }
+
+    .existing-comment {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px;
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-top: 8px;
+      position: relative;
+    }
+
+    .existing-comment .edit-btn {
+      position: absolute;
+      top: 6px;
+      right: 8px;
+      font-size: 11px;
+      color: var(--accent);
+      cursor: pointer;
+      background: none;
+      border: none;
+    }
+
+    /* Right panel: prompt output */
+    .right-panel {
+      width: 360px;
+      min-width: 200px;
+      background: var(--bg-surface);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .right-panel-header {
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .right-panel-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+    }
+
+    .right-panel-content::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .right-panel-content::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 3px;
+    }
+
+    .prompt-output {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 12px;
+      line-height: 1.6;
+      color: var(--text-muted);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .prompt-placeholder {
+      color: var(--text-dim);
+      font-style: italic;
+      font-size: 13px;
+      text-align: center;
+      padding: 40px 20px;
+    }
+
+    .copy-btn {
+      padding: 8px 16px;
+      margin: 12px 16px 16px;
+      background: var(--accent);
+      color: #0d1117;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .copy-btn:hover {
+      opacity: 0.9;
+    }
+
+    .copy-btn.copied {
+      background: var(--green);
+    }
+
+    /* Filter tabs in right panel */
+    .filter-tabs {
+      display: flex;
+      gap: 2px;
+      padding: 8px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-surface);
+    }
+
+    .filter-tab {
+      padding: 4px 10px;
+      font-size: 11px;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-radius: 4px;
+      transition: all 0.15s;
+    }
+
+    .filter-tab:hover {
+      background: var(--bg-hover);
+    }
+
+    .filter-tab.active {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+
+    /* Feedback summary items */
+    .feedback-item {
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+    }
+
+    .feedback-item:last-child {
+      border-bottom: none;
+    }
+
+    .feedback-item .fb-section {
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+      font-size: 12px;
+    }
+
+    .feedback-item .fb-status {
+      display: inline-block;
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-weight: 600;
+      margin-right: 6px;
+    }
+
+    .fb-status.approved {
+      background: var(--green-bg);
+      color: var(--green);
+    }
+
+    .fb-status.revision {
+      background: var(--red-bg);
+      color: var(--red);
+    }
+
+    .fb-status.question {
+      background: rgba(188, 140, 255, 0.1);
+      color: var(--purple);
+    }
+
+    .feedback-item .fb-comment {
+      color: var(--text-muted);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    /* Revised section highlight */
+    .section.revised {
+      border-left: 3px solid var(--accent) !important;
+      background: rgba(88, 166, 255, 0.04) !important;
+    }
+
+    .revised-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: rgba(88, 166, 255, 0.15);
+      color: var(--accent);
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
+    .mermaid-container {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 16px;
+      margin: 12px 0;
+      overflow-x: auto;
+    }
+
+    .mermaid-container svg {
+      max-width: 100%;
+      height: auto;
+    }
+    /* Terminal panel (TT-127) */
+    .terminal-panel {
+      width: 460px;
+      min-width: 240px;
+      background: var(--bg-surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      transition: width 0.2s ease, min-width 0.2s ease;
+    }
+
+    .terminal-panel.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      overflow: hidden;
+    }
+
+    .terminal-panel.collapsed > * {
+      display: none;
+    }
+
+    .terminal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+      flex-shrink: 0;
+    }
+
+    .terminal-header .term-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .term-status {
+      font-size: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      border-radius: 3px;
+      background: var(--bg-surface-2);
+      color: var(--text-dim);
+    }
+
+    .term-status.connected {
+      color: var(--green);
+      background: var(--green-bg);
+    }
+
+    .term-status.error {
+      color: var(--red);
+      background: var(--red-bg);
+    }
+
+    .terminal-host {
+      flex: 1;
+      min-height: 0;
+      padding: 6px 8px 8px 8px;
+      overflow: hidden;
+    }
+
+    .terminal-host .xterm {
+      height: 100%;
+    }
+
+    /* Send to Claude button (TT-127) */
+    .send-claude-btn {
+      margin: 12px 16px 16px;
+      padding: 10px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #0d1117;
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      cursor: pointer;
+      transition: filter 0.15s;
+      font-family: inherit;
+    }
+
+    .send-claude-btn:hover {
+      filter: brightness(1.1);
+    }
+
+    .send-claude-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .send-claude-btn.sent {
+      background: var(--green);
+      border-color: var(--green);
+    }
+  </style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+</head>
+
+<body>
+
+  <div class="topbar">
+    <div class="topbar-toggles">
+      <button class="collapse-toggle" id="leftToggle" title="Toggle sections">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <rect x="1" y="1" width="4" height="14" rx="1" opacity="0.9" />
+          <rect x="7" y="1" width="8" height="14" rx="1" opacity="0.3" />
+        </svg>
+      </button>
+    </div>
+    <h1>TT-128: Open-Source /plan-review Plugin</h1>
+    <div class="stats" id="stats"></div>
+    <div class="topbar-toggles">
+      <button class="collapse-toggle" id="termToggle" title="Toggle terminal">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M2 3h12v10H2V3zm1 1v8h10V4H3z" opacity="0.6"/>
+          <path d="M4 6l2 2-2 2M7 10h3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.9"/>
+        </svg>
+      </button>
+      <button class="collapse-toggle" id="rightToggle" title="Toggle feedback">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <rect x="1" y="1" width="8" height="14" rx="1" opacity="0.3" />
+          <rect x="11" y="1" width="4" height="14" rx="1" opacity="0.9" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="main">
+    <div class="nav" id="nav"></div>
+    <div class="resize-handle" id="leftHandle"></div>
+    <div class="doc-panel" id="docPanel"></div>
+    <div class="resize-handle" id="termHandle"></div>
+    <div class="terminal-panel" id="termPanel">
+      <div class="terminal-header">
+        <span class="term-title">
+          <svg width="14" height="14" viewBox="0 6.603 1192.672 1193.397" fill="#d97757" aria-hidden="true">
+            <path d="m233.96 800.215 234.684-131.678 3.947-11.436-3.947-6.363h-11.436l-39.221-2.416-134.094-3.624-116.296-4.832-112.67-6.04-28.35-6.04-26.577-35.035 2.738-17.477 23.84-16.027 34.147 2.98 75.463 5.155 113.235 7.812 82.147 4.832 121.692 12.644h19.329l2.738-7.812-6.604-4.832-5.154-4.832-117.182-79.41-126.845-83.92-66.443-48.321-35.92-24.484-18.12-22.953-7.813-50.093 32.618-35.92 43.812 2.98 11.195 2.98 44.375 34.147 94.792 73.37 123.786 91.167 18.12 15.06 7.249-5.154.886-3.624-8.135-13.61-67.329-121.692-71.838-123.785-31.974-51.302-8.456-30.765c-2.98-12.645-5.154-23.275-5.154-36.242l37.127-50.416 20.537-6.604 49.53 6.604 20.86 18.121 30.765 70.39 49.852 110.818 77.315 150.684 22.631 44.698 12.08 41.396 4.51 12.645h7.813v-7.248l6.362-84.886 11.759-104.215 11.436-134.094 3.946-37.772 18.685-45.262 37.127-24.482 28.994 13.852 23.839 34.148-3.303 22.067-14.174 92.134-27.785 144.323-18.121 96.644h10.55l12.08-12.08 48.887-64.913 82.147-102.685 36.242-40.752 42.282-45.02 27.14-21.423h51.303l37.772 56.135-16.913 57.986-52.832 67.007-43.812 56.779-62.82 84.563-39.22 67.651 3.623 5.396 9.343-.886 141.906-30.201 76.671-13.852 91.49-15.705 41.396 19.329 4.51 19.65-16.269 40.189-97.852 24.16-114.764 22.954-170.9 40.43-2.093 1.53 2.416 2.98 76.993 7.248 32.94 1.771h80.617l150.12 11.195 39.222 25.933 23.517 31.732-3.946 24.16-60.403 30.766-81.503-19.33-190.228-45.26-65.235-16.27h-9.02v5.397l54.362 53.154 99.624 89.96 124.752 115.973 6.362 28.671-16.027 22.63-16.912-2.415-109.611-82.47-42.282-37.127-95.758-80.618h-6.363v8.456l22.067 32.296 116.537 175.167 6.04 53.719-8.456 17.476-30.201 10.55-33.181-6.04-68.215-95.758-70.39-107.84-56.778-96.644-6.926 3.947-33.503 360.886-15.705 18.443-36.243 13.852-30.201-22.953-16.027-37.127 16.027-73.37 19.329-95.758 15.704-76.107 14.175-94.55 8.456-31.41-.563-2.094-6.927.886-71.275 97.852-108.402 146.497-85.772 91.812-20.537 8.134-35.597-18.443 3.301-32.94 19.893-29.315 118.712-151.007 71.597-93.583 46.228-54.04-.322-7.813h-2.738l-315.302 204.725-56.135 7.248-24.16-22.63 2.98-37.128 11.435-12.08 94.792-65.236-.322.323z"/>
+          </svg>
+          Claude Opus 4.7
+        </span>
+        <span class="term-status" id="termStatus">connecting…</span>
+      </div>
+      <div class="terminal-host" id="termHost"></div>
+    </div>
+    <div class="resize-handle" id="rightHandle"></div>
+    <div class="right-panel" id="rightPanel">
+      <div class="right-panel-header">
+        <span>Review Feedback</span>
+        <span id="feedbackCount" style="font-size:11px;color:var(--text-dim)"></span>
+      </div>
+      <div class="filter-tabs" id="filterTabs">
+        <div class="filter-tab active" data-filter="all">All</div>
+        <div class="filter-tab" data-filter="approved">Approved</div>
+        <div class="filter-tab" data-filter="revision">Needs Revision</div>
+        <div class="filter-tab" data-filter="question">Questions</div>
+      </div>
+      <div class="right-panel-content" id="feedbackList"></div>
+      <button class="send-claude-btn" id="sendClaudeBtn" onclick="sendToClaude()" disabled>Send to Claude</button>
+    </div>
+  </div>
+
+  <script>
+    // ============================================================
+    // CONTENT: Replace this array with your plan sections.
+    // Each section needs: id, title, content (markdown-like string).
+    // Optional: revised (boolean) to highlight as updated.
+    // ============================================================
+    const docSections = [
+      {
+        id: "context",
+        title: "Context & Motivation",
+        content: `The \`/plan-review\` skill creates interactive HTML review playgrounds from implementation plans. A partner saw a demo and suggested open sourcing it.
+
+- **What exists today** — \`.claude/skills/plan-review/SKILL.md\` + \`docs/plans/review-template.html\` (1659 lines) + \`docs/plans/REVIEW_TEMPLATE.md\` (108 lines), reusing \`docs/architecture-map/_devserver.py\`
+- **What we want** — a standalone Claude Code plugin installable via the plugin marketplace in any project, with zero assumptions about the consuming repo's layout
+- **Reference model** — Anthropic's official \`playground\` plugin (\`claude-plugins-official/plugins/playground\`) — same packaging shape to follow
+
+**Driving constraint:** no hidden dependencies on tastytrade-sdk paths or conventions. A fresh-clone user should be able to install and run \`/plan-review\` without creating any directories or copying files.`
+      },
+      {
+        id: "packaging",
+        title: "Plugin Packaging Structure",
+        content: `Standard Claude Code plugin layout, mirroring \`claude-plugins-official/plugins/playground\`.
+
+### Proposed Repo Layout
+
+\`\`\`
+claude-plan-review/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── plan-review/
+│       └── SKILL.md
+├── assets/
+│   ├── review-template.html
+│   └── REVIEW_TEMPLATE.md
+├── bin/
+│   └── devserver.py
+├── LICENSE
+└── README.md
+\`\`\`
+
+### What Moves Where
+
+| Current location | Plugin location |
+|---|---|
+| \`.claude/skills/plan-review/SKILL.md\` | \`skills/plan-review/SKILL.md\` |
+| \`docs/plans/review-template.html\` | \`assets/review-template.html\` |
+| \`docs/plans/REVIEW_TEMPLATE.md\` | \`assets/REVIEW_TEMPLATE.md\` |
+| \`docs/architecture-map/_devserver.py\` (shared) | \`bin/devserver.py\` (dedicated, bundled) |
+
+### plugin.json Contents
+
+\`\`\`json
+{
+  "name": "plan-review",
+  "description": "Create interactive HTML review playgrounds for implementation plans with approve/revise/question controls and copy-as-prompt feedback.",
+  "author": { "name": "<your name>", "email": "<your email>" }
+}
+\`\`\``
+      },
+      {
+        id: "path-decoupling",
+        title: "Path Decoupling via \${CLAUDE_PLUGIN_ROOT}",
+        revised: true,
+        content: `The current SKILL.md reads \`docs/plans/review-template.html\` and shells out to \`docs/architecture-map/_devserver.py\` — both project-relative. As a plugin, these assets live inside the plugin's install directory, not the user's project.
+
+### The Change
+
+\`\${CLAUDE_PLUGIN_ROOT}\` is Claude Code's platform-provided pointer to the plugin's install directory (like \`$HOME\` for the shell). It's substituted inline in skill content. SKILL.md references become:
+
+| Before | After |
+|---|---|
+| \`docs/plans/review-template.html\` | \`\${CLAUDE_PLUGIN_ROOT}/assets/review-template.html\` |
+| \`docs/plans/REVIEW_TEMPLATE.md\` | \`\${CLAUDE_PLUGIN_ROOT}/assets/REVIEW_TEMPLATE.md\` |
+| \`docs/architecture-map/_devserver.py\` | \`\${CLAUDE_PLUGIN_ROOT}/bin/devserver.py\` |
+
+### Notes
+- Verified against Claude Code's official Plugins reference (Environment variables section)
+- Not a variable we define — Claude Code provides it automatically when the plugin is installed and invoked
+- ~20-line edit to SKILL.md, no new code`
+      },
+      {
+        id: "output-dir",
+        title: "Output Directory Resolution",
+        revised: true,
+        content: `Generated review docs need a home. Default is \`.claude/plans/\` — keeps artifacts out of the project tree unless the user explicitly opts into a different location.
+
+### Resolution Order (first match wins)
+
+1. **\`PLAN_REVIEW_DIR\` env var** — explicit override, absolute or project-relative path
+2. **\`.claude/plans/\`** — always the default, auto-created if missing (\`mkdir -p\`)
+
+### Rationale
+- Don't pollute the user's project with generated artifacts unless they intentionally redirect
+- \`.claude/\` is the Claude Code tooling directory — familiar, non-source, already outside most teams' commit flows
+- Env var is the escape hatch for users who want plans in \`docs/plans/\` or anywhere else
+
+### Note on \`.claude/\` Creation
+\`.claude/\` is not guaranteed to exist in every project — plugins often need to create it. Auto-creating \`.claude/plans/\` (and \`.claude/\` as a side effect) is standard; README documents this for transparency.`
+      },
+      {
+        id: "invocation",
+        title: "Generalized Invocation (No Jira Assumption)",
+        revised: true,
+        content: `Current signature \`/plan-review <TT-XXX> <title>\` bakes in Jira framing and requires both args. Open-source users may not have Jira, and if they're mid-planning, the model already has the context.
+
+### Invocation Forms
+
+| Invocation | Behavior |
+|---|---|
+| \`/plan-review\` | Model reads the conversation (plan doc being discussed, recent file edits, messages like "we're scoping TT-128 for MCP migration") and infers both the ticket ID and the title. Confirms with user before writing. If no recoverable context, asks. |
+| \`/plan-review <ticket>\` | User supplies the ticket ID. Model infers the title from the same conversation context. If no title context, asks. |
+
+### "Title Inferred from Context" — What That Means
+The model looks at the conversation it's already in — the plan markdown under discussion, recent edits to a scoping doc, user messages naming the work — and proposes a title based on what it sees. No API calls, no Jira lookups. If the conversation is empty or ambiguous, the skill prompts the user for the title rather than guessing.
+
+### Ticket ID Handling
+- Any tracker format accepted as-is: \`TT-128\`, \`RFC-042\`, \`PROJ-7\`, \`JIRA-1024\`, etc.
+- If it matches \`/^[A-Z]+-\\d+$/\`, optionally render as a link in the review doc header
+- No Jira-specific assumption; no assumption of any API availability
+
+### What's NOT Supported
+- **Free-form slugs as IDs.** Something like \`auth-rework\` isn't a ticket — if passed as the single arg, treat it as a title fragment rather than an ID. No new artifacts, no overlapping labels.
+- **Both args explicit** — a third form \`/plan-review <id> <title>\` was considered and dropped. Keep the signature close to existing behavior.`
+      },
+      {
+        id: "session-preamble",
+        title: "Send-to-Claude Preamble (First-Click-Only)",
+        revised: true,
+        content: `When a reviewer clicks "Send to Claude" and the feedback lands in the running session, the agent has no awareness context has switched — it may jump straight to editing the HTML instead of discussing first.
+
+### Fix
+
+The "Send to Claude" button prepends a one-time context-switch preamble to the first click of a browser session, then omits it on subsequent clicks.
+
+### Preamble Text (first click only)
+
+**Context switch:** you are now in the plan-review playground. The review document is at \`<path>\`. Discuss the feedback below conversationally. Do NOT edit the HTML until I explicitly say to update. When discussion on a section wraps, ask whether to update the document.
+
+### State Handling
+- Tracked via \`localStorage\` keyed by the review doc's filename
+- Persists across page refresh; new browser session or new review doc resets
+- Subsequent clicks in the same session: just the feedback payload, no preamble
+
+### Design Notes
+- **No ID/title in the preamble** — the feedback payload already carries plan context, and the ID is optional (per invocation section). Omitting keeps the preamble clean regardless of args.
+- **Context-switch framing** handles \`--continue\`'s mid-conversation resume: the agent sees an explicit role transition rather than a random new turn.`
+      },
+      {
+        id: "session-binding",
+        title: "Session Resume via --continue",
+        revised: true,
+        content: `When a reviewer opens the HTML and the PTY bridge connects, it spawns \`claude --continue\`, which resumes the most-recently-modified session in the working directory. This is the current skill's behavior and **we're keeping it**.
+
+### Why Not Capture or Compute a UUID
+
+- **Compute a new UUID** (e.g., UUIDv5 from plan ID) — creates a *new* session unrelated to the conversation the reviewer was in. Destroys the "pick up where we were" feature. Non-starter.
+- **Capture the current session's UUID** — Claude Code does not expose a \`CLAUDE_SESSION_ID\` env var to skills (verified against the official plugin docs). Filesystem heuristics (\`~/.claude/projects/<encoded-cwd>/*.jsonl\` newest) would work but depend on undocumented behavior.
+- **Keep \`--continue\`** — works for the common workflow (one claude session per project at a time). Fails only if the user opens another \`claude\` in the same cwd between creating and resuming a review.
+
+### Known Limitation (README must document)
+If you run multiple Claude Code sessions in the same project between creating and resuming a review, \`--continue\` may pick the wrong one. Close other sessions before resuming, or create the review fresh.
+
+### Future Refinement (not blocking)
+If Claude Code later exposes a session-ID env var or a supported CLI capture mechanism, we can swap \`--continue\` for \`--resume <captured-id>\` without breaking the plugin's external contract.`
+      },
+      {
+        id: "devserver",
+        title: "Bundled Devserver (WS + PTY Bridge)",
+        revised: true,
+        content: `The real devserver is **Python, ~450 lines**, and includes the WebSocket + PTY bridge that drives the embedded Claude Code terminal from TT-127. This is the core of the tool, not optional.
+
+### What It Does
+- Serves the generated HTML file over HTTP
+- Binds on LAN IP (not \`localhost\`) so reviewers on other devices can open the URL
+- WebSocket endpoint \`/api/claude\` spawns \`claude --continue\` in a pseudo-terminal and bridges I/O to the browser's xterm.js pane
+- "Send to Claude" writes feedback directly into the running session via WebSocket — no copy/paste
+
+### Prerequisites (must be on user's machine)
+- **Python 3.10+** — nearly ubiquitous on dev systems (macOS ships Python 3, Linux distros ship it, modern Windows has it). Plugin fails loudly at launch with a clear error if missing.
+- **\`ptyprocess\`** pip package — installed alongside the plugin: \`pip install ptyprocess\`. Documented in README install steps.
+- **\`claude\` CLI** available in PATH — required for the PTY bridge to spawn a session.
+
+### Why Not Avoid Python
+Alternatives considered and rejected:
+- **Rewrite in Node** — adds a frontend runtime dep for users who don't have one; throws away the existing 450-line devserver.
+- **Bundle a Python binary** — huge, platform-specific, maintenance burden.
+- **Use \`uv run --python 3.10 …\`** — auto-provisions Python but adds \`uv\` as a dep.
+
+None justify the cost. Python is standard equipment on developer machines. Document the prereq, fail loudly if absent, move on.
+
+### Implementation Details
+- **WebSocket:** hand-rolled RFC 6455 framing over stdlib \`socket\` (~170 lines)
+- **PTY:** \`ptyprocess\`
+- **Source:** adapt from \`docs/architecture-map/_devserver.py\` in this repo. Strip the \`/api/refresh\` endpoint (tastytrade-specific).
+- **Spawn cwd:** from the HTML's serving directory or user's invocation CWD — not \`.git\`-walking.
+- **LAN IP** auto-detected via \`socket\` stdlib; fallback to \`localhost\`.
+- **Optional** \`PLAN_REVIEW_HOST\` / \`PLAN_REVIEW_PORT\` env overrides.
+
+### Location
+\`\${CLAUDE_PLUGIN_ROOT}/bin/devserver.py\``
+      },
+      {
+        id: "decision-name-license",
+        title: "DECISION: Repo Name & License",
+        content: `Two open calls before publishing.
+
+### Repo Name
+- **Option A:** \`claude-plan-review\` — descriptive, follows \`claude-*\` convention for ecosystem packages
+- **Option B:** \`plan-review\` — shorter, matches the skill name exactly; risks name collision
+- **Option C:** \`<user-handle>/plan-review-plugin\` — scoped under personal handle, no ecosystem prefix
+
+### License
+- **Option A:** MIT — permissive, matches Anthropic's playground plugin, easy reuse
+- **Option B:** Apache 2.0 — patent grant included, slightly more formal
+- **Option C:** CC0 / Unlicense — public domain, maximum permissiveness
+
+### Resolution
+- **Repo Name:** Option B — \`plan-review\`
+- **License:** Option A — MIT`
+      },
+      {
+        id: "decision-migration",
+        title: "DECISION: Migration from In-Repo Skill",
+        revised: true,
+        content: `Once the plugin is published, what happens to \`.claude/skills/plan-review/SKILL.md\` in this repo?
+
+| Option | Behavior | Tradeoff |
+|---|---|---|
+| **A. Rip and replace** | Delete in-repo skill, install plugin | Clean; forces team to install plugin |
+| **B. Keep both** | Leave in-repo skill as-is; plugin is a separate artifact | No team disruption; risk of drift between versions |
+| **C. In-repo becomes thin wrapper** | In-repo skill points at installed plugin | Awkward; two maintenance surfaces |
+
+### Resolution
+**Option B** — keep both for now. Ship the plugin as a separate artifact; leave the in-repo skill untouched. Revisit migration once the plugin is stable and dogfooded — at that point we'll have evidence for whether convergence is worth it or the two surfaces should continue living side by side.`
+      },
+      {
+        id: "readme",
+        title: "README & Documentation",
+        revised: true,
+        content: `README is the entry point for open-source users. Must cover prerequisites, install, first-use, and customization.
+
+### Sections the README Must Have
+- **What it does** — 2-sentence pitch with a screenshot or GIF
+- **Prerequisites** — Python 3.10+, \`claude\` CLI in PATH
+- **Install** — \`/plugin marketplace add <user>/<repo>\` + \`/plugin install plan-review\` + \`pip install ptyprocess\`
+- **Quick start** — \`/plan-review TT-128\` end-to-end walkthrough
+- **Invocation forms** — zero-arg (infer) and one-arg (explicit ticket) variants with examples
+- **Output directory** — default \`.claude/plans/\` (auto-created), override with \`PLAN_REVIEW_DIR\` to write elsewhere
+- **Feedback loop** — how "Send to Claude" works; what the first-click context-switch preamble does
+- **Content format** — the markdown subset supported in \`content\` fields (table in SKILL.md)
+- **Session resume** — \`claude --continue\` behavior and the multi-session limitation
+
+### Optional
+- Troubleshooting (\`devserver port already in use\`, \`python3 not found\`, \`claude\` not in PATH, \`ptyprocess\` install issues)
+- Contributing guide if you want PRs`
+      },
+      {
+        id: "acceptance-criteria",
+        title: "Acceptance Criteria Checklist",
+        revised: true,
+        content: `Consolidated ACs, updated to match the current plan. Must all pass before merging to \`main\` on the plugin repo.
+
+### Packaging
+- [ ] Plugin repo created on GitHub, public, with LICENSE (MIT) and README
+- [ ] Plugin name: \`plan-review\`
+- [ ] Structure matches Anthropic playground conventions (\`.claude-plugin/plugin.json\`, \`skills/plan-review/SKILL.md\`, \`assets/\`, \`bin/\`)
+
+### Path Decoupling
+- [ ] SKILL.md uses \`\${CLAUDE_PLUGIN_ROOT}\` for template and devserver paths
+- [ ] No references to consuming project's \`docs/architecture-map/\` or \`docs/plans/\`
+
+### Output Directory
+- [ ] Default output directory is \`.claude/plans/\`, auto-created if missing (\`mkdir -p\`)
+- [ ] \`PLAN_REVIEW_DIR\` env var overrides the default
+- [ ] Devserver root is set to whichever directory the file was written to
+
+### Invocation
+- [ ] Zero-arg invocation infers ticket ID and title from conversation context, confirms with user, asks if context is empty
+- [ ] One-arg invocation accepts a ticket ID in any tracker format; title inferred from context
+- [ ] Free-form slugs that aren't ticket-format are treated as titles, not IDs
+- [ ] No third invocation form with two explicit args
+
+### Send-to-Claude Preamble
+- [ ] First "Send to Claude" click in a browser session prepends the context-switch preamble
+- [ ] Subsequent clicks in the same session omit the preamble
+- [ ] Preamble substitutes the document path (no ID/title reference)
+- [ ] State persists across refresh (localStorage); new session/doc resets
+
+### Feedback Handling (Skill Behavior)
+- [ ] SKILL.md instructs the agent: when revising a section in response to feedback, **clear any stale "What Changed" notes or prior-round commentary** from that section — do not stack them
+- [ ] If the history appears load-bearing (documents a specific decision still informing the current content), the agent asks the reviewer before clearing
+
+### Devserver (WS + PTY Bridge)
+- [ ] Devserver is Python 3.10+, includes WebSocket framing + PTY bridge
+- [ ] README documents Python + \`ptyprocess\` + \`claude\` CLI prerequisites
+- [ ] \`/api/refresh\` endpoint stripped (tastytrade-specific)
+- [ ] Devserver binds on LAN IP (not localhost); fallback to \`localhost\`
+- [ ] Skill returns URL using LAN IP
+- [ ] Optional \`PLAN_REVIEW_HOST\` / \`PLAN_REVIEW_PORT\` env overrides
+
+### Session Resume
+- [ ] PTY bridge spawns \`claude --continue\`
+- [ ] README documents the "most recent session" limitation
+
+### Documentation
+- [ ] README covers: prerequisites, install (including \`ptyprocess\`), invocation forms, output dir, feedback loop, session resume limitation, content format
+
+### Verification
+- [ ] End-to-end verified in a clean test project — plugin installs, \`/plan-review\` runs, Send-to-Claude drives an embedded live session`
+      },
+      {
+        id: "out-of-scope",
+        title: "Out of Scope & Open Questions",
+        content: `### Out of Scope
+- Submission to Anthropic's official marketplace — follow-up once the plugin is battle-tested
+- Any new features beyond the current skill's capabilities
+- Migration of the in-repo skill — keep both for now (see DECISION: Migration)
+- Replacing \`--continue\` with session-ID capture — only if Claude Code later exposes a supported mechanism
+
+### Open Questions
+- **GitHub org or personal account?** Publishing under a personal handle vs. creating a small org for Claude Code plugins.
+- **Version number to ship with?** Start at \`0.1.0\` (signals work-in-progress) or \`1.0.0\` (signals confidence)?
+- **Changelog / release notes?** Start one now, or defer until v2?
+
+### Things to Decide Later (Not Blocking)
+- Telemetry / usage tracking — almost certainly no, but worth an explicit "no" so contributors don't add it later
+- Alternative review templates via a \`--template\` flag — out of scope for v1`
+      }
+    ];
+
+    // ============================================================
+    // OPTIONAL: Pre-approved sections from prior review rounds.
+    // Map section id -> status ("approved", "revision", "question").
+    // ============================================================
+    const priorApprovals = {
+      "context": "approved",
+      "packaging": "approved",
+      "path-decoupling": "approved",
+      "session-preamble": "approved",
+      "session-binding": "approved",
+      "decision-name-license": "approved",
+      "decision-migration": "approved",
+      "out-of-scope": "approved",
+    };
+
+    // ============================================================
+    // PLAN NAME: Update this string for the copy-to-prompt output.
+    // ============================================================
+    const PLAN_NAME = "TT-128: Open-Source /plan-review Plugin";
+
+    // Persistence — save/restore review state across sessions
+    const STORAGE_KEY = 'review-state:' + PLAN_NAME;
+    const LAYOUT_KEY = 'review-layout:' + PLAN_NAME;
+
+    function saveToStorage() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+          sections: state.sections.map(s => ({ id: s.id, status: s.status, comment: s.comment })),
+          activeSection: state.activeSection,
+          activeFilter: state.activeFilter
+        }));
+      } catch (e) { }
+    }
+
+    function loadFromStorage() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        (data.sections || []).forEach(saved => {
+          const s = state.sections.find(s => s.id === saved.id);
+          if (s) { s.status = saved.status || 'pending'; s.comment = saved.comment || ''; }
+        });
+        if (data.activeSection) state.activeSection = data.activeSection;
+        if (data.activeFilter) state.activeFilter = data.activeFilter;
+      } catch (e) { }
+    }
+
+    // State
+    const state = {
+      sections: docSections.map(s => ({
+        ...s,
+        status: priorApprovals[s.id] || 'pending',
+        comment: ''
+      })),
+      activeSection: docSections[0]?.id || '',
+      activeFilter: 'all'
+    };
+
+    // Render markdown-like content to HTML
+    function renderMarkdown(text) {
+      let html = '';
+      const lines = text.split('\n');
+      let inCode = false;
+      let codeLang = '';
+      let codeLines = [];
+      let inList = false;
+      let listTag = 'ul';
+      let inTable = false;
+      let tableRows = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (line.trim().startsWith('```')) {
+          if (inCode) {
+            if (codeLang === 'mermaid') {
+              html += '<div class="mermaid-container"><pre class="mermaid">' + codeLines.join('\n') + '</pre></div>';
+            } else {
+              html += '<pre><code>' + codeLines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</code></pre>';
+            }
+            codeLines = [];
+            inCode = false;
+            codeLang = '';
+          } else {
+            if (inList) { html += '</' + listTag + '>'; inList = false; }
+            if (inTable) { html += renderTable(tableRows); inTable = false; tableRows = []; }
+            codeLang = line.trim().slice(3).trim().toLowerCase();
+            inCode = true;
+          }
+          continue;
+        }
+        if (inCode) { codeLines.push(line); continue; }
+
+        if (line.trim().startsWith('|')) {
+          if (inList) { html += '</' + listTag + '>'; inList = false; }
+          if (!inTable) inTable = true;
+          if (!line.trim().match(/^\|[\s-|]+\|$/)) {
+            tableRows.push(line);
+          }
+          continue;
+        } else if (inTable) {
+          html += renderTable(tableRows);
+          inTable = false;
+          tableRows = [];
+        }
+
+        if (line.trim() === '') {
+          if (inList) {
+            // Look ahead: if next non-blank line continues the list, keep it open
+            let keepList = false;
+            for (let j = i + 1; j < lines.length; j++) {
+              const next = lines[j].trim();
+              if (next === '') continue;
+              if (listTag === 'ol' && next.match(/^\d+\.\s/)) keepList = true;
+              if (listTag === 'ul' && (next.startsWith('- ') || next.startsWith('* '))) keepList = true;
+              break;
+            }
+            if (!keepList) { html += '</' + listTag + '>'; inList = false; }
+          }
+          continue;
+        }
+
+        if (line.startsWith('### ')) {
+          if (inList) { html += '</' + listTag + '>'; inList = false; }
+          html += '<h4 style="font-size:14px;font-weight:600;color:var(--text);margin:16px 0 8px">' + inlineFormat(line.slice(4)) + '</h4>';
+          continue;
+        }
+
+        if (line.trim().startsWith('- ') || line.trim().startsWith('* ')) {
+          if (inList && listTag !== 'ul') { html += '</' + listTag + '>'; inList = false; }
+          if (!inList) { listTag = 'ul'; html += '<ul>'; inList = true; }
+          html += '<li>' + inlineFormat(line.trim().slice(2)) + '</li>';
+          continue;
+        }
+        if (line.trim().match(/^\d+\.\s/)) {
+          if (inList && listTag !== 'ol') { html += '</' + listTag + '>'; inList = false; }
+          if (!inList) { listTag = 'ol'; html += '<ol>'; inList = true; }
+          html += '<li>' + inlineFormat(line.trim().replace(/^\d+\.\s/, '')) + '</li>';
+          continue;
+        }
+
+        if (inList) { html += '</' + listTag + '>'; inList = false; }
+        html += '<p>' + inlineFormat(line) + '</p>';
+      }
+
+      if (inCode) html += '<pre><code>' + codeLines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</code></pre>';
+      if (inList) html += '</' + listTag + '>';
+      if (inTable) html += renderTable(tableRows);
+
+      return html;
+    }
+
+    function renderTable(rows) {
+      if (rows.length === 0) return '';
+      let html = '<table>';
+      rows.forEach((row, idx) => {
+        const cells = row.split('|').filter(c => c.trim() !== '');
+        const tag = idx === 0 ? 'th' : 'td';
+        html += '<tr>' + cells.map(c => `<${tag}>${inlineFormat(c.trim())}</${tag}>`).join('') + '</tr>';
+      });
+      html += '</table>';
+      return html;
+    }
+
+    function inlineFormat(text) {
+      return text
+        .replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/`([^`]+)`/g, '<code>$1</code>')
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" style="color:var(--accent);text-decoration:none">$1</a>')
+        .replace(/\\`/g, '`');
+    }
+
+    // Render navigation
+    function renderNav() {
+      const nav = document.getElementById('nav');
+      nav.innerHTML = state.sections.map(s => {
+        const icon = s.status === 'approved' ? '<span style="color:var(--green)">&#10003;</span>'
+          : s.status === 'revision' ? '<span style="color:var(--red)">&#9998;</span>'
+            : s.status === 'question' ? '<span style="color:var(--purple)">?</span>'
+              : '<span style="color:var(--text-dim)">&bull;</span>';
+        return `<div class="nav-item ${s.id === state.activeSection ? 'active' : ''}"
+                 onclick="navigateTo('${s.id}')">
+      <span class="status-icon">${icon}</span>
+      <span class="label">${s.title}</span>
+      ${s.revised ? '<span style="font-size:9px;color:var(--accent);font-weight:700">REV</span>' : ''}
+    </div>`;
+      }).join('');
+    }
+
+    // Render document
+    function renderDoc() {
+      const panel = document.getElementById('docPanel');
+      panel.innerHTML = state.sections.map(s => {
+        const borderColor = s.status === 'approved' ? 'var(--green)'
+          : s.status === 'revision' ? 'var(--red)'
+            : s.status === 'question' ? 'var(--purple)' : 'transparent';
+        const bgColor = s.status === 'approved' ? 'var(--green-bg)'
+          : s.status === 'revision' ? 'var(--red-bg)'
+            : s.status === 'question' ? 'rgba(188,140,255,0.06)' : 'transparent';
+
+        const revisedAndPending = s.revised && s.status === 'pending';
+        const revisedClass = revisedAndPending ? ' revised' : '';
+        return `<div class="section${revisedClass}" id="section-${s.id}"
+                 style="border-left: 3px solid ${revisedAndPending ? 'var(--accent)' : borderColor}; background: ${revisedAndPending ? 'rgba(88,166,255,0.04)' : bgColor};">
+      <div class="section-header">
+        <h2>${s.title}</h2>
+        ${s.revised ? '<span class="revised-badge">Revised</span>' : ''}
+      </div>
+      <div class="section-content">${renderMarkdown(s.content)}</div>
+      <div class="review-bar">
+        <button class="review-btn ${s.status === 'approved' ? 'active-approved' : ''}"
+                onclick="setStatus('${s.id}','approved')">Approve</button>
+        <button class="review-btn ${s.status === 'revision' ? 'active-revision' : ''}"
+                onclick="setStatus('${s.id}','revision')">Needs Revision</button>
+        <button class="review-btn ${s.status === 'question' ? 'active-question' : ''}"
+                onclick="setStatus('${s.id}','question')">Question</button>
+        <button class="review-btn" onclick="toggleComment('${s.id}')"
+                style="margin-left:auto">Comment</button>
+      </div>
+      <div class="comment-area" id="comment-${s.id}">
+        ${s.comment
+            ? `<div class="existing-comment">${s.comment.replace(/</g, '&lt;').replace(/\n/g, '<br>')}
+               <button class="edit-btn" onclick="editComment('${s.id}')">edit</button></div>`
+            : `<textarea placeholder="Add your feedback for this section..."
+                      onblur="saveComment('${s.id}', this.value)"
+                      id="textarea-${s.id}"></textarea>`
+          }
+      </div>
+    </div>`;
+      }).join('');
+    }
+
+    // Render stats
+    function renderStats() {
+      const counts = { pending: 0, approved: 0, revision: 0, question: 0 };
+      state.sections.forEach(s => counts[s.status]++);
+      document.getElementById('stats').innerHTML = `
+    <div class="stat"><div class="dot dot-approved"></div>${counts.approved} Approved</div>
+    <div class="stat"><div class="dot dot-pending"></div>${counts.pending} Pending</div>
+    <div class="stat"><div class="dot dot-revision"></div>${counts.revision} Needs Revision</div>
+    <div class="stat"><div class="dot dot-question"></div>${counts.question} Questions</div>
+  `;
+    }
+
+    // Render feedback panel
+    function renderFeedback() {
+      const list = document.getElementById('feedbackList');
+      const filtered = state.sections.filter(s => {
+        if (state.activeFilter === 'all') return s.status !== 'pending';
+        return s.status === state.activeFilter;
+      });
+
+      const count = state.sections.filter(s => s.status !== 'pending').length;
+      document.getElementById('feedbackCount').textContent = count > 0 ? `${count} reviewed` : '';
+
+      if (filtered.length === 0) {
+        list.innerHTML = `<div class="prompt-placeholder">
+      ${state.activeFilter === 'all'
+            ? 'Review sections by clicking Approve, Needs Revision, or Question. Your feedback will appear here.'
+            : 'No sections with this status yet.'}
+    </div>`;
+        return;
+      }
+
+      list.innerHTML = filtered.map(s => `
+    <div class="feedback-item" onclick="navigateTo('${s.id}')" style="cursor:pointer">
+      <div class="fb-section">
+        <span class="fb-status ${s.status}">${s.status === 'approved' ? 'APPROVED' : s.status === 'revision' ? 'REVISION' : 'QUESTION'}</span>
+        ${s.title}
+      </div>
+      ${s.comment ? `<div class="fb-comment">"${s.comment}"</div>` : ''}
+    </div>
+  `).join('');
+    }
+
+    // Actions
+    function navigateTo(id) {
+      state.activeSection = id;
+      saveToStorage();
+      renderNav();
+      var el = document.getElementById('section-' + id);
+      var panel = document.getElementById('docPanel');
+      panel.scrollTo({ top: el.offsetTop - panel.offsetTop, behavior: 'smooth' });
+    }
+
+    function setStatus(id, status) {
+      const section = state.sections.find(s => s.id === id);
+      if (section.status === status) {
+        section.status = 'pending';
+      } else {
+        section.status = status;
+        if (status === 'revision' || status === 'question') {
+          setTimeout(() => {
+            const area = document.getElementById('comment-' + id);
+            if (area) area.classList.add('visible');
+          }, 50);
+        }
+      }
+      renderAll();
+      saveToStorage();
+    }
+
+    function toggleComment(id) {
+      const area = document.getElementById('comment-' + id);
+      area.classList.toggle('visible');
+      if (area.classList.contains('visible')) {
+        const ta = document.getElementById('textarea-' + id);
+        if (ta) ta.focus();
+      }
+    }
+
+    function saveComment(id, value) {
+      const section = state.sections.find(s => s.id === id);
+      section.comment = value.trim();
+      renderAll();
+      saveToStorage();
+    }
+
+    function editComment(id) {
+      const section = state.sections.find(s => s.id === id);
+      const area = document.getElementById('comment-' + id);
+      area.innerHTML = `<textarea placeholder="Edit your feedback..."
+    onblur="saveComment('${id}', this.value)"
+    id="textarea-${id}">${section.comment}</textarea>`;
+      area.classList.add('visible');
+      document.getElementById('textarea-' + id).focus();
+    }
+
+    function generatePrompt() {
+      const approved = state.sections.filter(s => s.status === 'approved');
+      const revision = state.sections.filter(s => s.status === 'revision');
+      const questions = state.sections.filter(s => s.status === 'question');
+
+      if (approved.length === 0 && revision.length === 0 && questions.length === 0) {
+        return '';
+      }
+
+      let prompt = `Here is my review of the ${PLAN_NAME} plan:\n\n`;
+
+      if (approved.length > 0) {
+        prompt += `## Approved Sections (${approved.length}/${state.sections.length})\n`;
+        approved.forEach(s => {
+          prompt += `- **${s.title}**: Approved`;
+          if (s.comment) prompt += ` — ${s.comment}`;
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      if (revision.length > 0) {
+        prompt += `## Needs Revision (${revision.length})\n`;
+        revision.forEach(s => {
+          prompt += `- **${s.title}**`;
+          if (s.comment) prompt += `: ${s.comment}`;
+          else prompt += ': (no specific feedback provided)';
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      if (questions.length > 0) {
+        prompt += `## Questions (${questions.length})\n`;
+        questions.forEach(s => {
+          prompt += `- **${s.title}**`;
+          if (s.comment) prompt += `: ${s.comment}`;
+          else prompt += ': (question not specified)';
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      const remaining = state.sections.filter(s => s.status === 'pending');
+      if (remaining.length > 0) {
+        prompt += `## Not Yet Reviewed (${remaining.length})\n`;
+        remaining.forEach(s => prompt += `- ${s.title}\n`);
+      }
+
+      return prompt;
+    }
+
+    function copyPrompt() {
+      const prompt = generatePrompt();
+      if (!prompt) return;
+      const btn = document.getElementById('copyBtn');
+      function onSuccess() {
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => { btn.textContent = 'Copy Feedback as Prompt'; btn.classList.remove('copied'); }, 2000);
+      }
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(prompt).then(onSuccess).catch(fallbackCopy);
+      } else {
+        fallbackCopy();
+      }
+      function fallbackCopy() {
+        const ta = document.createElement('textarea');
+        ta.value = prompt;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); onSuccess(); } catch (e) { btn.textContent = 'Copy failed'; }
+        document.body.removeChild(ta);
+      }
+    }
+
+    // Filter tabs
+    document.getElementById('filterTabs').addEventListener('click', e => {
+      const tab = e.target.closest('.filter-tab');
+      if (!tab) return;
+      state.activeFilter = tab.dataset.filter;
+      document.querySelectorAll('.filter-tab').forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      renderFeedback();
+      saveToStorage();
+    });
+
+    function renderAll() {
+      renderNav();
+      renderDoc();
+      renderStats();
+      renderFeedback();
+      document.querySelectorAll('.mermaid[data-processed]').forEach(el => el.removeAttribute('data-processed'));
+      if (typeof mermaid !== 'undefined') mermaid.run();
+    }
+
+    // Resizable & collapsible panels (mouse + touch)
+    let __fitTerminal = () => { };
+    (function () {
+      const nav = document.getElementById('nav');
+      const rightPanel = document.getElementById('rightPanel');
+      const termPanel = document.getElementById('termPanel');
+      const leftHandle = document.getElementById('leftHandle');
+      const rightHandle = document.getElementById('rightHandle');
+      const termHandle = document.getElementById('termHandle');
+      const leftToggle = document.getElementById('leftToggle');
+      const rightToggle = document.getElementById('rightToggle');
+      const termToggle = document.getElementById('termToggle');
+
+      let dragging = null;
+      let navWidth = 240;
+      let rightWidth = 360;
+      let termWidth = 460;
+
+      // Restore saved layout
+      const savedLayout = (() => { try { return JSON.parse(localStorage.getItem(LAYOUT_KEY) || '{}'); } catch (e) { return {}; } })();
+      if (savedLayout.navWidth) navWidth = savedLayout.navWidth;
+      if (savedLayout.rightWidth) rightWidth = savedLayout.rightWidth;
+      if (savedLayout.termWidth) termWidth = savedLayout.termWidth;
+      if (savedLayout.navCollapsed) nav.classList.add('collapsed');
+      else nav.style.width = navWidth + 'px';
+      if (savedLayout.rightCollapsed) rightPanel.classList.add('collapsed');
+      else rightPanel.style.width = rightWidth + 'px';
+      // Terminal defaults to closed; only expand if user previously opened it.
+      if (savedLayout.termCollapsed === false) termPanel.style.width = termWidth + 'px';
+      else termPanel.classList.add('collapsed');
+
+      function saveLayout() {
+        try {
+          localStorage.setItem(LAYOUT_KEY, JSON.stringify({
+            navWidth, rightWidth, termWidth,
+            navCollapsed: nav.classList.contains('collapsed'),
+            rightCollapsed: rightPanel.classList.contains('collapsed'),
+            termCollapsed: termPanel.classList.contains('collapsed')
+          }));
+        } catch (e) { }
+      }
+
+      function updateToggles() {
+        const navCollapsed = nav.classList.contains('collapsed');
+        const rightCollapsed = rightPanel.classList.contains('collapsed');
+        const termCollapsed = termPanel.classList.contains('collapsed');
+        leftToggle.title = navCollapsed ? 'Show sections' : 'Hide sections';
+        leftToggle.classList.toggle('panel-collapsed', navCollapsed);
+        rightToggle.title = rightCollapsed ? 'Show feedback' : 'Hide feedback';
+        rightToggle.classList.toggle('panel-collapsed', rightCollapsed);
+        termToggle.title = termCollapsed ? 'Show terminal' : 'Hide terminal';
+        termToggle.classList.toggle('panel-collapsed', termCollapsed);
+      }
+
+      function toggleNav(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (nav.classList.contains('collapsed')) {
+          nav.classList.remove('collapsed');
+          nav.style.width = navWidth + 'px';
+        } else {
+          navWidth = nav.offsetWidth;
+          nav.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      function toggleRight(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (rightPanel.classList.contains('collapsed')) {
+          // Opening feedback — close terminal first AND inherit its width.
+          if (!termPanel.classList.contains('collapsed')) {
+            termWidth = termPanel.offsetWidth;
+            rightWidth = termWidth;
+            termPanel.classList.add('collapsed');
+          }
+          rightPanel.classList.remove('collapsed');
+          rightPanel.style.width = rightWidth + 'px';
+        } else {
+          rightWidth = rightPanel.offsetWidth;
+          rightPanel.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      function toggleTerm(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (termPanel.classList.contains('collapsed')) {
+          // Opening terminal — close feedback first AND inherit its width.
+          if (!rightPanel.classList.contains('collapsed')) {
+            rightWidth = rightPanel.offsetWidth;
+            termWidth = rightWidth;
+            rightPanel.classList.add('collapsed');
+          }
+          termPanel.classList.remove('collapsed');
+          termPanel.style.width = termWidth + 'px';
+          setTimeout(__fitTerminal, 220);
+        } else {
+          termWidth = termPanel.offsetWidth;
+          termPanel.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      let touchFiredLeft = false, touchFiredRight = false, touchFiredTerm = false;
+
+      leftToggle.addEventListener('touchend', e => { touchFiredLeft = true; toggleNav(e); }, { passive: false });
+      leftToggle.addEventListener('click', e => { if (touchFiredLeft) { touchFiredLeft = false; return; } toggleNav(e); });
+
+      rightToggle.addEventListener('touchend', e => { touchFiredRight = true; toggleRight(e); }, { passive: false });
+      rightToggle.addEventListener('click', e => { if (touchFiredRight) { touchFiredRight = false; return; } toggleRight(e); });
+
+      termToggle.addEventListener('touchend', e => { touchFiredTerm = true; toggleTerm(e); }, { passive: false });
+      termToggle.addEventListener('click', e => { if (touchFiredTerm) { touchFiredTerm = false; return; } toggleTerm(e); });
+
+      updateToggles();
+
+      // Drag resize (mouse)
+      function onDragStart(e, side) {
+        e.preventDefault();
+        dragging = side;
+        document.body.classList.add('resizing');
+        const handle = side === 'left' ? leftHandle : (side === 'term' ? termHandle : rightHandle);
+        handle.classList.add('dragging');
+      }
+
+      leftHandle.addEventListener('mousedown', e => onDragStart(e, 'left'));
+      termHandle.addEventListener('mousedown', e => onDragStart(e, 'term'));
+      rightHandle.addEventListener('mousedown', e => onDragStart(e, 'right'));
+
+      document.addEventListener('mousemove', e => {
+        if (!dragging) return;
+        applyDrag(e.clientX);
+      });
+
+      document.addEventListener('mouseup', endDrag);
+
+      // Drag resize (touch)
+      leftHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'left'); }, { passive: false });
+      termHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'term'); }, { passive: false });
+      rightHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'right'); }, { passive: false });
+
+      document.addEventListener('touchmove', e => {
+        if (!dragging) return;
+        e.preventDefault();
+        applyDrag(e.touches[0].clientX);
+      }, { passive: false });
+
+      document.addEventListener('touchend', endDrag);
+
+      function applyDrag(clientX) {
+        if (dragging === 'left') {
+          const w = Math.max(140, Math.min(400, clientX));
+          nav.classList.remove('collapsed');
+          nav.style.width = w + 'px';
+          navWidth = w;
+        } else if (dragging === 'right') {
+          const w = Math.max(200, Math.min(600, window.innerWidth - clientX));
+          rightPanel.classList.remove('collapsed');
+          rightPanel.style.width = w + 'px';
+          rightWidth = w;
+        } else if (dragging === 'term') {
+          // termHandle sits between doc and terminal; the terminal's width is
+          // (everything to the right of clientX) minus the right-panel width
+          // (when expanded) and the right resize handle (1px).
+          const rightTaken = rightPanel.classList.contains('collapsed') ? 0 : rightPanel.offsetWidth + 1;
+          const w = Math.max(240, Math.min(900, window.innerWidth - clientX - rightTaken));
+          termPanel.classList.remove('collapsed');
+          termPanel.style.width = w + 'px';
+          termWidth = w;
+          __fitTerminal();
+        }
+        updateToggles();
+      }
+
+      function endDrag() {
+        if (!dragging) return;
+        document.body.classList.remove('resizing');
+        leftHandle.classList.remove('dragging');
+        rightHandle.classList.remove('dragging');
+        termHandle.classList.remove('dragging');
+        dragging = null;
+        saveLayout();
+        __fitTerminal();
+      }
+
+      // Re-fit terminal on viewport changes
+      window.addEventListener('resize', () => __fitTerminal());
+    })();
+
+    // ============================================================
+    // TT-127: Terminal panel + Send to Claude
+    // Mounts xterm.js in #termHost, opens a websocket to the
+    // devserver's /api/claude endpoint (which spawns
+    // `claude --continue` in a PTY), and exposes sendToClaude()
+    // which writes the existing feedback bundle to that session.
+    // ============================================================
+    let __claudeWS = null;
+    let __claudeReady = false;
+    let __claudeTerm = null;
+    let __claudeFitAddon = null;
+
+    (function initClaudeTerminal() {
+      const host = document.getElementById('termHost');
+      const status = document.getElementById('termStatus');
+      const sendBtn = document.getElementById('sendClaudeBtn');
+      if (!host || typeof Terminal === 'undefined') return;
+
+      const term = new Terminal({
+        fontFamily: '"SF Mono", "Fira Code", "JetBrains Mono", monospace',
+        fontSize: 12,
+        lineHeight: 1.2,
+        theme: {
+          background: '#161b22',
+          foreground: '#e6edf3',
+          cursor: '#58a6ff',
+          selectionBackground: 'rgba(88, 166, 255, 0.35)',
+        },
+        cursorBlink: true,
+        scrollback: 5000,
+        convertEol: false,
+      });
+      const fitAddon = new FitAddon.FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(host);
+      try { fitAddon.fit(); } catch (e) { }
+
+      __claudeTerm = term;
+      __claudeFitAddon = fitAddon;
+      __fitTerminal = () => {
+        if (document.getElementById('termPanel').classList.contains('collapsed')) return;
+        try { fitAddon.fit(); } catch (e) { }
+        if (__claudeReady && __claudeWS && __claudeWS.readyState === WebSocket.OPEN) {
+          try {
+            __claudeWS.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+          } catch (e) { }
+        }
+      };
+
+      function setStatus(text, kind) {
+        status.textContent = text;
+        status.classList.remove('connected', 'error');
+        if (kind) status.classList.add(kind);
+      }
+
+      function connect() {
+        const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const url = `${proto}//${location.host}/api/claude`;
+        setStatus('connecting…');
+        let ws;
+        try {
+          ws = new WebSocket(url);
+        } catch (e) {
+          setStatus('error', 'error');
+          term.writeln(`\r\n[devserver] failed to open ${url}: ${e}\r\n`);
+          return;
+        }
+        ws.binaryType = 'arraybuffer';
+        __claudeWS = ws;
+
+        ws.onopen = () => {
+          __claudeReady = true;
+          setStatus('connected', 'connected');
+          sendBtn.disabled = false;
+          // send initial size so PTY matches xterm
+          try {
+            ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+          } catch (e) { }
+        };
+
+        ws.onmessage = (ev) => {
+          if (typeof ev.data === 'string') {
+            // control message (e.g. error JSON); print to terminal for visibility
+            term.writeln('\r\n[devserver] ' + ev.data);
+            return;
+          }
+          term.write(new Uint8Array(ev.data));
+        };
+
+        ws.onerror = () => {
+          setStatus('error', 'error');
+        };
+
+        ws.onclose = () => {
+          __claudeReady = false;
+          sendBtn.disabled = true;
+          setStatus('disconnected');
+          term.writeln('\r\n[devserver] session closed. refresh page to reconnect.\r\n');
+        };
+
+        const encoder = new TextEncoder();
+        term.onData((data) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          try { ws.send(encoder.encode(data)); } catch (e) { }
+        });
+
+        term.onResize(({ cols, rows }) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          try { ws.send(JSON.stringify({ type: 'resize', cols, rows })); } catch (e) { }
+        });
+      }
+
+      connect();
+    })();
+
+    function sendToClaude() {
+      const btn = document.getElementById('sendClaudeBtn');
+      const prompt = generatePrompt();
+      if (!prompt) return;
+      if (!__claudeWS || __claudeWS.readyState !== WebSocket.OPEN) {
+        btn.textContent = 'Terminal disconnected';
+        setTimeout(() => { btn.textContent = 'Send to Claude'; }, 2000);
+        return;
+      }
+      // On send: open terminal panel, collapse feedback panel — single focused surface.
+      const termPanel = document.getElementById('termPanel');
+      const rightPanel = document.getElementById('rightPanel');
+      if (termPanel.classList.contains('collapsed')) {
+        document.getElementById('termToggle').click();
+      }
+      if (!rightPanel.classList.contains('collapsed')) {
+        document.getElementById('rightToggle').click();
+      }
+      const encoder = new TextEncoder();
+      // Newline at the end so Claude Code submits the bundle as one turn.
+      __claudeWS.send(encoder.encode(prompt + '\n'));
+      btn.textContent = 'Sent';
+      btn.classList.add('sent');
+      if (__claudeTerm) __claudeTerm.focus();
+      setTimeout(() => {
+        btn.textContent = 'Send to Claude';
+        btn.classList.remove('sent');
+      }, 2000);
+    }
+
+    mermaid.initialize({ startOnLoad: false, theme: 'dark', themeVariables: {
+      primaryColor: '#1c2128', primaryTextColor: '#e6edf3', primaryBorderColor: '#30363d',
+      lineColor: '#58a6ff', secondaryColor: '#161b22', tertiaryColor: '#21262d',
+      nodeTextColor: '#e6edf3', edgeLabelBackground: '#161b22'
+    }});
+
+    loadFromStorage();
+    document.querySelectorAll('.filter-tab').forEach(t => {
+      t.classList.toggle('active', t.dataset.filter === state.activeFilter);
+    });
+    renderAll();
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

Open-sourced the in-repo `/plan-review` skill as a standalone Claude Code plugin, distributed via a new public marketplace at [`xmandeng/claude-plugins`](https://github.com/xmandeng/claude-plugins).

This branch only contains the approved scoping plan artifact (`docs/plans/TT-128-open-source-plan-review-plugin-review.html`). The actual plugin code lives in the standalone repo — there's no code change to tastytrade-sdk.

## Plugin Repo

- **Marketplace:** `xmandeng-plugins` at https://github.com/xmandeng/claude-plugins
- **Plugin:** `plan-review` (v0.1.4)
- **Install:** `/plugin marketplace add xmandeng/claude-plugins` then `/plugin install plan-review@xmandeng-plugins`
- **Invoke:** `/plan-review:plan-review [<ticket>]`

## What's in the Plugin

- Bundled review template (`assets/review-template.html`) and authoring guide (`assets/REVIEW_TEMPLATE.md`)
- Self-contained Python devserver with WebSocket + PTY bridge (`bin/devserver.py`) — no third-party deps required (stdlib `pty.fork()` fallback; `ptyprocess` used as optional acceleration if installed)
- Per-project port allocation via `<output-dir>/.devserver-port` so multiple projects can run `/plan-review` concurrently without port conflicts
- LAN IP auto-detection so reviewers on other devices can open the URL
- Default output to `.plan-review/` (overridable via `PLAN_REVIEW_DIR`) — non-polluting

## Functional Verification

User confirmed end-to-end (quote: "I have tested and this worked perfectly"):
- [x] Plugin installs from the marketplace
- [x] `/plan-review:plan-review <ticket>` generates the review HTML
- [x] Devserver launches on a free port and binds to LAN IP
- [x] Embedded terminal connects to a live `claude --continue` session
- [x] "Send to Claude" delivers structured feedback into the live session
- [x] Multiple projects can run concurrently without port conflicts

## What This PR Merges to tastytrade-sdk

Just the approved scoping plan HTML at `docs/plans/TT-128-open-source-plan-review-plugin-review.html` — preserved as a planning artifact for the work that was completed externally.

The in-repo `/plan-review` skill at `.claude/skills/plan-review/SKILL.md` is **not modified** by this PR (per the approved plan's "Migration: Option B — keep both for now" decision). It continues to work as it always did. Migration to the plugin can be a separate follow-up ticket once the plugin is dogfooded long enough.

## Test Plan

- [ ] Verify `docs/plans/TT-128-open-source-plan-review-plugin-review.html` renders correctly in browser
- [ ] Confirm no other source files changed (this is a documentation-only PR)
- [ ] Reviewer optionally tests plugin install: `/plugin marketplace add xmandeng/claude-plugins`
