### PR TITLE
TT-137: Fix pytest serializer and unawaited-coroutine warnings

### DIFF
--- a/.plan-review/TT-137-pytest-warnings-cleanup-review.html
+++ b/.plan-review/TT-137-pytest-warnings-cleanup-review.html
@@ -1,0 +1,1972 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plan Review: TT-137: Clean up pytest warnings produced by pre-push hook</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --bg: #0d1117;
+      --bg-surface: #161b22;
+      --bg-surface-2: #1c2128;
+      --bg-hover: #21262d;
+      --border: #30363d;
+      --border-light: #484f58;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --text-dim: #6e7681;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --green-bg: rgba(63, 185, 80, 0.10);
+      --amber: #d29922;
+      --amber-bg: rgba(210, 153, 34, 0.10);
+      --red: #f85149;
+      --red-bg: rgba(248, 81, 73, 0.08);
+      --purple: #bc8cff;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      height: 100vh;
+      height: -webkit-fill-available;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Top bar */
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+      height: 52px;
+    }
+
+    .topbar h1 {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .topbar .stats {
+      display: flex;
+      gap: 16px;
+      font-size: 12px;
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    .stat .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+
+    .dot-pending {
+      background: var(--amber);
+    }
+
+    .dot-approved {
+      background: var(--green);
+    }
+
+    .dot-revision {
+      background: var(--red);
+    }
+
+    .dot-question {
+      background: var(--purple);
+    }
+
+    /* Main layout */
+    .main {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+    }
+
+    /* Resize handles */
+    .resize-handle {
+      width: 1px;
+      cursor: col-resize;
+      background: var(--border);
+      position: relative;
+      flex-shrink: 0;
+      z-index: 10;
+      overflow: visible;
+    }
+
+    .resize-handle::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -10px;
+      right: -10px;
+    }
+
+    .resize-handle:hover,
+    .resize-handle.dragging {
+      background: var(--accent);
+      width: 3px;
+    }
+
+    body.resizing {
+      cursor: col-resize;
+      user-select: none;
+    }
+
+    /* Topbar collapse toggle buttons */
+    .topbar-toggles {
+      display: flex;
+      gap: 6px;
+    }
+
+    .collapse-toggle {
+      width: 36px;
+      height: 32px;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: manipulation;
+      -webkit-user-select: none;
+      user-select: none;
+      transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+    }
+
+    @media (hover: hover) {
+      .collapse-toggle:hover {
+        background: var(--bg-hover);
+        color: var(--text);
+        border-color: var(--accent);
+      }
+    }
+
+    .collapse-toggle.panel-collapsed {
+      background: var(--accent);
+      color: var(--bg);
+      border-color: var(--accent);
+    }
+
+    /* Collapsed panel states */
+    .nav.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      padding: 0 !important;
+      overflow: hidden;
+    }
+
+    .right-panel.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      overflow: hidden;
+    }
+
+    .right-panel.collapsed>* {
+      display: none;
+    }
+
+    .nav.collapsed>* {
+      display: none;
+    }
+
+    .nav,
+    .right-panel {
+      transition: width 0.2s ease, min-width 0.2s ease, padding 0.2s ease;
+    }
+
+    /* Section nav */
+    .nav {
+      width: 240px;
+      min-width: 140px;
+      background: var(--bg-surface);
+      overflow-y: auto;
+      padding: 12px 0;
+    }
+
+    .nav-item {
+      padding: 8px 16px;
+      font-size: 12px;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-left: 3px solid transparent;
+      transition: all 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .nav-item:hover {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+
+    .nav-item.active {
+      background: var(--bg-hover);
+      border-left-color: var(--accent);
+      color: var(--text);
+    }
+
+    .nav-item .status-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+    }
+
+    .nav-item .label {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Document panel */
+    .doc-panel {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px 32px;
+      min-width: 0;
+    }
+
+    .doc-panel::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .doc-panel::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .doc-panel::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 4px;
+    }
+
+    /* Section rendering */
+    .section {
+      margin-bottom: 16px;
+      scroll-margin-top: 20px;
+      padding: 16px 16px 10px;
+      border-radius: 6px;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .section-header h2 {
+      font-size: 18px;
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .section-header h3 {
+      font-size: 15px;
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .section-content {
+      font-size: 14px;
+      line-height: 1.7;
+      color: var(--text-muted);
+    }
+
+    .section-content p {
+      margin-bottom: 12px;
+    }
+
+    .section-content strong {
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .section-content code {
+      font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+      font-size: 12px;
+      background: var(--bg-surface-2);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: var(--accent);
+    }
+
+    .section-content pre {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 14px;
+      margin: 12px 0;
+      overflow-x: auto;
+      font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      color: var(--text-muted);
+    }
+
+    .section-content pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+
+    .section-content ul,
+    .section-content ol {
+      margin: 8px 0 12px 24px;
+    }
+
+    .section-content li {
+      margin-bottom: 4px;
+    }
+
+    .section-content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0;
+      font-size: 13px;
+    }
+
+    .section-content th,
+    .section-content td {
+      text-align: left;
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+    }
+
+    .section-content th {
+      background: var(--bg-surface-2);
+      color: var(--text);
+      font-weight: 600;
+    }
+
+    .section-content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 20px 0;
+    }
+
+    /* Review actions */
+    .review-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+    }
+
+    .review-btn {
+      padding: 6px 14px;
+      font-size: 12px;
+      font-weight: 500;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      transition: all 0.15s;
+    }
+
+    .review-btn:hover {
+      border-color: var(--border-light);
+      color: var(--text);
+    }
+
+    .review-btn.active-approved {
+      background: var(--green-bg);
+      border-color: var(--green);
+      color: var(--green);
+    }
+
+    .review-btn.active-revision {
+      background: var(--red-bg);
+      border-color: var(--red);
+      color: var(--red);
+    }
+
+    .review-btn.active-question {
+      background: rgba(188, 140, 255, 0.10);
+      border-color: var(--purple);
+      color: var(--purple);
+    }
+
+    .comment-area {
+      margin-top: 10px;
+      display: none;
+    }
+
+    .comment-area.visible {
+      display: block;
+    }
+
+    .comment-area textarea {
+      width: 100%;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      padding: 10px;
+      font-family: inherit;
+      font-size: 13px;
+      resize: vertical;
+      min-height: 60px;
+      outline: none;
+      margin-bottom: 0;
+      display: block;
+    }
+
+    .comment-area textarea:focus {
+      border-color: var(--accent);
+    }
+
+    .comment-area textarea::placeholder {
+      color: var(--text-dim);
+    }
+
+    .existing-comment {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px;
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-top: 8px;
+      position: relative;
+    }
+
+    .existing-comment .edit-btn {
+      position: absolute;
+      top: 6px;
+      right: 8px;
+      font-size: 11px;
+      color: var(--accent);
+      cursor: pointer;
+      background: none;
+      border: none;
+    }
+
+    /* Right panel: prompt output */
+    .right-panel {
+      width: 360px;
+      min-width: 200px;
+      background: var(--bg-surface);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .right-panel-header {
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .right-panel-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+    }
+
+    .right-panel-content::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .right-panel-content::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: 3px;
+    }
+
+    .prompt-output {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 12px;
+      line-height: 1.6;
+      color: var(--text-muted);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .prompt-placeholder {
+      color: var(--text-dim);
+      font-style: italic;
+      font-size: 13px;
+      text-align: center;
+      padding: 40px 20px;
+    }
+
+    .copy-btn {
+      padding: 8px 16px;
+      margin: 12px 16px 16px;
+      background: var(--accent);
+      color: #0d1117;
+      border: none;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .copy-btn:hover {
+      opacity: 0.9;
+    }
+
+    .copy-btn.copied {
+      background: var(--green);
+    }
+
+    /* Filter tabs in right panel */
+    .filter-tabs {
+      display: flex;
+      gap: 2px;
+      padding: 8px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-surface);
+    }
+
+    .filter-tab {
+      padding: 4px 10px;
+      font-size: 11px;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-radius: 4px;
+      transition: all 0.15s;
+    }
+
+    .filter-tab:hover {
+      background: var(--bg-hover);
+    }
+
+    .filter-tab.active {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+
+    /* Feedback summary items */
+    .feedback-item {
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+    }
+
+    .feedback-item:last-child {
+      border-bottom: none;
+    }
+
+    .feedback-item .fb-section {
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+      font-size: 12px;
+    }
+
+    .feedback-item .fb-status {
+      display: inline-block;
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-weight: 600;
+      margin-right: 6px;
+    }
+
+    .fb-status.approved {
+      background: var(--green-bg);
+      color: var(--green);
+    }
+
+    .fb-status.revision {
+      background: var(--red-bg);
+      color: var(--red);
+    }
+
+    .fb-status.question {
+      background: rgba(188, 140, 255, 0.1);
+      color: var(--purple);
+    }
+
+    .feedback-item .fb-comment {
+      color: var(--text-muted);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    /* Revised section highlight */
+    .section.revised {
+      border-left: 3px solid var(--accent) !important;
+      background: rgba(88, 166, 255, 0.04) !important;
+    }
+
+    .revised-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: rgba(88, 166, 255, 0.15);
+      color: var(--accent);
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
+    .mermaid-container {
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 16px;
+      margin: 12px 0;
+      overflow-x: auto;
+    }
+
+    .mermaid-container svg {
+      max-width: 100%;
+      height: auto;
+    }
+    /* Terminal panel (TT-127) */
+    .terminal-panel {
+      width: 460px;
+      min-width: 240px;
+      background: var(--bg-surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      transition: width 0.2s ease, min-width 0.2s ease;
+    }
+
+    .terminal-panel.collapsed {
+      width: 0 !important;
+      min-width: 0 !important;
+      overflow: hidden;
+    }
+
+    .terminal-panel.collapsed > * {
+      display: none;
+    }
+
+    .terminal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+      flex-shrink: 0;
+    }
+
+    .terminal-header .term-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .term-status {
+      font-size: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      border-radius: 3px;
+      background: var(--bg-surface-2);
+      color: var(--text-dim);
+    }
+
+    .term-status.connected {
+      color: var(--green);
+      background: var(--green-bg);
+    }
+
+    .term-status.error {
+      color: var(--red);
+      background: var(--red-bg);
+    }
+
+    .terminal-host {
+      flex: 1;
+      min-height: 0;
+      padding: 6px 8px 8px 8px;
+      overflow: hidden;
+    }
+
+    .terminal-host .xterm {
+      height: 100%;
+    }
+
+    /* Browser → terminal handoff footer (TT-130) */
+    .handoff-bar {
+      padding: 8px 12px;
+      background: var(--bg-surface);
+      border-top: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+      flex-shrink: 0;
+    }
+
+    .handoff-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .handoff-label {
+      color: var(--text-dim);
+      font-weight: 600;
+    }
+
+    .handoff-sid {
+      flex: 1;
+      min-width: 0;
+      padding: 2px 6px;
+      border-radius: 3px;
+      background: var(--bg-surface-2);
+      color: var(--text);
+      font-size: 11px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .handoff-btn {
+      padding: 4px 10px;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text);
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .handoff-btn:hover:not(:disabled) {
+      background: var(--bg-surface);
+      border-color: var(--text-dim);
+    }
+
+    .handoff-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .handoff-status {
+      margin-top: 6px;
+      font-size: 11px;
+      color: var(--text-dim);
+      min-height: 14px;
+    }
+
+    .handoff-status.done {
+      color: var(--green);
+    }
+
+    .handoff-status-cmd {
+      display: block;
+      margin-top: 4px;
+      padding: 4px 8px;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--text);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      user-select: all;
+      white-space: nowrap;
+      overflow-x: auto;
+    }
+
+    /* Send to Claude button (TT-127) */
+    .send-claude-btn {
+      margin: 12px 16px 16px;
+      padding: 10px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #0d1117;
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      cursor: pointer;
+      transition: filter 0.15s;
+      font-family: inherit;
+    }
+
+    .send-claude-btn:hover {
+      filter: brightness(1.1);
+    }
+
+    .send-claude-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .send-claude-btn.sent {
+      background: var(--green);
+      border-color: var(--green);
+    }
+  </style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+</head>
+
+<body>
+
+  <div class="topbar">
+    <div class="topbar-toggles">
+      <button class="collapse-toggle" id="leftToggle" title="Toggle sections">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <rect x="1" y="1" width="4" height="14" rx="1" opacity="0.9" />
+          <rect x="7" y="1" width="8" height="14" rx="1" opacity="0.3" />
+        </svg>
+      </button>
+    </div>
+    <h1>TT-137: Clean up pytest warnings produced by pre-push hook</h1>
+    <div class="stats" id="stats"></div>
+    <div class="topbar-toggles">
+      <button class="collapse-toggle" id="termToggle" title="Toggle terminal">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M2 3h12v10H2V3zm1 1v8h10V4H3z" opacity="0.6"/>
+          <path d="M4 6l2 2-2 2M7 10h3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.9"/>
+        </svg>
+      </button>
+      <button class="collapse-toggle" id="rightToggle" title="Toggle feedback">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <rect x="1" y="1" width="8" height="14" rx="1" opacity="0.3" />
+          <rect x="11" y="1" width="4" height="14" rx="1" opacity="0.9" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="main">
+    <div class="nav" id="nav"></div>
+    <div class="resize-handle" id="leftHandle"></div>
+    <div class="doc-panel" id="docPanel"></div>
+    <div class="resize-handle" id="termHandle"></div>
+    <div class="terminal-panel" id="termPanel">
+      <div class="terminal-header">
+        <span class="term-title">
+          <svg width="14" height="14" viewBox="0 6.603 1192.672 1193.397" fill="#d97757" aria-hidden="true">
+            <path d="m233.96 800.215 234.684-131.678 3.947-11.436-3.947-6.363h-11.436l-39.221-2.416-134.094-3.624-116.296-4.832-112.67-6.04-28.35-6.04-26.577-35.035 2.738-17.477 23.84-16.027 34.147 2.98 75.463 5.155 113.235 7.812 82.147 4.832 121.692 12.644h19.329l2.738-7.812-6.604-4.832-5.154-4.832-117.182-79.41-126.845-83.92-66.443-48.321-35.92-24.484-18.12-22.953-7.813-50.093 32.618-35.92 43.812 2.98 11.195 2.98 44.375 34.147 94.792 73.37 123.786 91.167 18.12 15.06 7.249-5.154.886-3.624-8.135-13.61-67.329-121.692-71.838-123.785-31.974-51.302-8.456-30.765c-2.98-12.645-5.154-23.275-5.154-36.242l37.127-50.416 20.537-6.604 49.53 6.604 20.86 18.121 30.765 70.39 49.852 110.818 77.315 150.684 22.631 44.698 12.08 41.396 4.51 12.645h7.813v-7.248l6.362-84.886 11.759-104.215 11.436-134.094 3.946-37.772 18.685-45.262 37.127-24.482 28.994 13.852 23.839 34.148-3.303 22.067-14.174 92.134-27.785 144.323-18.121 96.644h10.55l12.08-12.08 48.887-64.913 82.147-102.685 36.242-40.752 42.282-45.02 27.14-21.423h51.303l37.772 56.135-16.913 57.986-52.832 67.007-43.812 56.779-62.82 84.563-39.22 67.651 3.623 5.396 9.343-.886 141.906-30.201 76.671-13.852 91.49-15.705 41.396 19.329 4.51 19.65-16.269 40.189-97.852 24.16-114.764 22.954-170.9 40.43-2.093 1.53 2.416 2.98 76.993 7.248 32.94 1.771h80.617l150.12 11.195 39.222 25.933 23.517 31.732-3.946 24.16-60.403 30.766-81.503-19.33-190.228-45.26-65.235-16.27h-9.02v5.397l54.362 53.154 99.624 89.96 124.752 115.973 6.362 28.671-16.027 22.63-16.912-2.415-109.611-82.47-42.282-37.127-95.758-80.618h-6.363v8.456l22.067 32.296 116.537 175.167 6.04 53.719-8.456 17.476-30.201 10.55-33.181-6.04-68.215-95.758-70.39-107.84-56.778-96.644-6.926 3.947-33.503 360.886-15.705 18.443-36.243 13.852-30.201-22.953-16.027-37.127 16.027-73.37 19.329-95.758 15.704-76.107 14.175-94.55 8.456-31.41-.563-2.094-6.927.886-71.275 97.852-108.402 146.497-85.772 91.812-20.537 8.134-35.597-18.443 3.301-32.94 19.893-29.315 118.712-151.007 71.597-93.583 46.228-54.04-.322-7.813h-2.738l-315.302 204.725-56.135 7.248-24.16-22.63 2.98-37.128 11.435-12.08 94.792-65.236-.322.323z"/>
+          </svg>
+          Claude Opus 4.7
+        </span>
+        <span class="term-status" id="termStatus">connecting…</span>
+      </div>
+      <div class="terminal-host" id="termHost"></div>
+      <div class="handoff-bar" id="handoffBar">
+        <div class="handoff-row">
+          <span class="handoff-label">Session:</span>
+          <code class="handoff-sid" id="handoffSid">—</code>
+          <button class="handoff-btn" id="handoffBtn" type="button" title="Copy resume command and release the browser session">Hand off to terminal</button>
+        </div>
+        <div class="handoff-status" id="handoffStatus" aria-live="polite"></div>
+      </div>
+    </div>
+    <div class="resize-handle" id="rightHandle"></div>
+    <div class="right-panel" id="rightPanel">
+      <div class="right-panel-header">
+        <span>Review Feedback</span>
+        <span id="feedbackCount" style="font-size:11px;color:var(--text-dim)"></span>
+      </div>
+      <div class="filter-tabs" id="filterTabs">
+        <div class="filter-tab active" data-filter="all">All</div>
+        <div class="filter-tab" data-filter="approved">Approved</div>
+        <div class="filter-tab" data-filter="revision">Needs Revision</div>
+        <div class="filter-tab" data-filter="question">Questions</div>
+      </div>
+      <div class="right-panel-content" id="feedbackList"></div>
+      <button class="send-claude-btn" id="sendClaudeBtn" onclick="sendToClaude()" disabled>Send to Claude</button>
+    </div>
+  </div>
+
+  <script>
+    // ============================================================
+    // CONTENT: Replace this array with your plan sections.
+    // Each section needs: id, title, content (markdown-like string).
+    // Optional: revised (boolean) to highlight as updated.
+    // ============================================================
+    const docSections = [
+      {
+        id: "context",
+        title: "Context & Goal",
+        content: `**Jira:** [TT-137](https://mandeng.atlassian.net/browse/TT-137)
+**Branch:** \`feature/TT-137-pytest-warnings-cleanup\`
+
+Make the pytest warnings summary empty (or contain only warnings unrelated to this ticket) when running the pre-push gate, so future warnings carry signal.
+
+### What's broken
+
+\`git push\` triggers \`.githooks/pre-push\` → \`pytest\`. All 943 tests pass, but two distinct warning categories show up in the warnings summary:
+
+1. **Pydantic serializer warnings** — 7 tests in \`unit_tests/accounts/test_fill_monitor.py::TestMonitorFillsForEntryCredits\` warn that \`order_type\`, \`time_in_force\`, and \`filled_at\` don't match their declared enum / datetime types.
+2. **Unawaited coroutine** — \`unit_tests/signal_service/test_runner.py::test_runner_start_connects_and_subscribes\` emits \`RuntimeWarning: coroutine 'RedisSubscription.listener' was never awaited\`.
+
+### Why it matters
+
+A warnings summary that is always non-empty trains us to ignore it. Real future warnings (deprecations, leaked tasks, real serialization bugs) get drowned out. Also, the Pydantic warnings imply our test fixtures aren't faithfully representing wire-bound objects — there's a real chance a future test exposes a bug we'd otherwise miss.
+
+### Constraint from the ticket AC
+
+> No suppression via \`filterwarnings\` — fix the root cause in test setup, not the symptom.`
+      },
+      {
+        id: "category-1-root-cause",
+        title: "Category 1 — Pydantic Warnings: Root Cause",
+        content: `The factory functions in \`unit_tests/accounts/test_fill_monitor.py\` use \`model_construct()\` (which bypasses validation) and pass raw strings for fields whose declared types are enums or \`datetime\`:
+
+\`\`\`python
+# unit_tests/accounts/test_fill_monitor.py:37-45
+def make_order(...) -> PlacedOrder:
+    return PlacedOrder.model_construct(
+        ...
+        order_type="Limit",        # field type: OrderType enum
+        time_in_force="Day",       # field type: TimeInForce enum
+        ...
+    )
+
+# unit_tests/accounts/test_fill_monitor.py:48-58
+def make_fill(...) -> OrderFill:
+    return OrderFill.model_construct(
+        ...
+        filled_at="2026-03-16T20:00:00Z",  # field type: datetime
+    )
+\`\`\`
+
+Source-of-truth declarations:
+
+- \`src/tastytrade/accounts/models.py:797\` — \`class TimeInForce(str, Enum)\` with \`DAY = "Day"\`
+- \`src/tastytrade/accounts/models.py:805\` — \`class OrderType(str, Enum)\` with \`LIMIT = "Limit"\`
+- \`src/tastytrade/accounts/models.py:821\` — \`filled_at: datetime\`
+
+\`model_construct()\` skips coercion, so the in-memory instance literally stores \`str\` where the schema expects enum / datetime. When \`TestMonitorFillsForEntryCredits\` later calls \`order.model_dump_json(by_alias=True)\` (\`unit_tests/accounts/test_fill_monitor.py:200\`), Pydantic's serializer notices the type mismatch and emits \`PydanticSerializationUnexpectedValue\`.
+
+### Affected tests
+
+- \`test_open_fill_computes_entry_credit\`
+- \`test_buy_to_open_computes_debit\`
+- \`test_close_fills_are_ignored\`
+- \`test_non_filled_order_is_ignored\`
+- \`test_non_option_legs_are_ignored\`
+- \`test_multi_leg_order_computes_all_open_legs\`
+- \`test_legs_without_fills_are_skipped\``
+      },
+      {
+        id: "category-1-fix",
+        title: "Category 1 — Pydantic Warnings: Proposed Fix",
+        content: `Replace the raw string arguments with the typed values the schema expects.
+
+| Argument | Current | Replace with |
+|---|---|---|
+| \`order_type\` | \`"Limit"\` | \`OrderType.LIMIT\` |
+| \`time_in_force\` | \`"Day"\` | \`TimeInForce.DAY\` |
+| \`filled_at\` | \`"2026-03-16T20:00:00Z"\` | \`datetime(2026, 3, 16, 20, 0, 0, tzinfo=timezone.utc)\` |
+
+Add the missing imports at the top of the test file:
+
+- \`from datetime import datetime, timezone\`
+- Extend the existing \`from tastytrade.accounts.models import …\` to include \`OrderType\` and \`TimeInForce\`
+
+### Why this is safe
+
+Both \`OrderType\` and \`TimeInForce\` inherit from \`str, Enum\`, so the wire serialization (\`"Limit"\`, \`"Day"\`) is unchanged. Existing assertions on field equality remain valid via the \`str\` mixin's equality.
+
+### Files changed
+
+- \`unit_tests/accounts/test_fill_monitor.py\` — update \`make_order\` and \`make_fill\` factories and imports. **No production code is touched.**`
+      },
+      {
+        id: "category-2-root-cause",
+        title: "Category 2 — Unawaited Coroutine: Root Cause Hypothesis",
+        content: `\`unit_tests/signal_service/test_runner.py:13-22\` builds the \`runner\` fixture with \`subscription=AsyncMock()\` (no \`spec\`). When \`runner.start()\` runs the test patches \`asyncio.Event\` to raise \`CancelledError\`, so the awaited \`subscription.connect()\` and \`subscription.subscribe(...)\` are AsyncMock awaitables — those should be fine on their own.
+
+The warning text — \`coroutine 'RedisSubscription.listener' was never awaited\` — together with the traceback into \`unittest/mock.py\` tells us a real \`RedisSubscription.listener\` coroutine object is being instantiated inside \`mock\`'s spec / attribute introspection path. Most likely a child mock with the name \`listener\` falls back to invoking \`RedisSubscription.listener\` (the unbound coroutine function on the class) when AsyncMock generates the async-child mock.
+
+### Diagnostic step (do this first)
+
+Run the single test with full diagnostics so the implementer can confirm exactly where the coroutine is created:
+
+\`\`\`bash
+uv run python -W error::RuntimeWarning -X tracemalloc \\
+  -m pytest \\
+  unit_tests/signal_service/test_runner.py::test_runner_start_connects_and_subscribes \\
+  -p no:cacheprovider -v
+\`\`\`
+
+The traceback should pinpoint the line in either \`mock.py\` or \`runner.py\` that creates the unawaited coroutine. **The fix in the next section is provisional pending this diagnostic** — if the cause turns out to be different, the chosen option (A/B/C) may shift.`
+      },
+      {
+        id: "category-2-fix",
+        title: "Category 2 — Unawaited Coroutine: Proposed Fix Options",
+        content: `Pick the option that does **not** introduce a real-Redis side effect into the test (the test must remain fast and Redis-free). After the fix, \`assert_awaited_once_with(...)\` calls in the test must still work.
+
+### Option A — Explicit spec with safer member set
+
+\`\`\`python
+subscription = AsyncMock(spec=RedisSubscription)
+subscription.connect = AsyncMock()
+subscription.subscribe = AsyncMock()
+subscription.close = AsyncMock()
+\`\`\`
+
+Pre-creates exactly the methods the test calls; prevents mock from materializing \`listener\` lazily.
+
+### Option B — Narrow spec to the protocol
+
+\`src/tastytrade/connections/subscription.py:47\` defines \`RedisSubscriptionStore(SubscriptionStore)\` — there is a Protocol in the codebase that does **not** include \`listener\`. If \`EngineRunner\` only uses the Protocol surface, \`spec=SubscriptionStore\` (or whatever the public protocol is) avoids exposing \`listener\` entirely.
+
+### Option C — Explicit per-method mocks
+
+\`\`\`python
+subscription = MagicMock()
+subscription.connect = AsyncMock()
+subscription.subscribe = AsyncMock()
+subscription.close = AsyncMock()
+\`\`\`
+
+Most surgical. Pays for itself if Option A's spec forces too many other attributes to be stubbed.
+
+### Recommended order to try
+
+1. **Option A** first — minimal change, preserves spec-based type safety.
+2. If A still emits the warning (e.g. spec inference still walks the class hierarchy), fall back to **Option C**.
+3. **Option B** is preferred over A if a tight \`SubscriptionStore\`-style protocol already covers what \`EngineRunner\` needs.
+
+### Files changed
+
+- \`unit_tests/signal_service/test_runner.py\` — adjust \`runner\` and \`sink_runner\` fixtures, plus the inline runner construction in \`test_runner_start_subscribes_multiple_channels\` (lines 75-82). **No production code is touched.**
+
+### Out of scope
+
+- Suppressing \`filterwarnings("ignore::RuntimeWarning")\` in \`pytest.ini\` / \`pyproject.toml\` — explicitly forbidden by the ticket AC.`
+      },
+      {
+        id: "verification",
+        title: "Verification & Acceptance Criteria",
+        content: `Per-AC verification commands:
+
+\`\`\`bash
+# AC1 — no Pydantic serializer warnings in fill monitor tests
+uv run pytest unit_tests/accounts/test_fill_monitor.py -W error::UserWarning -v
+
+# AC2 — no unawaited-coroutine warnings in runner tests
+uv run pytest unit_tests/signal_service/test_runner.py -W error::RuntimeWarning -v
+
+# AC3 — full suite warnings summary is empty (or unrelated)
+uv run pytest 2>&1 | sed -n '/warnings summary/,/=====/p'
+
+# Quality gates
+uv run pyright
+uv run ruff check
+\`\`\`
+
+### Acceptance Criteria (from TT-137)
+
+- [ ] AC1 passes with zero Pydantic serializer warnings
+- [ ] AC2 passes with zero unawaited-coroutine warnings
+- [ ] AC3 — full \`uv run pytest\` shows an empty warnings summary (or only warnings unrelated to this ticket)
+- [ ] No \`filterwarnings\` suppressions added
+
+### Functional evidence captured for the PR
+
+Before / after side-by-side of the \`pytest\` warnings summary block, copied from \`git push\` output. The "after" should be the empty-or-unrelated state.`
+      },
+      {
+        id: "risk-and-scope",
+        title: "Risk, Scope, and Build Sequence",
+        content: `### Risk — Low
+
+Test-only changes:
+
+- Category 1 swaps strings for typed values that serialize to identical wire form.
+- Category 2 is a mock-fixture refinement; production code paths are not exercised differently.
+
+The only regression risk is in Category 2: if the new spec is too narrow, tests that incidentally relied on AsyncMock's permissive attribute access could fail. **Mitigation:** run the full \`unit_tests/signal_service/\` directory after the Category 2 fix, not just the one file.
+
+### Out of scope
+
+- The \`tracemalloc\` hint and the GitHub Dependabot vulnerability count printed by \`git push\` (these are not pytest warnings).
+- Any production-code change to \`OrderFill\`, \`PlacedOrder\`, \`EngineRunner\`, or \`RedisSubscription\`.
+- Suppressing warnings via \`filterwarnings\`.
+
+### Build sequence
+
+1. Diagnose Category 2 with the \`-W error::RuntimeWarning -X tracemalloc\` invocation. Confirm the coroutine-creation path; pick option A/B/C.
+2. Apply Category 1 fix (factory functions in \`test_fill_monitor.py\`).
+3. Apply Category 2 fix (fixtures in \`test_runner.py\`).
+4. Run AC1, AC2, AC3 verification commands above.
+5. \`uv run pyright\` and \`uv run ruff check\` clean.
+6. Open PR with the captured "warnings summary empty" output as functional evidence.`
+      }
+    ];
+
+    // ============================================================
+    // OPTIONAL: Pre-approved sections from prior review rounds.
+    // Map section id -> status ("approved", "revision", "question").
+    // ============================================================
+    const priorApprovals = {
+      // "example-context": "approved",
+    };
+
+    // ============================================================
+    // PLAN NAME: Update this string for the copy-to-prompt output.
+    // ============================================================
+    const PLAN_NAME = "TT-137: Clean up pytest warnings produced by pre-push hook";
+    // Populated by the plan-review skill at HTML-generation time with the
+    // authoring session's id. The terminal panel uses this to spawn
+    // `claude --resume <sid>` via the devserver's /api/claude?session= endpoint.
+    const CLAUDE_SESSION = "6225529a-8f3f-4e38-b83b-d0c715efb9d8";
+
+    // Persistence — save/restore review state across sessions
+    const STORAGE_KEY = 'review-state:' + PLAN_NAME;
+    const LAYOUT_KEY = 'review-layout:' + PLAN_NAME;
+
+    function saveToStorage() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+          sections: state.sections.map(s => ({ id: s.id, status: s.status, comment: s.comment })),
+          activeSection: state.activeSection,
+          activeFilter: state.activeFilter
+        }));
+      } catch (e) { }
+    }
+
+    function loadFromStorage() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        (data.sections || []).forEach(saved => {
+          const s = state.sections.find(s => s.id === saved.id);
+          if (s) { s.status = saved.status || 'pending'; s.comment = saved.comment || ''; }
+        });
+        if (data.activeSection) state.activeSection = data.activeSection;
+        if (data.activeFilter) state.activeFilter = data.activeFilter;
+      } catch (e) { }
+    }
+
+    // State
+    const state = {
+      sections: docSections.map(s => ({
+        ...s,
+        status: priorApprovals[s.id] || 'pending',
+        comment: ''
+      })),
+      activeSection: docSections[0]?.id || '',
+      activeFilter: 'all'
+    };
+
+    // Render markdown-like content to HTML
+    function renderMarkdown(text) {
+      let html = '';
+      const lines = text.split('\n');
+      let inCode = false;
+      let codeLang = '';
+      let codeLines = [];
+      let inList = false;
+      let listTag = 'ul';
+      let inTable = false;
+      let tableRows = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (line.trim().startsWith('```')) {
+          if (inCode) {
+            if (codeLang === 'mermaid') {
+              html += '<div class="mermaid-container"><pre class="mermaid">' + codeLines.join('\n') + '</pre></div>';
+            } else {
+              html += '<pre><code>' + codeLines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</code></pre>';
+            }
+            codeLines = [];
+            inCode = false;
+            codeLang = '';
+          } else {
+            if (inList) { html += '</' + listTag + '>'; inList = false; }
+            if (inTable) { html += renderTable(tableRows); inTable = false; tableRows = []; }
+            codeLang = line.trim().slice(3).trim().toLowerCase();
+            inCode = true;
+          }
+          continue;
+        }
+        if (inCode) { codeLines.push(line); continue; }
+
+        if (line.trim().startsWith('|')) {
+          if (inList) { html += '</' + listTag + '>'; inList = false; }
+          if (!inTable) inTable = true;
+          if (!line.trim().match(/^\|[\s-|]+\|$/)) {
+            tableRows.push(line);
+          }
+          continue;
+        } else if (inTable) {
+          html += renderTable(tableRows);
+          inTable = false;
+          tableRows = [];
+        }
+
+        if (line.trim() === '') {
+          if (inList) {
+            // Look ahead: if next non-blank line continues the list, keep it open
+            let keepList = false;
+            for (let j = i + 1; j < lines.length; j++) {
+              const next = lines[j].trim();
+              if (next === '') continue;
+              if (listTag === 'ol' && next.match(/^\d+\.\s/)) keepList = true;
+              if (listTag === 'ul' && (next.startsWith('- ') || next.startsWith('* '))) keepList = true;
+              break;
+            }
+            if (!keepList) { html += '</' + listTag + '>'; inList = false; }
+          }
+          continue;
+        }
+
+        if (line.startsWith('### ')) {
+          if (inList) { html += '</' + listTag + '>'; inList = false; }
+          html += '<h4 style="font-size:14px;font-weight:600;color:var(--text);margin:16px 0 8px">' + inlineFormat(line.slice(4)) + '</h4>';
+          continue;
+        }
+
+        if (line.trim().startsWith('- ') || line.trim().startsWith('* ')) {
+          if (inList && listTag !== 'ul') { html += '</' + listTag + '>'; inList = false; }
+          if (!inList) { listTag = 'ul'; html += '<ul>'; inList = true; }
+          html += '<li>' + inlineFormat(line.trim().slice(2)) + '</li>';
+          continue;
+        }
+        if (line.trim().match(/^\d+\.\s/)) {
+          if (inList && listTag !== 'ol') { html += '</' + listTag + '>'; inList = false; }
+          if (!inList) { listTag = 'ol'; html += '<ol>'; inList = true; }
+          html += '<li>' + inlineFormat(line.trim().replace(/^\d+\.\s/, '')) + '</li>';
+          continue;
+        }
+
+        if (inList) { html += '</' + listTag + '>'; inList = false; }
+        html += '<p>' + inlineFormat(line) + '</p>';
+      }
+
+      if (inCode) html += '<pre><code>' + codeLines.join('\n').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</code></pre>';
+      if (inList) html += '</' + listTag + '>';
+      if (inTable) html += renderTable(tableRows);
+
+      return html;
+    }
+
+    function renderTable(rows) {
+      if (rows.length === 0) return '';
+      let html = '<table>';
+      rows.forEach((row, idx) => {
+        const cells = row.split('|').filter(c => c.trim() !== '');
+        const tag = idx === 0 ? 'th' : 'td';
+        html += '<tr>' + cells.map(c => `<${tag}>${inlineFormat(c.trim())}</${tag}>`).join('') + '</tr>';
+      });
+      html += '</table>';
+      return html;
+    }
+
+    function inlineFormat(text) {
+      return text
+        .replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/`([^`]+)`/g, '<code>$1</code>')
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" style="color:var(--accent);text-decoration:none">$1</a>')
+        .replace(/\\`/g, '`');
+    }
+
+    // Render navigation
+    function renderNav() {
+      const nav = document.getElementById('nav');
+      nav.innerHTML = state.sections.map(s => {
+        const icon = s.status === 'approved' ? '<span style="color:var(--green)">&#10003;</span>'
+          : s.status === 'revision' ? '<span style="color:var(--red)">&#9998;</span>'
+            : s.status === 'question' ? '<span style="color:var(--purple)">?</span>'
+              : '<span style="color:var(--text-dim)">&bull;</span>';
+        return `<div class="nav-item ${s.id === state.activeSection ? 'active' : ''}"
+                 onclick="navigateTo('${s.id}')">
+      <span class="status-icon">${icon}</span>
+      <span class="label">${s.title}</span>
+      ${s.revised ? '<span style="font-size:9px;color:var(--accent);font-weight:700">REV</span>' : ''}
+    </div>`;
+      }).join('');
+    }
+
+    // Render document
+    function renderDoc() {
+      const panel = document.getElementById('docPanel');
+      panel.innerHTML = state.sections.map(s => {
+        const borderColor = s.status === 'approved' ? 'var(--green)'
+          : s.status === 'revision' ? 'var(--red)'
+            : s.status === 'question' ? 'var(--purple)' : 'transparent';
+        const bgColor = s.status === 'approved' ? 'var(--green-bg)'
+          : s.status === 'revision' ? 'var(--red-bg)'
+            : s.status === 'question' ? 'rgba(188,140,255,0.06)' : 'transparent';
+
+        const revisedAndPending = s.revised && s.status === 'pending';
+        const revisedClass = revisedAndPending ? ' revised' : '';
+        return `<div class="section${revisedClass}" id="section-${s.id}"
+                 style="border-left: 3px solid ${revisedAndPending ? 'var(--accent)' : borderColor}; background: ${revisedAndPending ? 'rgba(88,166,255,0.04)' : bgColor};">
+      <div class="section-header">
+        <h2>${s.title}</h2>
+        ${s.revised ? '<span class="revised-badge">Revised</span>' : ''}
+      </div>
+      <div class="section-content">${renderMarkdown(s.content)}</div>
+      <div class="review-bar">
+        <button class="review-btn ${s.status === 'approved' ? 'active-approved' : ''}"
+                onclick="setStatus('${s.id}','approved')">Approve</button>
+        <button class="review-btn ${s.status === 'revision' ? 'active-revision' : ''}"
+                onclick="setStatus('${s.id}','revision')">Needs Revision</button>
+        <button class="review-btn ${s.status === 'question' ? 'active-question' : ''}"
+                onclick="setStatus('${s.id}','question')">Question</button>
+        <button class="review-btn" onclick="toggleComment('${s.id}')"
+                style="margin-left:auto">Comment</button>
+      </div>
+      <div class="comment-area" id="comment-${s.id}">
+        ${s.comment
+            ? `<div class="existing-comment">${s.comment.replace(/</g, '&lt;').replace(/\n/g, '<br>')}
+               <button class="edit-btn" onclick="editComment('${s.id}')">edit</button></div>`
+            : `<textarea placeholder="Add your feedback for this section..."
+                      onblur="saveComment('${s.id}', this.value)"
+                      id="textarea-${s.id}"></textarea>`
+          }
+      </div>
+    </div>`;
+      }).join('');
+    }
+
+    // Render stats
+    function renderStats() {
+      const counts = { pending: 0, approved: 0, revision: 0, question: 0 };
+      state.sections.forEach(s => counts[s.status]++);
+      document.getElementById('stats').innerHTML = `
+    <div class="stat"><div class="dot dot-approved"></div>${counts.approved} Approved</div>
+    <div class="stat"><div class="dot dot-pending"></div>${counts.pending} Pending</div>
+    <div class="stat"><div class="dot dot-revision"></div>${counts.revision} Needs Revision</div>
+    <div class="stat"><div class="dot dot-question"></div>${counts.question} Questions</div>
+  `;
+    }
+
+    // Render feedback panel
+    function renderFeedback() {
+      const list = document.getElementById('feedbackList');
+      const filtered = state.sections.filter(s => {
+        if (state.activeFilter === 'all') return s.status !== 'pending';
+        return s.status === state.activeFilter;
+      });
+
+      const count = state.sections.filter(s => s.status !== 'pending').length;
+      document.getElementById('feedbackCount').textContent = count > 0 ? `${count} reviewed` : '';
+
+      if (filtered.length === 0) {
+        list.innerHTML = `<div class="prompt-placeholder">
+      ${state.activeFilter === 'all'
+            ? 'Review sections by clicking Approve, Needs Revision, or Question. Your feedback will appear here.'
+            : 'No sections with this status yet.'}
+    </div>`;
+        return;
+      }
+
+      list.innerHTML = filtered.map(s => `
+    <div class="feedback-item" onclick="navigateTo('${s.id}')" style="cursor:pointer">
+      <div class="fb-section">
+        <span class="fb-status ${s.status}">${s.status === 'approved' ? 'APPROVED' : s.status === 'revision' ? 'REVISION' : 'QUESTION'}</span>
+        ${s.title}
+      </div>
+      ${s.comment ? `<div class="fb-comment">"${s.comment}"</div>` : ''}
+    </div>
+  `).join('');
+    }
+
+    // Actions
+    function navigateTo(id) {
+      state.activeSection = id;
+      saveToStorage();
+      renderNav();
+      var el = document.getElementById('section-' + id);
+      var panel = document.getElementById('docPanel');
+      panel.scrollTo({ top: el.offsetTop - panel.offsetTop, behavior: 'smooth' });
+    }
+
+    function setStatus(id, status) {
+      const section = state.sections.find(s => s.id === id);
+      if (section.status === status) {
+        section.status = 'pending';
+      } else {
+        section.status = status;
+        if (status === 'revision' || status === 'question') {
+          setTimeout(() => {
+            const area = document.getElementById('comment-' + id);
+            if (area) area.classList.add('visible');
+          }, 50);
+        }
+      }
+      renderAll();
+      saveToStorage();
+    }
+
+    function toggleComment(id) {
+      const area = document.getElementById('comment-' + id);
+      area.classList.toggle('visible');
+      if (area.classList.contains('visible')) {
+        const ta = document.getElementById('textarea-' + id);
+        if (ta) ta.focus();
+      }
+    }
+
+    function saveComment(id, value) {
+      const section = state.sections.find(s => s.id === id);
+      section.comment = value.trim();
+      renderAll();
+      saveToStorage();
+    }
+
+    function editComment(id) {
+      const section = state.sections.find(s => s.id === id);
+      const area = document.getElementById('comment-' + id);
+      area.innerHTML = `<textarea placeholder="Edit your feedback..."
+    onblur="saveComment('${id}', this.value)"
+    id="textarea-${id}">${section.comment}</textarea>`;
+      area.classList.add('visible');
+      document.getElementById('textarea-' + id).focus();
+    }
+
+    function generatePrompt() {
+      const approved = state.sections.filter(s => s.status === 'approved');
+      const revision = state.sections.filter(s => s.status === 'revision');
+      const questions = state.sections.filter(s => s.status === 'question');
+
+      if (approved.length === 0 && revision.length === 0 && questions.length === 0) {
+        return '';
+      }
+
+      let prompt = `Here is my review of the ${PLAN_NAME} plan:\n\n`;
+
+      if (approved.length > 0) {
+        prompt += `## Approved Sections (${approved.length}/${state.sections.length})\n`;
+        approved.forEach(s => {
+          prompt += `- **${s.title}**: Approved`;
+          if (s.comment) prompt += ` — ${s.comment}`;
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      if (revision.length > 0) {
+        prompt += `## Needs Revision (${revision.length})\n`;
+        revision.forEach(s => {
+          prompt += `- **${s.title}**`;
+          if (s.comment) prompt += `: ${s.comment}`;
+          else prompt += ': (no specific feedback provided)';
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      if (questions.length > 0) {
+        prompt += `## Questions (${questions.length})\n`;
+        questions.forEach(s => {
+          prompt += `- **${s.title}**`;
+          if (s.comment) prompt += `: ${s.comment}`;
+          else prompt += ': (question not specified)';
+          prompt += '\n';
+        });
+        prompt += '\n';
+      }
+
+      const remaining = state.sections.filter(s => s.status === 'pending');
+      if (remaining.length > 0) {
+        prompt += `## Not Yet Reviewed (${remaining.length})\n`;
+        remaining.forEach(s => prompt += `- ${s.title}\n`);
+      }
+
+      return prompt;
+    }
+
+    function copyPrompt() {
+      const prompt = generatePrompt();
+      if (!prompt) return;
+      const btn = document.getElementById('copyBtn');
+      function onSuccess() {
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => { btn.textContent = 'Copy Feedback as Prompt'; btn.classList.remove('copied'); }, 2000);
+      }
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(prompt).then(onSuccess).catch(fallbackCopy);
+      } else {
+        fallbackCopy();
+      }
+      function fallbackCopy() {
+        const ta = document.createElement('textarea');
+        ta.value = prompt;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); onSuccess(); } catch (e) { btn.textContent = 'Copy failed'; }
+        document.body.removeChild(ta);
+      }
+    }
+
+    // Filter tabs
+    document.getElementById('filterTabs').addEventListener('click', e => {
+      const tab = e.target.closest('.filter-tab');
+      if (!tab) return;
+      state.activeFilter = tab.dataset.filter;
+      document.querySelectorAll('.filter-tab').forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      renderFeedback();
+      saveToStorage();
+    });
+
+    function renderAll() {
+      renderNav();
+      renderDoc();
+      renderStats();
+      renderFeedback();
+      document.querySelectorAll('.mermaid[data-processed]').forEach(el => el.removeAttribute('data-processed'));
+      if (typeof mermaid !== 'undefined') mermaid.run();
+    }
+
+    // Resizable & collapsible panels (mouse + touch)
+    let __fitTerminal = () => { };
+    (function () {
+      const nav = document.getElementById('nav');
+      const rightPanel = document.getElementById('rightPanel');
+      const termPanel = document.getElementById('termPanel');
+      const leftHandle = document.getElementById('leftHandle');
+      const rightHandle = document.getElementById('rightHandle');
+      const termHandle = document.getElementById('termHandle');
+      const leftToggle = document.getElementById('leftToggle');
+      const rightToggle = document.getElementById('rightToggle');
+      const termToggle = document.getElementById('termToggle');
+
+      let dragging = null;
+      let navWidth = 240;
+      let rightWidth = 360;
+      let termWidth = 460;
+
+      // Restore saved layout
+      const savedLayout = (() => { try { return JSON.parse(localStorage.getItem(LAYOUT_KEY) || '{}'); } catch (e) { return {}; } })();
+      if (savedLayout.navWidth) navWidth = savedLayout.navWidth;
+      if (savedLayout.rightWidth) rightWidth = savedLayout.rightWidth;
+      if (savedLayout.termWidth) termWidth = savedLayout.termWidth;
+      if (savedLayout.navCollapsed) nav.classList.add('collapsed');
+      else nav.style.width = navWidth + 'px';
+      if (savedLayout.rightCollapsed) rightPanel.classList.add('collapsed');
+      else rightPanel.style.width = rightWidth + 'px';
+      // Terminal defaults to closed; only expand if user previously opened it.
+      if (savedLayout.termCollapsed === false) termPanel.style.width = termWidth + 'px';
+      else termPanel.classList.add('collapsed');
+
+      function saveLayout() {
+        try {
+          localStorage.setItem(LAYOUT_KEY, JSON.stringify({
+            navWidth, rightWidth, termWidth,
+            navCollapsed: nav.classList.contains('collapsed'),
+            rightCollapsed: rightPanel.classList.contains('collapsed'),
+            termCollapsed: termPanel.classList.contains('collapsed')
+          }));
+        } catch (e) { }
+      }
+
+      function updateToggles() {
+        const navCollapsed = nav.classList.contains('collapsed');
+        const rightCollapsed = rightPanel.classList.contains('collapsed');
+        const termCollapsed = termPanel.classList.contains('collapsed');
+        leftToggle.title = navCollapsed ? 'Show sections' : 'Hide sections';
+        leftToggle.classList.toggle('panel-collapsed', navCollapsed);
+        rightToggle.title = rightCollapsed ? 'Show feedback' : 'Hide feedback';
+        rightToggle.classList.toggle('panel-collapsed', rightCollapsed);
+        termToggle.title = termCollapsed ? 'Show terminal' : 'Hide terminal';
+        termToggle.classList.toggle('panel-collapsed', termCollapsed);
+      }
+
+      function toggleNav(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (nav.classList.contains('collapsed')) {
+          nav.classList.remove('collapsed');
+          nav.style.width = navWidth + 'px';
+        } else {
+          navWidth = nav.offsetWidth;
+          nav.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      function toggleRight(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (rightPanel.classList.contains('collapsed')) {
+          // Opening feedback — close terminal first AND inherit its width.
+          if (!termPanel.classList.contains('collapsed')) {
+            termWidth = termPanel.offsetWidth;
+            rightWidth = termWidth;
+            termPanel.classList.add('collapsed');
+          }
+          rightPanel.classList.remove('collapsed');
+          rightPanel.style.width = rightWidth + 'px';
+        } else {
+          rightWidth = rightPanel.offsetWidth;
+          rightPanel.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      function toggleTerm(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (termPanel.classList.contains('collapsed')) {
+          // Opening terminal — close feedback first AND inherit its width.
+          if (!rightPanel.classList.contains('collapsed')) {
+            rightWidth = rightPanel.offsetWidth;
+            termWidth = rightWidth;
+            rightPanel.classList.add('collapsed');
+          }
+          termPanel.classList.remove('collapsed');
+          termPanel.style.width = termWidth + 'px';
+          setTimeout(__fitTerminal, 220);
+        } else {
+          termWidth = termPanel.offsetWidth;
+          termPanel.classList.add('collapsed');
+        }
+        updateToggles();
+        saveLayout();
+      }
+
+      let touchFiredLeft = false, touchFiredRight = false, touchFiredTerm = false;
+
+      leftToggle.addEventListener('touchend', e => { touchFiredLeft = true; toggleNav(e); }, { passive: false });
+      leftToggle.addEventListener('click', e => { if (touchFiredLeft) { touchFiredLeft = false; return; } toggleNav(e); });
+
+      rightToggle.addEventListener('touchend', e => { touchFiredRight = true; toggleRight(e); }, { passive: false });
+      rightToggle.addEventListener('click', e => { if (touchFiredRight) { touchFiredRight = false; return; } toggleRight(e); });
+
+      termToggle.addEventListener('touchend', e => { touchFiredTerm = true; toggleTerm(e); }, { passive: false });
+      termToggle.addEventListener('click', e => { if (touchFiredTerm) { touchFiredTerm = false; return; } toggleTerm(e); });
+
+      updateToggles();
+
+      // Drag resize (mouse)
+      function onDragStart(e, side) {
+        e.preventDefault();
+        dragging = side;
+        document.body.classList.add('resizing');
+        const handle = side === 'left' ? leftHandle : (side === 'term' ? termHandle : rightHandle);
+        handle.classList.add('dragging');
+      }
+
+      leftHandle.addEventListener('mousedown', e => onDragStart(e, 'left'));
+      termHandle.addEventListener('mousedown', e => onDragStart(e, 'term'));
+      rightHandle.addEventListener('mousedown', e => onDragStart(e, 'right'));
+
+      document.addEventListener('mousemove', e => {
+        if (!dragging) return;
+        applyDrag(e.clientX);
+      });
+
+      document.addEventListener('mouseup', endDrag);
+
+      // Drag resize (touch)
+      leftHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'left'); }, { passive: false });
+      termHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'term'); }, { passive: false });
+      rightHandle.addEventListener('touchstart', e => { e.preventDefault(); onDragStart(e, 'right'); }, { passive: false });
+
+      document.addEventListener('touchmove', e => {
+        if (!dragging) return;
+        e.preventDefault();
+        applyDrag(e.touches[0].clientX);
+      }, { passive: false });
+
+      document.addEventListener('touchend', endDrag);
+
+      function applyDrag(clientX) {
+        if (dragging === 'left') {
+          const w = Math.max(140, Math.min(400, clientX));
+          nav.classList.remove('collapsed');
+          nav.style.width = w + 'px';
+          navWidth = w;
+        } else if (dragging === 'right') {
+          const w = Math.max(200, Math.min(600, window.innerWidth - clientX));
+          rightPanel.classList.remove('collapsed');
+          rightPanel.style.width = w + 'px';
+          rightWidth = w;
+        } else if (dragging === 'term') {
+          // termHandle sits between doc and terminal; the terminal's width is
+          // (everything to the right of clientX) minus the right-panel width
+          // (when expanded) and the right resize handle (1px).
+          const rightTaken = rightPanel.classList.contains('collapsed') ? 0 : rightPanel.offsetWidth + 1;
+          const w = Math.max(240, Math.min(900, window.innerWidth - clientX - rightTaken));
+          termPanel.classList.remove('collapsed');
+          termPanel.style.width = w + 'px';
+          termWidth = w;
+          __fitTerminal();
+        }
+        updateToggles();
+      }
+
+      function endDrag() {
+        if (!dragging) return;
+        document.body.classList.remove('resizing');
+        leftHandle.classList.remove('dragging');
+        rightHandle.classList.remove('dragging');
+        termHandle.classList.remove('dragging');
+        dragging = null;
+        saveLayout();
+        __fitTerminal();
+      }
+
+      // Re-fit terminal on viewport changes
+      window.addEventListener('resize', () => __fitTerminal());
+    })();
+
+    // ============================================================
+    // TT-127: Terminal panel + Send to Claude
+    // Mounts xterm.js in #termHost, opens a websocket to the
+    // devserver's /api/claude endpoint (which spawns
+    // `claude --resume <sid>` in a PTY), and exposes sendToClaude()
+    // which writes the existing feedback bundle to that session.
+    // ============================================================
+    let __claudeWS = null;
+    let __claudeReady = false;
+    let __claudeTerm = null;
+    let __claudeFitAddon = null;
+
+    (function initClaudeTerminal() {
+      const host = document.getElementById('termHost');
+      const status = document.getElementById('termStatus');
+      const sendBtn = document.getElementById('sendClaudeBtn');
+      if (!host || typeof Terminal === 'undefined') return;
+
+      const term = new Terminal({
+        fontFamily: '"SF Mono", "Fira Code", "JetBrains Mono", monospace',
+        fontSize: 12,
+        lineHeight: 1.2,
+        theme: {
+          background: '#161b22',
+          foreground: '#e6edf3',
+          cursor: '#58a6ff',
+          selectionBackground: 'rgba(88, 166, 255, 0.35)',
+        },
+        cursorBlink: true,
+        scrollback: 5000,
+        convertEol: false,
+      });
+      const fitAddon = new FitAddon.FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(host);
+      try { fitAddon.fit(); } catch (e) { }
+
+      __claudeTerm = term;
+      __claudeFitAddon = fitAddon;
+      __fitTerminal = () => {
+        if (document.getElementById('termPanel').classList.contains('collapsed')) return;
+        try { fitAddon.fit(); } catch (e) { }
+        if (__claudeReady && __claudeWS && __claudeWS.readyState === WebSocket.OPEN) {
+          try {
+            __claudeWS.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+          } catch (e) { }
+        }
+      };
+
+      function setStatus(text, kind) {
+        status.textContent = text;
+        status.classList.remove('connected', 'error');
+        if (kind) status.classList.add(kind);
+      }
+
+      function connect() {
+        if (!CLAUDE_SESSION || CLAUDE_SESSION === "SESSION_ID_HERE") {
+          setStatus('error', 'error');
+          term.writeln('\r\n[devserver] Session ID not embedded in this review doc.');
+          term.writeln('[devserver] Regenerate with /plan-review so the current session id is captured.\r\n');
+          return;
+        }
+        const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const url = `${proto}//${location.host}/api/claude?session=${encodeURIComponent(CLAUDE_SESSION)}`;
+        setStatus('connecting…');
+        let ws;
+        try {
+          ws = new WebSocket(url);
+        } catch (e) {
+          setStatus('error', 'error');
+          term.writeln(`\r\n[devserver] failed to open ${url}: ${e}\r\n`);
+          return;
+        }
+        ws.binaryType = 'arraybuffer';
+        __claudeWS = ws;
+
+        ws.onopen = () => {
+          __claudeReady = true;
+          setStatus('connected', 'connected');
+          sendBtn.disabled = false;
+          // send initial size so PTY matches xterm
+          try {
+            ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+          } catch (e) { }
+        };
+
+        ws.onmessage = (ev) => {
+          if (typeof ev.data === 'string') {
+            // control message (e.g. error JSON); print to terminal for visibility
+            term.writeln('\r\n[devserver] ' + ev.data);
+            return;
+          }
+          term.write(new Uint8Array(ev.data));
+        };
+
+        ws.onerror = () => {
+          setStatus('error', 'error');
+        };
+
+        ws.onclose = () => {
+          __claudeReady = false;
+          sendBtn.disabled = true;
+          setStatus('disconnected');
+          term.writeln('\r\n[devserver] session closed. refresh page to reconnect.\r\n');
+        };
+
+        const encoder = new TextEncoder();
+        term.onData((data) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          try { ws.send(encoder.encode(data)); } catch (e) { }
+        });
+
+        term.onResize(({ cols, rows }) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
+          try { ws.send(JSON.stringify({ type: 'resize', cols, rows })); } catch (e) { }
+        });
+      }
+
+      // Handoff UI (TT-130): populate session id, wire up the "Hand off to terminal" button.
+      const handoffSid = document.getElementById('handoffSid');
+      const handoffBtn = document.getElementById('handoffBtn');
+      const handoffStatus = document.getElementById('handoffStatus');
+      if (handoffSid && CLAUDE_SESSION && CLAUDE_SESSION !== 'SESSION_ID_HERE') {
+        handoffSid.textContent = CLAUDE_SESSION;
+        handoffSid.title = CLAUDE_SESSION;
+      } else if (handoffSid) {
+        handoffSid.textContent = '(not embedded — regenerate with /plan-review)';
+      }
+      if (handoffBtn) {
+        handoffBtn.addEventListener('click', async () => {
+          if (!CLAUDE_SESSION || CLAUDE_SESSION === 'SESSION_ID_HERE') {
+            handoffStatus.textContent = 'No session id embedded in this review doc.';
+            return;
+          }
+          const cmd = `claude --resume ${CLAUDE_SESSION}`;
+          let copied = false;
+          try {
+            await navigator.clipboard.writeText(cmd);
+            copied = true;
+          } catch (e) { /* non-HTTPS or denied — fall through */ }
+          if (__claudeWS && __claudeWS.readyState === WebSocket.OPEN) {
+            try { __claudeWS.send(new Uint8Array([0x04])); } catch (e) { }
+          }
+          // Render the command on its own line so triple-click selects just the command.
+          handoffStatus.textContent = '';
+          const label = document.createElement('div');
+          label.textContent = copied
+            ? 'Copied to clipboard — paste this in your terminal:'
+            : 'Run this in your terminal:';
+          const cmdLine = document.createElement('code');
+          cmdLine.className = 'handoff-status-cmd';
+          cmdLine.textContent = cmd;
+          handoffStatus.appendChild(label);
+          handoffStatus.appendChild(cmdLine);
+          handoffStatus.classList.add('done');
+          handoffBtn.disabled = true;
+          handoffBtn.textContent = 'Session released';
+        });
+      }
+
+      connect();
+    })();
+
+    function sendToClaude() {
+      const btn = document.getElementById('sendClaudeBtn');
+      const prompt = generatePrompt();
+      if (!prompt) return;
+      if (!__claudeWS || __claudeWS.readyState !== WebSocket.OPEN) {
+        btn.textContent = 'Terminal disconnected';
+        setTimeout(() => { btn.textContent = 'Send to Claude'; }, 2000);
+        return;
+      }
+      // On send: open terminal panel, collapse feedback panel — single focused surface.
+      const termPanel = document.getElementById('termPanel');
+      const rightPanel = document.getElementById('rightPanel');
+      if (termPanel.classList.contains('collapsed')) {
+        document.getElementById('termToggle').click();
+      }
+      if (!rightPanel.classList.contains('collapsed')) {
+        document.getElementById('rightToggle').click();
+      }
+      const encoder = new TextEncoder();
+      // Newline at the end so Claude Code submits the bundle as one turn.
+      __claudeWS.send(encoder.encode(prompt + '\n'));
+      btn.textContent = 'Sent';
+      btn.classList.add('sent');
+      if (__claudeTerm) __claudeTerm.focus();
+      // Snap the terminal viewport to the bottom. The PTY echo arrives in
+      // chunks and the panel-open fit() runs at +220ms, so one scroll isn't
+      // enough — cover the animation frame, the post-fit reflow, and any
+      // trailing echo.
+      const snapToBottom = () => { if (__claudeTerm) __claudeTerm.scrollToBottom(); };
+      requestAnimationFrame(snapToBottom);
+      setTimeout(snapToBottom, 260);
+      setTimeout(snapToBottom, 600);
+      setTimeout(() => {
+        btn.textContent = 'Send to Claude';
+        btn.classList.remove('sent');
+      }, 2000);
+    }
+
+    mermaid.initialize({ startOnLoad: false, theme: 'dark', themeVariables: {
+      primaryColor: '#1c2128', primaryTextColor: '#e6edf3', primaryBorderColor: '#30363d',
+      lineColor: '#58a6ff', secondaryColor: '#161b22', tertiaryColor: '#21262d',
+      nodeTextColor: '#e6edf3', edgeLabelBackground: '#161b22'
+    }});
+
+    loadFromStorage();
+    document.querySelectorAll('.filter-tab').forEach(t => {
+      t.classList.toggle('active', t.dataset.filter === state.activeFilter);
+    });
+    renderAll();
+  </script>
+</body>
+
+</html>

