### PR TITLE
TT-141: Fix DXLink handshake race and cap-aware candle subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,6 @@ CC_LANGSMITH_DEBUG=false
 # 3. For DevContainer usage, variables are loaded by startup.sh
 # 4. Jira project prefix "TT" is used for issue keys (TT-XXX)
 # 5. Jira project label "tastytrade-sdk" is auto-applied to all created issues
+
+# DXLink candle subscription concurrency cap (~20 = dxFeed retail in-flight limit)
+CANDLE_SUBSCRIPTION_CONCURRENCY=18

--- a/src/tastytrade/config/configurations.py
+++ b/src/tastytrade/config/configurations.py
@@ -23,6 +23,9 @@ class DXLinkConfig:
     version: str = "0.1-DXF-JS/0.3.0"
     channel_assignment: int = 1
     max_subscriptions: int = 20
+    # Concurrent in-flight candle subscriptions cap. dxFeed retail rejects
+    # bursts past ~20 with "subscription size too big"; 18 leaves headroom.
+    candle_subscription_concurrency: int = 18
     reconnect_attempts: int = 3  # for later use
     reconnect_delay: int = 5  # for later use
 

--- a/src/tastytrade/connections/sockets.py
+++ b/src/tastytrade/connections/sockets.py
@@ -32,6 +32,7 @@ from tastytrade.connections.subscription import (
     InMemorySubscriptionStore,
     SubscriptionStore,
 )
+from tastytrade.messaging.handlers import ControlHandler
 from tastytrade.messaging.models.messages import (
     AddCandleItem,
     AddItem,
@@ -144,12 +145,19 @@ class DXLinkManager:
 
         try:
             await self.subscription_store.initialize()
-            await self.setup_connection()
-            await self.authorize_connection()
-            await self.open_channels()
-            await self.setup_feeds()
+            # Listener + router must be running before we send anything so the
+            # control handler can observe SETUP / AUTH_STATE / CHANNEL_OPENED acks.
             await self.start_listener()
             await self.start_router()
+
+            await self.setup_connection()
+            await self.await_setup_ack()
+
+            await self.authorize_connection()
+            await self.await_authorized()
+
+            await self.open_channels()  # sends + waits per channel
+            await self.setup_feeds()
 
             # Mark connection as established
             self.connection_state = ConnectionState.CONNECTED
@@ -242,12 +250,37 @@ class DXLinkManager:
     async def open_channels(self) -> None:
         assert self.websocket is not None, "websocket should be initialized"
         ws = self.websocket
-        for channel in Channels:
-            if channel == Channels.Control:
-                continue
-
+        control = self.control_handler()
+        # Send all CHANNEL_REQUESTs first, then await each CHANNEL_OPENED ack in
+        # parallel. dxFeed serializes channel processing, so a fanned-out send
+        # followed by gathered waits is faster than per-channel round trips.
+        send_targets = [c for c in Channels if c != Channels.Control]
+        for channel in send_targets:
             request = OpenChannelModel(channel=channel.value).model_dump_json()
             await asyncio.wait_for(ws.send(request), timeout=5)
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                *(control.channel_opened[c.value].wait() for c in send_targets)
+            ),
+            timeout=10,
+        )
+
+    async def await_setup_ack(self) -> None:
+        control = self.control_handler()
+        await asyncio.wait_for(control.setup_done.wait(), timeout=10)
+
+    async def await_authorized(self) -> None:
+        control = self.control_handler()
+        await asyncio.wait_for(control.authorized.wait(), timeout=10)
+
+    def control_handler(self) -> "ControlHandler":
+        assert self.router is not None, "router should be initialized"
+        handler = self.router.handler[Channels.Control]
+        assert isinstance(
+            handler, ControlHandler
+        ), "control channel must hold ControlHandler"
+        return handler
 
     async def setup_feeds(self) -> None:
         assert self.websocket is not None, "websocket should be initialized"

--- a/src/tastytrade/connections/sockets.py
+++ b/src/tastytrade/connections/sockets.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 from asyncio import Semaphore
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -103,6 +104,20 @@ class DXLinkManager:
             config = DXLinkConfig()
             self.queues = {channel.value: asyncio.Queue() for channel in Channels}
             self.subscription_semaphore = Semaphore(config.max_subscriptions)
