### PR TITLE
TT-154: Filter stale subscriptions from chart symbol dropdown

### DIFF
--- a/.plan-review/TT-154/TT-154-chart-stale-symbol-filter.md
+++ b/.plan-review/TT-154/TT-154-chart-stale-symbol-filter.md
@@ -1,0 +1,69 @@
+# TT-154: Chart Symbol Dropdown Freshness Filter — Implementation Plan
+
+> **Jira:** [TT-154](https://mandeng.atlassian.net/browse/TT-154)
+> **Branch:** `feature/TT-154-chart-stale-symbol-filter`
+> **Epic:** [TT-96](https://mandeng.atlassian.net/browse/TT-96) Market Data Visualization
+
+## Problem
+
+The chart UI symbol dropdown is populated by `/api/symbols`
+(`src/tastytrade/charting/server.py`), which returns base symbols from
+`RedisSubscriptionStore.get_active_subscriptions()`. Entries in the Redis
+`subscriptions` hash are written `active: True` and only flipped to
+`active: False` by an explicit unsubscribe or the orchestrator's clean-shutdown
+finally-block. They are never aged out, so orphaned entries accumulate and show
+up as stale symbols in the dropdown.
+
+Orphans arise when a subscription process crashes before its cleanup runs, or
+when a dead process's position symbols (added by the in-memory, per-process
+`PositionSymbolResolver`) are never un-marked by a fresh process.
+
+## Scope — chart only
+
+Only the dropdown is affected. The running subscription service does **not**
+rely on the Redis `active` set to decide what to subscribe on reconnect — it
+re-derives the set from the launch `--symbols` list plus a live
+`PositionSymbolResolver` pass (`subscription/orchestrator.py`). The
+`subscriptions` hash is effectively a display/diagnostic projection, so
+filtering the chart's *view* of it carries no recovery or durability risk.
+
+## Approach — read-time freshness filter
+
+Filter inside the `/api/symbols` endpoint **only**. Exclude candle
+subscriptions whose `last_update` is older than a threshold. `last_update` is
+bumped on every incoming event (`messaging/handlers.py`), so live symbols stay
+fresh while orphans (frozen `last_update`) age out of the view. No writes, no
+TTL, no schema change, no change to `get_active_subscriptions()` or any
+recovery path. Fully reversible.
+
+### Threshold
+
+`CHART_SYMBOL_STALE_DAYS`, default **4 days**, env-overridable. Matches the
+resolver's documented "backfill 4 days to cover weekends + holidays" window and
+clears the worst realistic market gap (~3.7-day holiday weekend) with margin
+while still hiding ghosts from older dead processes.
+
+## Changes
+
+`src/tastytrade/charting/server.py`:
+1. `import os`.
+2. Add module constant `CHART_SYMBOL_STALE_DAYS` read from env (default 4).
+3. Add pure helper `fresh_base_symbols(subscriptions, now, max_age) -> set[str]`
+   — candle-feed filter + freshness check + suffix strip. Entries with a
+   missing/unparseable `last_update` are excluded (no silent "assume fresh"
+   fallback).
+4. `/api/symbols` calls the helper instead of the inline set comprehension.
+
+## Non-goals
+
+- No per-key TTL or Redis schema change.
+- No producer-side cleanup changes.
+- No changes to `status.py`, `restore_subscriptions`, or `get_reconnect_start`.
+
+## Testing
+
+- Unit-test `fresh_base_symbols` (pure, no Redis): fresh kept, stale dropped,
+  missing/unparseable `last_update` dropped, ticker (non-`{=`) entries ignored,
+  base-symbol dedup across intervals.
+- Functional: against real Redis subscription data, show a stale entry absent
+  from `/api/symbols` while fresh entries remain (per AC6).

--- a/src/tastytrade/charting/server.py
+++ b/src/tastytrade/charting/server.py
@@ -8,6 +8,7 @@ or write back to any data store.
 import asyncio
 import json
 import logging
+import os
 from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -31,6 +32,42 @@ logger = logging.getLogger(__name__)
 
 STATIC_DIR = Path(__file__).parent / "static"
 ET = ZoneInfo("America/New_York")
+
+# Candle subscriptions whose most recent event (`last_update`) is older than
+# this are treated as orphaned and excluded from the chart dropdown. Default
+# matches the resolver's weekend+holiday backfill window; override via env if a
+# legitimately quiet symbol ever gets hidden.
+CHART_SYMBOL_STALE_DAYS = float(os.environ.get("CHART_SYMBOL_STALE_DAYS", "4"))
+
+
+def fresh_base_symbols(
+    subscriptions: dict[str, Any],
+    now: datetime,
+    max_age: timedelta,
+) -> set[str]:
+    """Base symbols of candle subscriptions seen within ``max_age``.
+
+    Keeps only candle feeds (those carrying a ``{=interval}`` suffix) whose
+    ``last_update`` is recent, then strips the suffix. Entries with a missing or
+    unparseable ``last_update`` are excluded — we never assume an entry is fresh
+    without an authoritative timestamp.
+    """
+    base: set[str] = set()
+    for symbol, data in subscriptions.items():
+        if "{=" not in symbol:
+            continue
+        last_update_str = data.get("last_update") if isinstance(data, dict) else None
+        if not last_update_str:
+            continue
+        try:
+            last_update = datetime.fromisoformat(last_update_str)
+            stale = now - last_update > max_age
+        except (ValueError, TypeError):
+            continue
+        if stale:
+            continue
+        base.add(symbol.split("{=")[0])
+    return base
 
 
 def utc_epoch_to_et_epoch(utc_epoch: int) -> int:
@@ -126,7 +163,13 @@ class ChartServer:
 
         @app.get("/api/symbols")
         async def symbols() -> dict:
-            """Return deduplicated base symbols from active subscriptions."""
+            """Return deduplicated base symbols from recent candle subscriptions.
+
+            Orphaned subscriptions (a producer died without cleanup) keep an
+            ``active`` flag in Redis but stop receiving events, so their
+            ``last_update`` goes stale. Filtering by freshness keeps those out of
+            the dropdown without touching the store or any recovery path.
+            """
             from tastytrade.connections.subscription import (
                 RedisSubscriptionStore,
             )
@@ -135,7 +178,11 @@ class ChartServer:
             try:
                 await store.initialize()
                 subs = await store.get_active_subscriptions()
-                base = {sym.split("{=")[0] for sym in subs if "{=" in sym}
+                base = fresh_base_symbols(
+                    subs,
+                    now=datetime.now(timezone.utc),
+                    max_age=timedelta(days=CHART_SYMBOL_STALE_DAYS),
+                )
                 return {"symbols": sorted(base)}
             except Exception:
                 logger.exception("Failed to fetch symbols")

--- a/unit_tests/charting/test_server.py
+++ b/unit_tests/charting/test_server.py
@@ -1,0 +1,79 @@
+"""Tests for the chart symbol dropdown freshness filter (TT-154).
+
+`/api/symbols` populates the chart's symbol dropdown from the Redis
+`subscriptions` hash. Orphaned entries (a producer that died without cleanup)
+stay `active: True` but stop receiving events, so their `last_update` freezes.
+`fresh_base_symbols` keeps the dropdown to candle feeds seen recently, without
+touching the store or any recovery path.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from tastytrade.charting.server import fresh_base_symbols
+
+NOW = datetime(2026, 5, 26, 15, 0, 0, tzinfo=timezone.utc)
+MAX_AGE = timedelta(days=4)
+
+
+def sub(last_update: datetime | str | None) -> dict:
+    """Build a subscription entry like RedisSubscriptionStore stores."""
+    value = (
+        last_update.isoformat() if isinstance(last_update, datetime) else last_update
+    )
+    return {"active": True, "last_update": value, "metadata": {}}
+
+
+def test_fresh_candle_subscription_is_kept() -> None:
+    subs = {"SPX{=5m}": sub(NOW - timedelta(hours=1))}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == {"SPX"}
+
+
+def test_stale_candle_subscription_is_dropped() -> None:
+    # Orphan: last event was 5 days ago, beyond the 4-day window.
+    subs = {"SPX{=5m}": sub(NOW - timedelta(days=5))}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == set()
+
+
+def test_boundary_just_inside_window_is_kept() -> None:
+    subs = {"SPX{=5m}": sub(NOW - timedelta(days=4) + timedelta(minutes=1))}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == {"SPX"}
+
+
+def test_ticker_subscriptions_without_interval_are_ignored() -> None:
+    # No `{=` suffix → not a candle feed → never in the dropdown (matches
+    # the original endpoint behavior).
+    subs = {"SPY": sub(NOW), "AAPL": sub(NOW)}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == set()
+
+
+def test_base_symbol_deduped_across_intervals() -> None:
+    subs = {
+        "SPX{=5m}": sub(NOW),
+        "SPX{=1h}": sub(NOW - timedelta(hours=2)),
+        "/ES{=5m}": sub(NOW),
+    }
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == {"SPX", "/ES"}
+
+
+def test_mixed_fresh_and_stale_keeps_only_fresh() -> None:
+    subs = {
+        "SPX{=5m}": sub(NOW - timedelta(hours=1)),  # fresh
+        "QQQ{=5m}": sub(NOW - timedelta(days=10)),  # orphan
+    }
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == {"SPX"}
+
+
+def test_missing_last_update_is_excluded() -> None:
+    # No authoritative timestamp → excluded, never assumed fresh.
+    subs = {"SPX{=5m}": sub(None)}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == set()
+
+
+def test_unparseable_last_update_is_excluded() -> None:
+    subs = {"SPX{=5m}": sub("not-a-timestamp")}
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == set()
+
+
+def test_non_dict_entry_is_excluded() -> None:
+    subs = {"SPX{=5m}": "corrupt"}  # type: ignore[dict-item]
+    assert fresh_base_symbols(subs, now=NOW, max_age=MAX_AGE) == set()


### PR DESCRIPTION
## TT-154: Filter stale subscriptions from chart symbol dropdown

Jira: https://mandeng.atlassian.net/browse/TT-154

### Problem
The chart symbol dropdown (`/api/symbols` in `src/tastytrade/charting/server.py`) lists base symbols from `RedisSubscriptionStore.get_active_subscriptions()`. Entries in the Redis `subscriptions` hash are written `active: True` and never aged out, so when a subscription process crashes before cleanup, its orphaned symbols linger in the dropdown forever.

### Scope — chart only
The running subscription service does not rely on the Redis `active` set to decide what to subscribe on reconnect — it re-derives from the launch `--symbols` list plus a live `PositionSymbolResolver` pass. The `subscriptions` hash is a display/diagnostic projection, so filtering the chart's view of it carries no recovery or durability risk. No per-key TTL, no schema change, no producer-side or recovery-path changes.

### Change
Read-time freshness filter in the `/api/symbols` endpoint only. New pure helper `fresh_base_symbols(subscriptions, now, max_age)` keeps candle feeds whose `last_update` is within the threshold and strips the interval suffix. Entries with a missing/unparseable `last_update` are excluded (no "assume fresh" fallback). Threshold is `CHART_SYMBOL_STALE_DAYS` (default 4 days, env-overridable) — matches the resolver's documented weekend+holiday backfill window and clears the worst realistic market gap (~3.7-day holiday weekend) with margin.

### Acceptance criteria evidence

**AC1/AC2 — stale excluded, fresh kept (functional, live production Redis).** Ran the shipped code path (`get_active_subscriptions()` → `fresh_base_symbols`) against live Redis:

```
Threshold (CHART_SYMBOL_STALE_DAYS): 4.0 days
Active candle base symbols BEFORE: 18
['/6EM26:XCME', '/MCLN26:XNYM', '/ZBU26:XCBT', 'AAPL', 'BTC/USD:CXTALP', 'CSCO', 'DIA', 'GLD', 'IWM', 'NVDA', 'QQQ', 'SLV', 'SPX', 'SPY', 'TLT', 'USO', 'XLE', 'XLK']

Dropdown base symbols AFTER:       9
['/6EM26:XCME', '/ZBU26:XCBT', 'AAPL', 'BTC/USD:CXTALP', 'CSCO', 'NVDA', 'QQQ', 'SPX', 'SPY']

Stale symbols REMOVED (9): ['/MCLN26:XNYM', 'DIA', 'GLD', 'IWM', 'SLV', 'TLT', 'USO', 'XLE', 'XLK']
Symbols wrongly ADDED (0): []
```

The 9 removed symbols all had `active: True` but a `last_update` 8–11 days old (orphans from a prior session that died ~8 days ago); the 9 kept symbols all had `last_update` age ~0.00 days (the live session). No live symbol was dropped.

**AC3 — missing/unparseable `last_update` excluded.** Unit-tested (`test_missing_last_update_is_excluded`, `test_unparseable_last_update_is_excluded`, `test_non_dict_entry_is_excluded`).

**AC4 — non-chart consumers unchanged.** Diff touches only `charting/server.py`; `get_active_subscriptions()`, `subscription/status.py`, `restore_subscriptions`, and `get_reconnect_start` are not modified.

**AC5 — named, env-overridable constant.** `CHART_SYMBOL_STALE_DAYS = float(os.environ.get("CHART_SYMBOL_STALE_DAYS", "4"))`.

**AC6 — functional evidence against real Redis data.** See AC1/AC2 above.

### Unit tests
`unit_tests/charting/test_server.py` — 9 tests, all passing (fresh kept, stale dropped, window boundary, ticker entries ignored, dedup across intervals, mixed fresh/stale, missing/unparseable/non-dict `last_update` excluded). Ruff clean, pyright 0 errors.