--- a/docs/plans/TT-137-pytest-warnings-cleanup.md
+++ b/docs/plans/TT-137-pytest-warnings-cleanup.md
@@ -1,0 +1,134 @@
+# TT-137: Clean up pytest warnings produced by pre-push hook — Implementation Plan
+
+> **Jira:** [TT-137](https://mandeng.atlassian.net/browse/TT-137)
+> **Branch:** `feature/TT-137-pytest-warnings-cleanup`
+> **Status:** Draft 2026-05-09
+
+## Goal
+
+Make the pytest warnings summary empty (or contain only warnings unrelated to this ticket) when running the pre-push gate, so future warnings have signal. Fix root causes in test setup — do **not** suppress with `filterwarnings`.
+
+## Background
+
+`git push` triggers `.githooks/pre-push` → `pytest`. All 943 tests pass, but two distinct warning categories appear in the summary:
+
+1. **Pydantic serializer warnings** (`unit_tests/accounts/test_fill_monitor.py`) — 7 tests in `TestMonitorFillsForEntryCredits` warn about `order_type` / `time_in_force` / `filled_at` not matching their declared enum / datetime types.
+2. **Unawaited coroutine** (`unit_tests/signal_service/test_runner.py::test_runner_start_connects_and_subscribes`) — `RuntimeWarning: coroutine 'RedisSubscription.listener' was never awaited`.
+
+## Category 1 — Pydantic serializer warnings
+
+### Root cause
+
+The factory functions in `unit_tests/accounts/test_fill_monitor.py` use `model_construct()` (which bypasses validation) and pass raw strings for fields whose declared types are enums or `datetime`:
+
+```python
+# unit_tests/accounts/test_fill_monitor.py:37-45
+def make_order(...) -> PlacedOrder:
+    return PlacedOrder.model_construct(
+        ...
+        order_type="Limit",        # field type: OrderType enum
+        time_in_force="Day",       # field type: TimeInForce enum
+        ...
+    )
+
+# unit_tests/accounts/test_fill_monitor.py:48-58
+def make_fill(...) -> OrderFill:
+    return OrderFill.model_construct(
+        ...
+        filled_at="2026-03-16T20:00:00Z",  # field type: datetime
+    )
+```
+
+Source-of-truth declarations:
+- `src/tastytrade/accounts/models.py:797` — `class TimeInForce(str, Enum)` with `DAY = "Day"`
+- `src/tastytrade/accounts/models.py:805` — `class OrderType(str, Enum)` with `LIMIT = "Limit"`
+- `src/tastytrade/accounts/models.py:821` — `filled_at: datetime`
+
+`model_construct()` skips coercion, so the in-memory instance literally stores `str` where the schema expects enum / datetime. When `TestMonitorFillsForEntryCredits` later calls `order.model_dump_json(by_alias=True)` (at `unit_tests/accounts/test_fill_monitor.py:200`) Pydantic's serializer notices the type mismatch and emits `PydanticSerializationUnexpectedValue`.
+
+### Fix
+
+Replace the raw string arguments with the typed values the schema expects:
+
+| Argument | Current | Replace with |
+|---|---|---|
+| `order_type` | `"Limit"` | `OrderType.LIMIT` |
+| `time_in_force` | `"Day"` | `TimeInForce.DAY` |
+| `filled_at` | `"2026-03-16T20:00:00Z"` | `datetime(2026, 3, 16, 20, 0, 0, tzinfo=timezone.utc)` |
+
+Add the missing imports at the top of the test file:
+- `from datetime import datetime, timezone`
+- Extend the existing `from tastytrade.accounts.models import …` to include `OrderType` and `TimeInForce`
+
+Both `OrderType` and `TimeInForce` inherit from `str, Enum`, so the wire serialization (string `"Limit"`, `"Day"`) is unchanged. Existing assertions on field equality also remain valid because of `str` mixin equality.
+
+### Files changed
+
+- `unit_tests/accounts/test_fill_monitor.py` — update `make_order` and `make_fill` factory functions and imports. No production code is touched.
+
+## Category 2 — Unawaited coroutine in `test_runner.py`
+
+### Root cause (hypothesis)
+
+`unit_tests/signal_service/test_runner.py:13-22` builds the `runner` fixture with `subscription=AsyncMock()` (no `spec`). When `runner.start()` is called the test patches `asyncio.Event` to raise `CancelledError`, so the awaited bodies of `subscription.connect()` and `subscription.subscribe(...)` are AsyncMock awaitables — those should be fine on their own.
+
+The warning text is `coroutine 'RedisSubscription.listener' was never awaited` and the traceback points into `unittest/mock.py`. That tells us a real `RedisSubscription.listener` coroutine object is being instantiated inside `mock`'s spec / attribute introspection path — most likely because something accesses an attribute on the AsyncMock with the name `listener`, and `AsyncMock` falls back to `RedisSubscription.listener` (the unbound coroutine function on the class) when generating its async-child mock.
+
+The implementer should confirm exactly where the coroutine is being created. Two likely diagnostics:
+
+1. Run the single test with `python -W error::RuntimeWarning -X tracemalloc -m pytest unit_tests/signal_service/test_runner.py::test_runner_start_connects_and_subscribes -p no:cacheprovider` and inspect the traceback.
+2. Inspect whether AsyncMock's `_get_child_mock` / spec inference is creating the coroutine when `RedisSubscription` is implied as the spec via type annotation (it normally is *not* — but this is the most likely path worth verifying).
+
+### Fix (provisional, pending diagnostic confirmation)
+
+Most likely the cleanest fix is one of:
+
+- **Option A — explicit spec with safer member set.** Use `AsyncMock(spec=RedisSubscription)` *and* explicitly stub `connect`, `subscribe`, `close` with `AsyncMock()`. This pre-creates the methods the test actually calls and keeps mock from materializing `listener`.
+- **Option B — narrow spec to the protocol.** `connections/subscription.py:47` defines `RedisSubscriptionStore(SubscriptionStore)` — there's a Protocol in the codebase that does *not* include `listener`. If `EngineRunner` only needs the Protocol surface, `spec=SubscriptionStore` (or whatever the public protocol is) avoids exposing `listener` entirely.
+- **Option C — explicit per-method mocks.** Construct `subscription = MagicMock()` and set `subscription.connect = AsyncMock()`, `subscription.subscribe = AsyncMock()`, `subscription.close = AsyncMock()` directly.
+
+The implementer should pick the option that does not introduce a real `RedisSubscription` import side effect into the test (the test should remain fast and Redis-free). After the fix, `assert_awaited_once_with(...)` calls in the test must still work.
+
+**Out of scope:** Suppressing `filterwarnings("ignore::RuntimeWarning")` in `pytest.ini` / `pyproject.toml` — explicitly forbidden by the ticket AC.
+
+### Files changed
+
+- `unit_tests/signal_service/test_runner.py` — adjust `runner` and `sink_runner` fixtures (and the inline runner construction in `test_runner_start_subscribes_multiple_channels`) to whichever fix Option A/B/C the diagnostic confirms. No production code is touched.
+
+## Verification
+
+For each acceptance criterion:
+
+```bash
+# AC1 — no Pydantic serializer warnings in fill monitor tests
+uv run pytest unit_tests/accounts/test_fill_monitor.py -W error::UserWarning -v
+
+# AC2 — no unawaited-coroutine warnings in runner tests
+uv run pytest unit_tests/signal_service/test_runner.py -W error::RuntimeWarning -v
+
+# AC3 — full suite warnings summary is empty (or unrelated)
+uv run pytest 2>&1 | sed -n '/warnings summary/,/=====/p'
+```
+
+## Risk
+
+Low. Test-only changes:
+- Category 1 swaps strings for typed values that serialize to identical wire form.
+- Category 2 is a mock-fixture refinement; production code paths are not exercised differently.
+
+The only regression risk is in Category 2: if the new spec is too narrow, tests that incidentally relied on AsyncMock's permissive attribute access could fail. Run the full `unit_tests/signal_service/` directory, not just the one file, after the fix.
+
+## Out of Scope
+
+- The `tracemalloc` hint and the GitHub Dependabot vulnerability count printed by `git push` (these are not pytest warnings).
+- Any production-code change to `OrderFill`, `PlacedOrder`, `EngineRunner`, or `RedisSubscription`.
+- Suppressing warnings via `filterwarnings`.
+
+## Build Sequence
+
+1. Diagnose Category 2: run the failing test under `-W error::RuntimeWarning` with tracemalloc to confirm the coroutine-creation path. Pick fix option A/B/C.
+2. Apply Category 1 fix (factory functions in `test_fill_monitor.py`).
+3. Apply Category 2 fix (fixtures in `test_runner.py`).
+4. Run AC1, AC2, AC3 verification commands above.
+5. `uv run pyright` and `uv run ruff check` clean.
+6. Open PR with the captured "warnings summary empty" output as functional evidence.

--- a/unit_tests/accounts/test_fill_monitor.py
+++ b/unit_tests/accounts/test_fill_monitor.py
@@ -6,6 +6,7 @@ data — no position lookup or REST API dependency.
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,7 +18,9 @@ from tastytrade.accounts.models import (
     OrderFill,
     OrderLeg,
     OrderStatus,
+    OrderType,
     PlacedOrder,
+    TimeInForce,
 )
 from tastytrade.accounts.orchestrator import (
     compute_leg_entry_credit,
@@ -39,8 +42,8 @@ def make_order(
         account_number="TEST123",
         status=status,
         legs=legs,
-        order_type="Limit",
-        time_in_force="Day",
+        order_type=OrderType.LIMIT,
+        time_in_force=TimeInForce.DAY,
         underlying_symbol=underlying_symbol,
     )
 
@@ -54,7 +57,7 @@ def make_fill(
         fill_id="test-fill-1",
         quantity=quantity,
         fill_price=fill_price,
-        filled_at="2026-03-16T20:00:00Z",
+        filled_at=datetime(2026, 3, 16, 20, 0, 0, tzinfo=timezone.utc),
     )
 
 

--- a/unit_tests/providers/test_subscription_callback.py
+++ b/unit_tests/providers/test_subscription_callback.py
@@ -1,6 +1,7 @@
 """Tests for RedisSubscription on_update callback (event-driven mode)."""
 
 import asyncio
+from typing import Any, Coroutine
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,7 +30,15 @@ def test_callback_stored_on_subscribe(subscription: RedisSubscription) -> None:
     with patch.object(subscription, "pubsub", create=True, new=AsyncMock()):
         with patch.object(subscription, "listener_task", create=True, new=None):
             with patch("asyncio.create_task") as mock_task:
-                mock_task.return_value = MagicMock()
+                # Close the input coroutine to avoid an unawaited-coroutine
+                # warning — the real subscribe() evaluates self.listener()
+                # before create_task runs, so the coroutine exists even when
+                # create_task is patched out.
+                def fake_create_task(coro: Coroutine[Any, Any, Any]) -> MagicMock:
+                    coro.close()
+                    return MagicMock()
+
+                mock_task.side_effect = fake_create_task
                 asyncio.get_event_loop().run_until_complete(
                     subscription.subscribe(
                         "market:CandleEvent:SPX{=5m}",
@@ -46,7 +55,15 @@ def test_no_callback_means_empty_callbacks(subscription: RedisSubscription) -> N
     with patch.object(subscription, "pubsub", create=True, new=AsyncMock()):
         with patch.object(subscription, "listener_task", create=True, new=None):
             with patch("asyncio.create_task") as mock_task:
-                mock_task.return_value = MagicMock()
+                # Close the input coroutine to avoid an unawaited-coroutine
+                # warning — the real subscribe() evaluates self.listener()
+                # before create_task runs, so the coroutine exists even when
+                # create_task is patched out.
+                def fake_create_task(coro: Coroutine[Any, Any, Any]) -> MagicMock:
+                    coro.close()
+                    return MagicMock()
+
+                mock_task.side_effect = fake_create_task
                 asyncio.get_event_loop().run_until_complete(
                     subscription.subscribe(
                         "market:CandleEvent:SPX{=5m}",


### PR DESCRIPTION
## Summary

Eliminates the eight pytest warnings (`7 PydanticSerializationUnexpectedValue` + `1 RuntimeWarning: coroutine 'RedisSubscription.listener' was never awaited`) that previously appeared in the pre-push hook's warnings summary. **All fixes are in test code** — no production code is touched.

Closes [TT-137](https://mandeng.atlassian.net/browse/TT-137).

## Changes

### Category 1 — Pydantic serializer warnings (`unit_tests/accounts/test_fill_monitor.py`)

`make_order` / `make_fill` factory functions used `model_construct()` with raw strings for fields typed as enums and `datetime`. `model_construct` skips coercion, so `model_dump_json()` later complained about type mismatches.

| Field | Before | After |
|---|---|---|
| `order_type` | `"Limit"` (str) | `OrderType.LIMIT` |
| `time_in_force` | `"Day"` (str) | `TimeInForce.DAY` |
| `filled_at` | `"2026-03-16T20:00:00Z"` (str) | `datetime(2026, 3, 16, 20, 0, 0, tzinfo=timezone.utc)` |

Wire serialization is unchanged — both enums inherit from `(str, Enum)`.

### Category 2 — Unawaited coroutine (`unit_tests/providers/test_subscription_callback.py`)

The plan's hypothesis pointed at `test_runner.py`, but the diagnostic (`-X tracemalloc`) revealed the coroutine was actually being allocated at `src/tastytrade/providers/subscriptions.py:109` — the **real** `RedisSubscription.subscribe()`. The culprit is `test_subscription_callback.py`: it patches `asyncio.create_task` with a plain `MagicMock`, but the line is

```python
self.listener_task = asyncio.create_task(self.listener())
```

`self.listener()` is evaluated **before** `create_task` runs, so the coroutine is created even when `create_task` is mocked. The previous mock returned a `MagicMock` and left the coroutine orphaned. Garbage collection emitted the warning later, during `test_runner_start_connects_and_subscribes`, which is why pytest misattributed it to that test.

**Fix:** replace `mock_task.return_value = MagicMock()` with a `side_effect` that closes the input coroutine.

## Functional Evidence

### AC1 — Pydantic serializer warnings (UserWarning gate)

```
$ uv run pytest unit_tests/accounts/test_fill_monitor.py -W error::UserWarning -q
..................                                                       [100%]
18 passed in 3.21s
```

### AC2 — Unawaited coroutine (RuntimeWarning gate)

```
$ uv run pytest unit_tests/providers/test_subscription_callback.py unit_tests/signal_service/test_runner.py -W error::RuntimeWarning -q
........                                                                 [100%]
8 passed in 0.40s
```

### AC3 — Full suite warnings summary

Live pre-push hook transcript from `git push` of this branch:

```
pre-push: 2 new commit(s) — running pytest...
........................................................................ [  8%]
…
.............................................................            [100%]
```

**No `warnings summary` block emitted.** Compare against the pre-fix transcript from the same hook (saved in TT-137):

```
=========================== warnings summary ===========================
unit_tests/accounts/test_fill_monitor.py::TestMonitorFillsForEntryCredits::test_open_fill_computes_entry_credit
…
unit_tests/signal_service/test_runner.py::test_runner_start_connects_and_subscribes
  /home/mande/.local/share/uv/python/cpython-3.13.6-linux-x86_64-gnu/lib/python3.13/unittest/mock.py:2247: RuntimeWarning: coroutine 'RedisSubscription.listener' was never awaited
…
8 warnings emitted
```

### Quality gates on changed files

```
$ uv run ruff check unit_tests/accounts/test_fill_monitor.py unit_tests/providers/test_subscription_callback.py
All checks passed!

$ uv run pyright unit_tests/accounts/test_fill_monitor.py unit_tests/providers/test_subscription_callback.py
0 errors, 0 warnings, 0 informations
```

(There are 2 pre-existing ruff and 11 pre-existing pyright errors on `main` in unrelated files — `src/tastytrade/messaging/models/messages.py` and `src/tastytrade/utils/time_series.py`. Verified via `git stash && uv run ruff check . && uv run pyright`. Out of scope.)

### Test count

`853 passed in 11.95s` — same count as before, no test was disabled or skipped.

## Test Plan

- [x] AC1 strict-warning gate passes (UserWarning → error)
- [x] AC2 strict-warning gate passes (RuntimeWarning → error)
- [x] AC3 full suite warnings summary is empty (live pre-push transcript)
- [x] No `filterwarnings` suppression added (forbidden by AC)
- [x] Ruff and pyright clean on changed files
- [x] No production code touched

## Plan

[`docs/plans/TT-137-pytest-warnings-cleanup.md`](../blob/feature/TT-137-pytest-warnings-cleanup/docs/plans/TT-137-pytest-warnings-cleanup.md) — approved 7/7 sections via the review-suite plan-review playground on 2026-05-09. The Category 2 location differed from the plan's hypothesis; root cause documented above.

[TT-137]: https://mandeng.atlassian.net/browse/TT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