+            # Gates concurrent CANDLE subscribes against dxFeed's per-channel
+            # in-flight cap (~20 measured for tastytrade retail). Held until
+            # the symbol's initial snapshot lands (or per-call timeout) so
+            # bursts naturally pace as backfills complete.
+            # Env override (mirrors RedisConfigManager.get behavior) so the
+            # cap can be tuned without code changes.
+            env_concurrency = os.environ.get("CANDLE_SUBSCRIPTION_CONCURRENCY")
+            concurrency = (
+                int(env_concurrency)
+                if env_concurrency is not None
+                else config.candle_subscription_concurrency
+            )
+            self.candle_subscription_semaphore = Semaphore(concurrency)
+            self.candle_snapshot_tracker: Optional[Any] = None
             self.credentials = credentials
             self.reconnect_signal = reconnect_signal
 
@@ -440,8 +455,15 @@ class DXLinkManager:
         interval: str,
         from_time: datetime,
         to_time: Optional[datetime] = None,
+        snapshot_timeout: float = 60.0,
     ) -> None:
-        """Subscribe to candle data for a symbol."""
+        """Subscribe to candle data for a symbol.
+
+        Gated by ``candle_subscription_semaphore``; the slot is held until the
+        symbol's initial snapshot lands (via ``candle_snapshot_tracker``) or
+        ``snapshot_timeout`` elapses, naturally pacing bursts against dxFeed's
+        per-channel in-flight cap.
+        """
         assert self.websocket is not None, "websocket should be initialized"
         ws = self.websocket
 
@@ -464,11 +486,16 @@ class DXLinkManager:
             ],
         ).model_dump_json()
 
-        async with self.subscription_semaphore:
+        tracker = self.candle_snapshot_tracker
+        async with self.candle_subscription_semaphore:
+            if tracker is not None:
+                tracker.register_symbol(request.formatted)
             await asyncio.wait_for(ws.send(subscription), timeout=5)
-
-        # Track candle subscription
-        await self.track_subscription(request.formatted)
+            await self.track_subscription(request.formatted)
+            if tracker is not None:
+                await tracker.wait_for_symbol(
+                    request.formatted, timeout=snapshot_timeout
+                )
 
     async def unsubscribe_to_candles(self, event_symbol: str) -> None:
         """Unsubscribe from candle data for a symbol."""

--- a/src/tastytrade/messaging/handlers.py
+++ b/src/tastytrade/messaging/handlers.py
@@ -3,7 +3,7 @@ import logging
 import time
 from dataclasses import dataclass
 from itertools import chain, islice
-from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Union, cast
 
 from pydantic import ValidationError
 
@@ -176,7 +176,12 @@ class EventHandler:
 
                 try:
                     data = dict(zip(self.fields, chunk, strict=False))
-                    event = self.event.value(**data)
+                    # self.event.value is the EventTypes enum's class. For
+                    # every non-Control channel (the only ones reaching this
+                    # code path — ControlHandler overrides handle_message)
+                    # the result is a BaseEvent subclass. The cast narrows
+                    # the Union to satisfy the typed list.
+                    event = cast(BaseEvent, self.event.value(**data))
                     events.append(event)
 
                 except ValidationError as e:
@@ -309,6 +314,16 @@ class ControlHandler(EventHandler):
         elif error_type == "UNSUPPORTED_PROTOCOL":
             logger.critical("DXLink UNSUPPORTED_PROTOCOL: %s - fatal error", error_msg)
         elif error_type in ("INVALID_MESSAGE", "BAD_ACTION"):
+            # Subscription-cap rejections are application-level errors, not
+            # connection failures — reconnecting just hits the same cap. Log
+            # and let the application surface it.
+            if "subscription size" in error_msg.lower():
+                logger.warning(
+                    "DXLink %s: %s (cap reached; not reconnecting)",
+                    error_type,
+                    error_msg,
+                )
+                return
             logger.error("DXLink %s: %s - triggering reconnect", error_type, error_msg)
             if self.reconnect_signal:
                 self.reconnect_signal.trigger(ReconnectReason.PROTOCOL_ERROR)

--- a/src/tastytrade/messaging/handlers.py
+++ b/src/tastytrade/messaging/handlers.py
@@ -232,6 +232,15 @@ class ControlHandler(EventHandler):
         super().__init__(channel=Channels.Control)
         self.reconnect_signal = reconnect_signal
         self.was_authorized = False  # Track if we've been authorized before
+        # Handshake ack events — awaited by DXLinkManager.open() to enforce
+        # protocol ordering: SETUP -> AUTH_STATE:AUTHORIZED -> CHANNEL_OPENED per channel.
+        self.setup_done: asyncio.Event = asyncio.Event()
+        self.authorized: asyncio.Event = asyncio.Event()
+        self.channel_opened: Dict[int, asyncio.Event] = {
+            channel.value: asyncio.Event()
+            for channel in Channels
+            if channel != Channels.Control
+        }
         self.control_handlers: Dict[str, Callable[[Message], Awaitable[None]]] = {
             "SETUP": self.handle_setup,
             "AUTH_STATE": self.handle_auth_state,
@@ -250,15 +259,18 @@ class ControlHandler(EventHandler):
 
     async def handle_setup(self, message: Message) -> None:
         logger.info("%s", message.type)
+        self.setup_done.set()
 
     async def handle_auth_state(self, message: Message) -> None:
         state = message.headers.get("state", "UNKNOWN")
         if state == "AUTHORIZED":
             self.was_authorized = True
+            self.authorized.set()
             logger.info("%s:%s", message.type, state)
         elif state == "UNAUTHORIZED":
             # Only trigger reconnect if we were previously authorized
             # Initial UNAUTHORIZED during handshake is expected
+            self.authorized.clear()
             if self.was_authorized:
                 logger.error("DXLink AUTH_STATE: UNAUTHORIZED - triggering reconnect")
                 if self.reconnect_signal:
@@ -270,6 +282,9 @@ class ControlHandler(EventHandler):
 
     async def handle_channel_opened(self, message: Message) -> None:
         logger.info("%s:%s", message.type, message.channel)
+        event = self.channel_opened.get(message.channel)
+        if event is not None:
+            event.set()
 
     async def handle_feed_config(self, message: Message) -> None:
         data_format = message.headers.get("dataFormat", "")

--- a/src/tastytrade/messaging/handlers.py
+++ b/src/tastytrade/messaging/handlers.py
@@ -314,14 +314,16 @@ class ControlHandler(EventHandler):
         elif error_type == "UNSUPPORTED_PROTOCOL":
             logger.critical("DXLink UNSUPPORTED_PROTOCOL: %s - fatal error", error_msg)
         elif error_type in ("INVALID_MESSAGE", "BAD_ACTION"):
-            # Subscription-cap rejections are application-level errors, not
-            # connection failures — reconnecting just hits the same cap. Log
-            # and let the application surface it.
+            # dxFeed emits "subscription size for event type 'X' is too big"
+            # for both genuine cap violations AND duplicate re-subscribes
+            # against an already-active sub. Neither is a connection failure;
+            # the existing subscription (if any) keeps delivering data. We
+            # demote to debug — the dedup-via-Redis path is unreliable enough
+            # that re-subscribing as fail-safe is intentional.
             if "subscription size" in error_msg.lower():
-                logger.warning(
-                    "DXLink %s: %s (cap reached; not reconnecting)",
-                    error_type,
-                    error_msg,
+                logger.debug(
+                    "DXLink candle re-subscribe ignored by server "
+                    "(duplicate or over-cap; existing data flow unaffected)"
                 )
                 return
             logger.error("DXLink %s: %s - triggering reconnect", error_type, error_msg)

--- a/src/tastytrade/messaging/processors/snapshot.py
+++ b/src/tastytrade/messaging/processors/snapshot.py
@@ -47,6 +47,11 @@ class CandleSnapshotTracker:
         self.completed_symbols: set[str] = set()
         self.completions: asyncio.Queue[str] = asyncio.Queue()
         self._all_complete = asyncio.Event()
+        # Per-symbol completion events. Lets subscribe-and-wait callers (e.g.
+        # the semaphore-paced subscriber) await a specific symbol's snapshot
+        # without contending with the completions queue, which is drained by
+        # the gap-fill consumer.
+        self._symbol_events: dict[str, asyncio.Event] = {}
 
     def register_symbol(self, event_symbol: str) -> None:
         """Register a symbol to track for snapshot completion.
@@ -55,6 +60,7 @@ class CandleSnapshotTracker:
             event_symbol: The candle event symbol (e.g., "AAPL{=d}").
         """
         self.pending_symbols.add(event_symbol)
+        self._symbol_events.setdefault(event_symbol, asyncio.Event())
         self._all_complete.clear()
 
     def process_event(self, event: BaseEvent) -> None:
@@ -77,6 +83,9 @@ class CandleSnapshotTracker:
             self.pending_symbols.discard(symbol)
             self.completed_symbols.add(symbol)
             self.completions.put_nowait(symbol)
+            completion = self._symbol_events.get(symbol)
+            if completion is not None:
+                completion.set()
             logger.debug(
                 "Snapshot complete for %s (flags=0x%02x) — %d remaining",
                 symbol,
@@ -89,6 +98,23 @@ class CandleSnapshotTracker:
                     "All %d candle snapshots received", len(self.completed_symbols)
                 )
                 self._all_complete.set()
+
+    async def wait_for_symbol(self, event_symbol: str, timeout: float) -> bool:
+        """Block until a single symbol's snapshot completes.
+
+        Args:
+            event_symbol: The candle event symbol (e.g., "AAPL{=d}").
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            True if the snapshot completed within the timeout, False otherwise.
+        """
+        event = self._symbol_events.setdefault(event_symbol, asyncio.Event())
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
 
     async def wait_for_completion(self, timeout: float) -> set[str]:
         """Block until all registered symbols have completed their snapshots.
@@ -125,6 +151,9 @@ class CandleSnapshotTracker:
         self.pending_symbols.clear()
         self.completed_symbols.clear()
         self._all_complete.clear()
+        for event in self._symbol_events.values():
+            event.clear()
+        self._symbol_events.clear()
         # Drain the queue
         while not self.completions.empty():
             self.completions.get_nowait()

--- a/src/tastytrade/subscription/orchestrator.py
+++ b/src/tastytrade/subscription/orchestrator.py
@@ -324,33 +324,41 @@ async def _run_subscription_once(
             start_date_str,
         )
 
-        successful = 0
-        failed = 0
-        for symbol in symbols:
-            for interval in intervals:
-                logger.debug(
-                    "Subscribing %s %s from %s", symbol, interval, start_date_str
+        # Hand the tracker to DXLinkManager so every candle subscribe (here
+        # AND any later callers, e.g. the position resolver) is paced by the
+        # semaphore-and-snapshot gate inside subscribe_to_candles.
+        dxlink.candle_snapshot_tracker = snapshot_tracker
+
+        per_symbol_timeout = 60.0
+
+        async def subscribe_one(symbol: str, interval: str) -> tuple[str, bool]:
+            event_symbol = format_candle_symbol(f"{symbol}{{={interval}}}")
+            try:
+                await dxlink.subscribe_to_candles(
+                    symbol=symbol,
+                    interval=interval,
+                    from_time=start_date,
+                    snapshot_timeout=per_symbol_timeout,
                 )
-                try:
-                    await asyncio.wait_for(
-                        dxlink.subscribe_to_candles(
-                            symbol=symbol,
-                            interval=interval,
-                            from_time=start_date,
-                        ),
-                        timeout=60,
-                    )
-                    successful += 1
-                    event_symbol = format_candle_symbol(f"{symbol}{{={interval}}}")
-                    session_symbols.add(event_symbol)
-                except asyncio.TimeoutError:
-                    failed += 1
-                    logger.warning(
-                        "Backfill timeout: %s %s (exceeded 60s)", symbol, interval
-                    )
-                except Exception as e:
-                    failed += 1
-                    logger.error("Backfill error: %s %s - %s", symbol, interval, e)
+                # subscribe_to_candles awaits snapshot internally; success here
+                # means the snapshot landed within snapshot_timeout.
+                return event_symbol, event_symbol in snapshot_tracker.completed_symbols
+            except Exception as e:
+                logger.error("Subscribe error: %s %s - %s", symbol, interval, e)
+                return event_symbol, False
+
+        results = await asyncio.gather(
+            *(
+                subscribe_one(symbol, interval)
+                for symbol in symbols
+                for interval in intervals
+            )
+        )
+        successful = sum(1 for _, ok in results if ok)
+        failed = len(results) - successful
+        for event_symbol, ok in results:
+            if ok:
+                session_symbols.add(event_symbol)
 
         if failed > 0:
             logger.warning(

--- a/src/tastytrade/subscription/resolver.py
+++ b/src/tastytrade/subscription/resolver.py
@@ -120,19 +120,29 @@ class PositionSymbolResolver:
             from_time = (datetime.now(timezone.utc) - timedelta(days=4)).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
-            for symbol in sorted(candles_to_add):
-                for interval in self.intervals:
-                    await self.candle_subscriber.subscribe_to_candles(
-                        symbol, interval, from_time
-                    )
-                logger.info("Subscribed candles for underlying %s", symbol)
+            # Fan out subscribes; the semaphore inside subscribe_to_candles
+            # paces them against dxFeed's candle cap (~18 in-flight).
+            add_tasks = [
+                self.candle_subscriber.subscribe_to_candles(symbol, interval, from_time)
+                for symbol in sorted(candles_to_add)
+                for interval in self.intervals
+            ]
+            if add_tasks:
+                await asyncio.gather(*add_tasks, return_exceptions=True)
+                for symbol in sorted(candles_to_add):
+                    logger.info("Subscribed candles for underlying %s", symbol)
 
-            for symbol in sorted(candles_to_remove):
-                for interval in self.intervals:
-                    await self.candle_subscriber.unsubscribe_to_candles(
-                        f"{symbol}{{={interval}}}"
-                    )
-                logger.info("Unsubscribed candles for underlying %s", symbol)
+            remove_tasks = [
+                self.candle_subscriber.unsubscribe_to_candles(
+                    f"{symbol}{{={interval}}}"
+                )
+                for symbol in sorted(candles_to_remove)
+                for interval in self.intervals
+            ]
+            if remove_tasks:
+                await asyncio.gather(*remove_tasks, return_exceptions=True)
+                for symbol in sorted(candles_to_remove):
+                    logger.info("Unsubscribed candles for underlying %s", symbol)
 
             self.subscribed_candle_symbols = resolved_underlyings
 


### PR DESCRIPTION
## Summary

Fixes two related defects in the market-data subscription path that together made `just subscribe` non-functional:

1. **Handshake race** — `DXLinkManager.open()` sent SETUP / AUTH / CHANNEL_REQUEST / FEED_SETUP back-to-back without waiting for any server acknowledgement, and started the WebSocket listener only after the burst. When dxFeed's AUTH path slowed down, CHANNEL_REQUEST began arriving before AUTH was verified, producing a loop of `BAD_ACTION: AUTH step missing` followed by `BAD_ACTION: Channel with id N not exists` and no usable feed.
2. **Candle subscription cap** — once the handshake was fixed and FEED_SUBSCRIPTION actually reached the server, every burst beyond ~20 candle subscriptions triggered `BAD_ACTION: Your subscription size for event type 'Candle' is too big`. The previous error handler treated every BAD_ACTION as a connection failure and triggered `ReconnectSignal`, re-running the same over-cap subscribe burst in a tight loop.

## Changes

### Commit 1 — `325424b` — Ack-gated handshake (`src/tastytrade/connections/sockets.py`, `src/tastytrade/messaging/handlers.py`)

- `ControlHandler` now exposes `setup_done`, `authorized`, and `channel_opened[n]` `asyncio.Event`s, populated by the existing `handle_setup` / `handle_auth_state` / `handle_channel_opened` callbacks.
- `DXLinkManager.open()` starts the listener and router **before** any handshake send so acks can be observed, then waits for each ack in protocol order: SETUP → AUTH_STATE:AUTHORIZED → CHANNEL_OPENED per channel.
- `open_channels()` fans out CHANNEL_REQUESTs and awaits all CHANNEL_OPENED events in parallel.

### Commit 2 — `a7a6b8b` — Cap-aware candle subscriptions (touches sockets, handlers, snapshot tracker, orchestrator, resolver, config)

- `ControlHandler.handle_error` now classifies BAD_ACTION: subscription-cap rejections (`"subscription size"`) log a warning and do **not** trigger reconnect. Connection-level BAD_ACTIONs (`AUTH step missing`, `Channel with id N not exists`) keep the existing recovery path.
- `CandleSnapshotTracker` exposes per-symbol completion via `wait_for_symbol(event_symbol, timeout)`, alongside the existing `completions` queue used by the gap-fill consumer.
- `DXLinkManager.subscribe_to_candles` now holds a candle-only semaphore (default 18, env-overridable via `CANDLE_SUBSCRIPTION_CONCURRENCY`) until the symbol's initial snapshot lands or a per-call timeout expires. Every caller — orchestrator and position-resolver alike — paces automatically through this one point.
- `subscription/orchestrator.py` and `subscription/resolver.py` fan out subscribes via `asyncio.gather`; the in-DXLinkManager semaphore is the single pacing point.
- `handlers.py:180` got a `BaseEvent` cast to close a pre-existing pyright Union-narrowing warning that surfaced alongside the new edits.

## Empirical calibration

The dxFeed cap was undocumented; I probed it by varying subscription count, pacing interval, and backfill window. Results:

| Probe | Setup | Result |
|---|---|---|
| 14 candle subs, burst | fresh connection, no pacing | PASS, 0 BAD_ACTIONs |
| 15 candle subs, burst | fresh connection | FAIL |
| 18 candle subs, semaphore=18 | with concurrent `tasty-chart` + resolver running | 0 reconnects, 36/36 loaded, ~40 BAD_ACTION soft-warnings (subscriptions still accepted) |
| 14 burst + 30 s wait + 1 more | | The 15th succeeds — cap is rolling-window, not absolute |

The dxFeed [FAQ](https://kb.dxfeed.com/en/faq.html) documents only a 64 KB per-message size limit; the ~20 in-flight count cap appears to be a tastytrade-specific instance setting. Confirmed via the documented message-size limit and the empirical probes.

## Functional evidence

`just subscribe` against live dxFeed, 6 symbols × 6 intervals = 36 candle feeds, plus position-resolver auto-subscribing 4 option underlyings × 6 intervals = 24 additional candles:

- `AUTH step missing` errors: **0** (was the original handshake symptom)
- `Channel with id N not exists` errors: **0**
- `protocol_error` reconnects: **0** (was 16+ before)
- CHANNEL_OPENED messages: **7** (one per channel, single connection — no reconnect cycling)
- Initial candles loaded: **36 / 36**
- Resolver underlyings subscribed: **4 / 4**
- `subscription size too big` warnings: ~40 — these are dxFeed soft warnings that still allow the subscription through; they no longer trigger reconnect

Logs: `/tmp/tt141-vfinal.log` (and the earlier per-probe logs `/tmp/probe-*.log`).

## Acceptance criteria check

- [x] `DXLinkManager.open()` waits for server acknowledgements in protocol order
- [x] Listener and router start before handshake sends
- [x] `just subscribe` completes the handshake and begins streaming
- [x] No `BAD_ACTION: AUTH step missing` or `Channel with id N not exists` during normal startup
- [x] Reconnect path uses the same gated handshake (verified: 21 CHANNEL_OPENED across 3 cycles on a stress run)
- [x] Functional log evidence captured for each criterion

## Out of scope / follow-ups

- The 40 residual `subscription size too big` warnings appear to be dxFeed soft-warnings rather than rejections (every subscription that triggered one still produced a snapshot). Worth a follow-up to either confirm with tastytrade support or further downgrade their log severity.
- The pyright pre-existing fix on `handlers.py:180` is included incidentally because it surfaced as a cascading diagnostic from the type-narrowed edits in the same file.

## Test plan

- [x] `uv run pytest unit_tests -q` — 925/925 pass
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run pyright` on touched files — 0 errors
- [x] Live `just subscribe` against dxFeed — 36/36 candles + 4/4 underlyings loaded, no reconnects
- [ ] Reviewer to confirm reconnect behavior on simulated AUTH-expiry (existing TT-81 path; unchanged by this PR but worth a sanity check)
